### PR TITLE
fix(#740): Replace response()->json(null, 204) with response()->noContent()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CharacterSpellController`: `unprepare()` now uses `MessageResource` when spell is deleted
   - No breaking changes - response shapes remain identical, just wrapped in proper Resources
 
+- **Issue #740**: Replace `response()->json(null, 204)` with `response()->noContent()` across 7 endpoints
+  - `PartyController`: `destroy()`, `removeCharacter()`
+  - `PartyEncounterMonsterController`: `destroy()`, `clear()`
+  - `PartyEncounterPresetController`: `destroy()`
+  - `CharacterClassController`: `destroy()`
+  - `CharacterConditionController`: `destroy()`
+
 ### Added
 
 - **Issue #754**: Add `status` and `class` filter support to Characters API

--- a/api.json
+++ b/api.json
@@ -51,7 +51,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Paginated set",
+                        "description": "Array of `AbilityScoreResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -60,130 +60,12 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/AbilityScoreResource"
                                             }
-                                        },
-                                        "links": {
-                                            "type": "object",
-                                            "properties": {
-                                                "first": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "last": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "prev": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "next": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "first",
-                                                "last",
-                                                "prev",
-                                                "next"
-                                            ]
-                                        },
-                                        "meta": {
-                                            "type": "object",
-                                            "properties": {
-                                                "current_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "from": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "minimum": 1
-                                                },
-                                                "last_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "links": {
-                                                    "type": "array",
-                                                    "description": "Generated paginator links.",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "url": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "label": {
-                                                                "type": "string"
-                                                            },
-                                                            "active": {
-                                                                "type": "boolean"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "url",
-                                                            "label",
-                                                            "active"
-                                                        ]
-                                                    }
-                                                },
-                                                "path": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ],
-                                                    "description": "Base path for paginator generated URLs."
-                                                },
-                                                "per_page": {
-                                                    "type": "integer",
-                                                    "description": "Number of items shown per page.",
-                                                    "minimum": 0
-                                                },
-                                                "to": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "description": "Number of the last item in the slice.",
-                                                    "minimum": 1
-                                                },
-                                                "total": {
-                                                    "type": "integer",
-                                                    "description": "Total number of items being paginated.",
-                                                    "minimum": 0
-                                                }
-                                            },
-                                            "required": [
-                                                "current_page",
-                                                "from",
-                                                "last_page",
-                                                "links",
-                                                "path",
-                                                "per_page",
-                                                "to",
-                                                "total"
-                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data",
-                                        "links",
-                                        "meta"
+                                        "data"
                                     ]
                                 }
                             }
@@ -720,7 +602,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `BackgroundResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -729,7 +611,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/BackgroundResource"
                                             }
                                         }
                                     },
@@ -827,10 +709,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`BackgroundResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/BackgroundResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -1378,13 +1270,18 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`CharacterImportResultResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        201
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CharacterImportResultResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
                                     ]
                                 }
                             }
@@ -1418,14 +1315,339 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "`CharacterExportResource`",
+                        "description": "",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/components/schemas/CharacterExportResource"
+                                            "type": "object",
+                                            "properties": {
+                                                "format_version": {
+                                                    "type": "string"
+                                                },
+                                                "exported_at": {
+                                                    "type": "string"
+                                                },
+                                                "character": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "public_id": {
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "race": {
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        },
+                                                        "background": {
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        },
+                                                        "alignment": {
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        },
+                                                        "ability_scores": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "strength": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "dexterity": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "constitution": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "intelligence": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "wisdom": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "charisma": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "strength",
+                                                                "dexterity",
+                                                                "constitution",
+                                                                "intelligence",
+                                                                "wisdom",
+                                                                "charisma"
+                                                            ]
+                                                        },
+                                                        "classes": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "class": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "subclass": {
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "level": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "is_primary": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "class",
+                                                                    "subclass",
+                                                                    "level",
+                                                                    "is_primary"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "spells": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "spell": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "source": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "preparation_status": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "spell",
+                                                                    "source",
+                                                                    "preparation_status"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "equipment": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "item": {
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "custom_name": {
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "quantity": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "equipped": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "item",
+                                                                    "custom_name",
+                                                                    "quantity",
+                                                                    "equipped"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "languages": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "language": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "source": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "language",
+                                                                    "source"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "proficiencies": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "skills": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "skill": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "source": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "expertise": {
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "skill",
+                                                                            "source",
+                                                                            "expertise"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "types": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "source": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "expertise": {
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "source",
+                                                                            "expertise"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "skills",
+                                                                "types"
+                                                            ]
+                                                        },
+                                                        "conditions": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "condition": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "level": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "condition",
+                                                                    "level"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "feature_selections": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "feature": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "class": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "feature",
+                                                                    "class"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "notes": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "category": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "title": {
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "content": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "category",
+                                                                    "title",
+                                                                    "content"
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "public_id",
+                                                        "name",
+                                                        "race",
+                                                        "background",
+                                                        "alignment",
+                                                        "ability_scores",
+                                                        "classes",
+                                                        "spells",
+                                                        "equipment",
+                                                        "languages",
+                                                        "proficiencies",
+                                                        "conditions",
+                                                        "feature_selections",
+                                                        "notes"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "format_version",
+                                                "exported_at",
+                                                "character"
+                                            ]
                                         }
                                     },
                                     "required": [
@@ -1815,13 +2037,18 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`CharacterClassPivotResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        201
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CharacterClassPivotResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
                                     ]
                                 }
                             }
@@ -1869,10 +2096,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        204
-                                    ]
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2924,13 +3148,18 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`XpProgressResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        200
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/XpProgressResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
                                     ]
                                 }
                             }
@@ -2971,13 +3200,18 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`XpProgressResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        200
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/XpProgressResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
                                     ]
                                 }
                             }
@@ -3780,13 +4014,18 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`CharacterSpellResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        201
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CharacterSpellResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
                                     ]
                                 }
                             }
@@ -4176,13 +4415,18 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`ValidationSummaryResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        200
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/ValidationSummaryResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
                                     ]
                                 }
                             }
@@ -4213,13 +4457,18 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`CharacterValidationResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "integer",
-                                    "enum": [
-                                        200
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CharacterValidationResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
                                     ]
                                 }
                             }
@@ -4305,7 +4554,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `ClassResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4314,7 +4563,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/ClassResource"
                                             }
                                         }
                                     },
@@ -4423,10 +4672,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`ClassResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/ClassResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -4772,7 +5031,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Paginated set",
+                        "description": "Array of `ConditionResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4781,130 +5040,12 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/ConditionResource"
                                             }
-                                        },
-                                        "links": {
-                                            "type": "object",
-                                            "properties": {
-                                                "first": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "last": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "prev": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "next": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "first",
-                                                "last",
-                                                "prev",
-                                                "next"
-                                            ]
-                                        },
-                                        "meta": {
-                                            "type": "object",
-                                            "properties": {
-                                                "current_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "from": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "minimum": 1
-                                                },
-                                                "last_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "links": {
-                                                    "type": "array",
-                                                    "description": "Generated paginator links.",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "url": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "label": {
-                                                                "type": "string"
-                                                            },
-                                                            "active": {
-                                                                "type": "boolean"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "url",
-                                                            "label",
-                                                            "active"
-                                                        ]
-                                                    }
-                                                },
-                                                "path": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ],
-                                                    "description": "Base path for paginator generated URLs."
-                                                },
-                                                "per_page": {
-                                                    "type": "integer",
-                                                    "description": "Number of items shown per page.",
-                                                    "minimum": 0
-                                                },
-                                                "to": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "description": "Number of the last item in the slice.",
-                                                    "minimum": 1
-                                                },
-                                                "total": {
-                                                    "type": "integer",
-                                                    "description": "Total number of items being paginated.",
-                                                    "minimum": 0
-                                                }
-                                            },
-                                            "required": [
-                                                "current_page",
-                                                "from",
-                                                "last_page",
-                                                "links",
-                                                "path",
-                                                "per_page",
-                                                "to",
-                                                "total"
-                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data",
-                                        "links",
-                                        "meta"
+                                        "data"
                                     ]
                                 }
                             }
@@ -5804,7 +5945,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Paginated set",
+                        "description": "Array of `DamageTypeResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5813,130 +5954,12 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/DamageTypeResource"
                                             }
-                                        },
-                                        "links": {
-                                            "type": "object",
-                                            "properties": {
-                                                "first": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "last": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "prev": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "next": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "first",
-                                                "last",
-                                                "prev",
-                                                "next"
-                                            ]
-                                        },
-                                        "meta": {
-                                            "type": "object",
-                                            "properties": {
-                                                "current_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "from": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "minimum": 1
-                                                },
-                                                "last_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "links": {
-                                                    "type": "array",
-                                                    "description": "Generated paginator links.",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "url": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "label": {
-                                                                "type": "string"
-                                                            },
-                                                            "active": {
-                                                                "type": "boolean"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "url",
-                                                            "label",
-                                                            "active"
-                                                        ]
-                                                    }
-                                                },
-                                                "path": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ],
-                                                    "description": "Base path for paginator generated URLs."
-                                                },
-                                                "per_page": {
-                                                    "type": "integer",
-                                                    "description": "Number of items shown per page.",
-                                                    "minimum": 0
-                                                },
-                                                "to": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "description": "Number of the last item in the slice.",
-                                                    "minimum": 1
-                                                },
-                                                "total": {
-                                                    "type": "integer",
-                                                    "description": "Total number of items being paginated.",
-                                                    "minimum": 0
-                                                }
-                                            },
-                                            "required": [
-                                                "current_page",
-                                                "from",
-                                                "last_page",
-                                                "links",
-                                                "path",
-                                                "per_page",
-                                                "to",
-                                                "total"
-                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data",
-                                        "links",
-                                        "meta"
+                                        "data"
                                     ]
                                 }
                             }
@@ -6065,7 +6088,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `FeatResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6074,7 +6097,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/FeatResource"
                                             }
                                         }
                                     },
@@ -6178,10 +6201,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`FeatResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/FeatResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -6620,7 +6653,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `ItemResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6629,7 +6662,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/ItemResource"
                                             }
                                         }
                                     },
@@ -6765,10 +6798,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`ItemResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/ItemResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -7277,7 +7320,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Paginated set",
+                        "description": "Array of `LanguageResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -7286,130 +7329,12 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/LanguageResource"
                                             }
-                                        },
-                                        "links": {
-                                            "type": "object",
-                                            "properties": {
-                                                "first": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "last": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "prev": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "next": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "first",
-                                                "last",
-                                                "prev",
-                                                "next"
-                                            ]
-                                        },
-                                        "meta": {
-                                            "type": "object",
-                                            "properties": {
-                                                "current_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "from": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "minimum": 1
-                                                },
-                                                "last_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "links": {
-                                                    "type": "array",
-                                                    "description": "Generated paginator links.",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "url": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "label": {
-                                                                "type": "string"
-                                                            },
-                                                            "active": {
-                                                                "type": "boolean"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "url",
-                                                            "label",
-                                                            "active"
-                                                        ]
-                                                    }
-                                                },
-                                                "path": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ],
-                                                    "description": "Base path for paginator generated URLs."
-                                                },
-                                                "per_page": {
-                                                    "type": "integer",
-                                                    "description": "Number of items shown per page.",
-                                                    "minimum": 0
-                                                },
-                                                "to": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "description": "Number of the last item in the slice.",
-                                                    "minimum": 1
-                                                },
-                                                "total": {
-                                                    "type": "integer",
-                                                    "description": "Total number of items being paginated.",
-                                                    "minimum": 0
-                                                }
-                                            },
-                                            "required": [
-                                                "current_page",
-                                                "from",
-                                                "last_page",
-                                                "links",
-                                                "path",
-                                                "per_page",
-                                                "to",
-                                                "total"
-                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data",
-                                        "links",
-                                        "meta"
+                                        "data"
                                     ]
                                 }
                             }
@@ -8170,7 +8095,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `MonsterResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -8179,7 +8104,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/MonsterResource"
                                             }
                                         }
                                     },
@@ -8319,10 +8244,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`MonsterResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/MonsterResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -8542,7 +8477,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `OptionalFeatureResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -8551,7 +8486,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/OptionalFeatureResource"
                                             }
                                         }
                                     },
@@ -8599,10 +8534,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`OptionalFeatureResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/OptionalFeatureResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -9998,7 +9943,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `RaceResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -10007,7 +9952,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/RaceResource"
                                             }
                                         }
                                     },
@@ -10105,10 +10050,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`RaceResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/RaceResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -11425,7 +11380,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Array of items",
+                        "description": "Array of `SpellResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -11434,7 +11389,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/SpellResource"
                                             }
                                         }
                                     },
@@ -11550,10 +11505,20 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "`SpellResource`",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/SpellResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
                             }
                         }
                     },
@@ -11905,7 +11870,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Paginated set",
+                        "description": "Array of `SpellSchoolResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -11914,130 +11879,12 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "$ref": "#/components/schemas/SpellSchoolResource"
                                             }
-                                        },
-                                        "links": {
-                                            "type": "object",
-                                            "properties": {
-                                                "first": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "last": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "prev": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "next": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "first",
-                                                "last",
-                                                "prev",
-                                                "next"
-                                            ]
-                                        },
-                                        "meta": {
-                                            "type": "object",
-                                            "properties": {
-                                                "current_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "from": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "minimum": 1
-                                                },
-                                                "last_page": {
-                                                    "type": "integer",
-                                                    "minimum": 1
-                                                },
-                                                "links": {
-                                                    "type": "array",
-                                                    "description": "Generated paginator links.",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "url": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "label": {
-                                                                "type": "string"
-                                                            },
-                                                            "active": {
-                                                                "type": "boolean"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "url",
-                                                            "label",
-                                                            "active"
-                                                        ]
-                                                    }
-                                                },
-                                                "path": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ],
-                                                    "description": "Base path for paginator generated URLs."
-                                                },
-                                                "per_page": {
-                                                    "type": "integer",
-                                                    "description": "Number of items shown per page.",
-                                                    "minimum": 0
-                                                },
-                                                "to": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ],
-                                                    "description": "Number of the last item in the slice.",
-                                                    "minimum": 1
-                                                },
-                                                "total": {
-                                                    "type": "integer",
-                                                    "description": "Total number of items being paginated.",
-                                                    "minimum": 0
-                                                }
-                                            },
-                                            "required": [
-                                                "current_page",
-                                                "from",
-                                                "last_page",
-                                                "links",
-                                                "path",
-                                                "per_page",
-                                                "to",
-                                                "total"
-                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data",
-                                        "links",
-                                        "meta"
+                                        "data"
                                     ]
                                 }
                             }
@@ -12712,37 +12559,6 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/TagResource"
-                        }
-                    },
-                    "choices": {
-                        "type": "array",
-                        "description": "Non-equipment choices (language, proficiency)",
-                        "items": {
-                            "$ref": "#/components/schemas/EntityChoiceResource"
-                        }
-                    },
-                    "equipment_choices": {
-                        "type": "array",
-                        "description": "Equipment choices (grouped by option)",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "choice_group": {
-                                    "type": "string"
-                                },
-                                "quantity": {
-                                    "type": "integer"
-                                },
-                                "options": {
-                                    "type": "array",
-                                    "items": {}
-                                }
-                            },
-                            "required": [
-                                "choice_group",
-                                "quantity",
-                                "options"
-                            ]
                         }
                     },
                     "data_tables": {
@@ -13462,335 +13278,6 @@
                     }
                 },
                 "title": "CharacterEquipmentUpdateRequest"
-            },
-            "CharacterExportResource": {
-                "type": "object",
-                "properties": {
-                    "format_version": {
-                        "type": "string"
-                    },
-                    "exported_at": {
-                        "type": "string"
-                    },
-                    "character": {
-                        "type": "object",
-                        "properties": {
-                            "public_id": {
-                                "type": "string"
-                            },
-                            "name": {
-                                "type": "string"
-                            },
-                            "race": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "background": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "alignment": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "ability_scores": {
-                                "type": "object",
-                                "properties": {
-                                    "strength": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ]
-                                    },
-                                    "dexterity": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ]
-                                    },
-                                    "constitution": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ]
-                                    },
-                                    "intelligence": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ]
-                                    },
-                                    "wisdom": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ]
-                                    },
-                                    "charisma": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ]
-                                    }
-                                },
-                                "required": [
-                                    "strength",
-                                    "dexterity",
-                                    "constitution",
-                                    "intelligence",
-                                    "wisdom",
-                                    "charisma"
-                                ]
-                            },
-                            "classes": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "class": {
-                                            "type": "string"
-                                        },
-                                        "subclass": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "level": {
-                                            "type": "integer"
-                                        },
-                                        "is_primary": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "class",
-                                        "subclass",
-                                        "level",
-                                        "is_primary"
-                                    ]
-                                }
-                            },
-                            "spells": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "spell": {
-                                            "type": "string"
-                                        },
-                                        "source": {
-                                            "type": "string"
-                                        },
-                                        "preparation_status": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "spell",
-                                        "source",
-                                        "preparation_status"
-                                    ]
-                                }
-                            },
-                            "equipment": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "item": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "custom_name": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "quantity": {
-                                            "type": "integer"
-                                        },
-                                        "equipped": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "item",
-                                        "custom_name",
-                                        "quantity",
-                                        "equipped"
-                                    ]
-                                }
-                            },
-                            "languages": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "language": {
-                                            "type": "string"
-                                        },
-                                        "source": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "language",
-                                        "source"
-                                    ]
-                                }
-                            },
-                            "proficiencies": {
-                                "type": "object",
-                                "properties": {
-                                    "skills": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "skill": {
-                                                    "type": "string"
-                                                },
-                                                "source": {
-                                                    "type": "string"
-                                                },
-                                                "expertise": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "skill",
-                                                "source",
-                                                "expertise"
-                                            ]
-                                        }
-                                    },
-                                    "types": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "type": "string"
-                                                },
-                                                "source": {
-                                                    "type": "string"
-                                                },
-                                                "expertise": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "type",
-                                                "source",
-                                                "expertise"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "required": [
-                                    "skills",
-                                    "types"
-                                ]
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "condition": {
-                                            "type": "string"
-                                        },
-                                        "level": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "condition",
-                                        "level"
-                                    ]
-                                }
-                            },
-                            "feature_selections": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "feature": {
-                                            "type": "string"
-                                        },
-                                        "class": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "feature",
-                                        "class"
-                                    ]
-                                }
-                            },
-                            "notes": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "category": {
-                                            "type": "string"
-                                        },
-                                        "title": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "content": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "category",
-                                        "title",
-                                        "content"
-                                    ]
-                                }
-                            }
-                        },
-                        "required": [
-                            "public_id",
-                            "name",
-                            "race",
-                            "background",
-                            "alignment",
-                            "ability_scores",
-                            "classes",
-                            "spells",
-                            "equipment",
-                            "languages",
-                            "proficiencies",
-                            "conditions",
-                            "feature_selections",
-                            "notes"
-                        ]
-                    }
-                },
-                "required": [
-                    "format_version",
-                    "exported_at",
-                    "character"
-                ],
-                "title": "CharacterExportResource"
             },
             "CharacterFeatureResource": {
                 "type": "object",
@@ -14660,6 +14147,53 @@
                 ],
                 "title": "CharacterImportRequest"
             },
+            "CharacterImportResultResource": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "character": {
+                        "type": "object",
+                        "properties": {
+                            "public_id": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "race": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "background": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "public_id",
+                            "name",
+                            "race",
+                            "background"
+                        ]
+                    },
+                    "warnings": {
+                        "type": "array",
+                        "items": {}
+                    }
+                },
+                "required": [
+                    "success",
+                    "character",
+                    "warnings"
+                ],
+                "title": "CharacterImportResultResource"
+            },
             "CharacterLanguageResource": {
                 "type": "object",
                 "properties": {
@@ -14727,7 +14261,7 @@
                         "type": "string"
                     },
                     "level": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "race": {
                         "type": [
@@ -14746,7 +14280,7 @@
                         ]
                     },
                     "is_complete": {
-                        "type": "boolean"
+                        "type": "string"
                     },
                     "updated_at": {
                         "type": "string"
@@ -17337,6 +16871,43 @@
                 },
                 "title": "CharacterUpdateRequest"
             },
+            "CharacterValidationResource": {
+                "type": "object",
+                "properties": {
+                    "valid": {
+                        "type": "boolean"
+                    },
+                    "dangling_references": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "summary": {
+                        "type": "object",
+                        "properties": {
+                            "total_references": {
+                                "type": "integer"
+                            },
+                            "valid_references": {
+                                "type": "integer"
+                            },
+                            "dangling_count": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "total_references",
+                            "valid_references",
+                            "dangling_count"
+                        ]
+                    }
+                },
+                "required": [
+                    "valid",
+                    "dangling_references",
+                    "summary"
+                ],
+                "title": "CharacterValidationResource"
+            },
             "ChoiceResultResource": {
                 "type": "object",
                 "properties": {
@@ -17588,7 +17159,8 @@
                         "type": "string"
                     },
                     "hit_die": {
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "Hit die value (e.g., 8, 10, 12) - inherits from parent for subclasses"
                     },
                     "description": {
                         "type": "string"
@@ -17615,13 +17187,15 @@
                         ]
                     },
                     "is_base_class": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Whether this is a base class (not a subclass)"
                     },
                     "subclass_level": {
                         "type": [
                             "integer",
                             "null"
-                        ]
+                        ],
+                        "description": "Level at which subclass is chosen"
                     },
                     "spellcasting_type": {
                         "type": "string"
@@ -17630,7 +17204,8 @@
                         "type": [
                             "integer",
                             "null"
-                        ]
+                        ],
+                        "description": "Number of spells available to this class"
                     },
                     "starting_wealth": {
                         "type": [
@@ -18056,49 +17631,7 @@
             },
             "CounterResource": {
                 "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer"
-                    },
-                    "slug": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "current": {
-                        "type": "integer"
-                    },
-                    "max": {
-                        "type": "integer"
-                    },
-                    "reset_on": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "source_slug": {
-                        "type": "string"
-                    },
-                    "source_type": {
-                        "type": "string"
-                    },
-                    "unlimited": {
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "id",
-                    "slug",
-                    "name",
-                    "current",
-                    "max",
-                    "reset_on",
-                    "source_slug",
-                    "source_type",
-                    "unlimited"
-                ],
+                "additionalProperties": {},
                 "title": "CounterResource"
             },
             "CreatureTypeResource": {
@@ -18507,111 +18040,6 @@
                 },
                 "title": "EncounterPresetUpdateRequest"
             },
-            "EntityChoiceResource": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer"
-                    },
-                    "choice_type": {
-                        "type": "string"
-                    },
-                    "choice_group": {
-                        "type": "string"
-                    },
-                    "choice_option": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "quantity": {
-                        "type": "integer"
-                    },
-                    "constraint": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "target_type": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "target_slug": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "description": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "level_granted": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "is_required": {
-                        "type": "boolean"
-                    },
-                    "spell_max_level": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "Spell-specific fields"
-                    },
-                    "spell_list_slug": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "spell_school_slug": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "proficiency_type": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Proficiency-specific fields"
-                    },
-                    "constraints": {
-                        "type": [
-                            "array",
-                            "null"
-                        ],
-                        "description": "Additional constraints",
-                        "items": {}
-                    }
-                },
-                "required": [
-                    "id",
-                    "choice_type",
-                    "choice_group",
-                    "choice_option",
-                    "quantity",
-                    "constraint",
-                    "target_type",
-                    "target_slug",
-                    "description",
-                    "level_granted",
-                    "is_required",
-                    "constraints"
-                ],
-                "title": "EntityChoiceResource"
-            },
             "EntityConditionResource": {
                 "type": "object",
                 "properties": {
@@ -18898,7 +18326,10 @@
                         "type": "integer"
                     },
                     "spell_id": {
-                        "type": "integer"
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
                     },
                     "spell": {
                         "$ref": "#/components/schemas/SpellResource"
@@ -19036,13 +18467,6 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/EntityLanguageResource"
-                        }
-                    },
-                    "choices": {
-                        "type": "array",
-                        "description": "Non-equipment choices (spell, proficiency, ability_score)",
-                        "items": {
-                            "$ref": "#/components/schemas/EntityChoiceResource"
                         }
                     }
                 },
@@ -19196,53 +18620,7 @@
             },
             "HitDiceResource": {
                 "type": "object",
-                "properties": {
-                    "hit_dice": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "object",
-                            "properties": {
-                                "available": {
-                                    "type": "integer"
-                                },
-                                "max": {
-                                    "type": "integer"
-                                },
-                                "spent": {
-                                    "type": "integer"
-                                }
-                            },
-                            "required": [
-                                "available",
-                                "max",
-                                "spent"
-                            ]
-                        }
-                    },
-                    "total": {
-                        "type": "object",
-                        "properties": {
-                            "available": {
-                                "type": "integer"
-                            },
-                            "max": {
-                                "type": "integer"
-                            },
-                            "spent": {
-                                "type": "integer"
-                            }
-                        },
-                        "required": [
-                            "available",
-                            "max",
-                            "spent"
-                        ]
-                    }
-                },
-                "required": [
-                    "hit_dice",
-                    "total"
-                ],
+                "additionalProperties": {},
                 "title": "HitDiceResource"
             },
             "HitPointsResource": {
@@ -20558,7 +19936,7 @@
                 "type": "object",
                 "properties": {
                     "quantity": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "item": {
                         "type": [
@@ -20615,7 +19993,7 @@
                         "type": "string"
                     },
                     "level": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "class_name": {
                         "type": [
@@ -20661,7 +20039,7 @@
                         "type": "string"
                     },
                     "level": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "class_name": {
                         "type": [
@@ -21784,10 +21162,12 @@
                         ]
                     },
                     "is_subrace": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Whether this race is a subrace (has a parent race)"
                     },
                     "subrace_required": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Whether subrace selection is required to play this race (false = base race is complete on its own)"
                     },
                     "traits": {
                         "type": "array",
@@ -21851,13 +21231,6 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/TagResource"
-                        }
-                    },
-                    "choices": {
-                        "type": "array",
-                        "description": "Non-equipment choices (ability_score, language, proficiency, spell)",
-                        "items": {
-                            "$ref": "#/components/schemas/EntityChoiceResource"
                         }
                     },
                     "inherited_data": {
@@ -22571,16 +21944,16 @@
                 "type": "object",
                 "properties": {
                     "level": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "total": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "spent": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "available": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "slot_type": {
                         "type": "string"
@@ -22632,59 +22005,7 @@
             },
             "SpellSlotsResource": {
                 "type": "object",
-                "properties": {
-                    "slots": {
-                        "type": "object"
-                    },
-                    "pact_magic": {
-                        "type": [
-                            "object",
-                            "null"
-                        ],
-                        "properties": {
-                            "level": {
-                                "type": "integer"
-                            },
-                            "total": {
-                                "type": "integer"
-                            },
-                            "spent": {
-                                "type": "integer"
-                            },
-                            "available": {
-                                "type": "integer"
-                            }
-                        },
-                        "required": [
-                            "level",
-                            "total",
-                            "spent",
-                            "available"
-                        ]
-                    },
-                    "preparation_limit": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "prepared_count": {
-                        "type": "integer"
-                    },
-                    "preparation_limits": {
-                        "type": [
-                            "object",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "slots",
-                    "pact_magic",
-                    "preparation_limit",
-                    "prepared_count",
-                    "preparation_limits"
-                ],
+                "additionalProperties": {},
                 "title": "SpellSlotsResource"
             },
             "SpendHitDiceRequest": {
@@ -22887,6 +22208,71 @@
                     "slot_type"
                 ],
                 "title": "UseSpellSlotRequest"
+            },
+            "ValidationSummaryResource": {
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer"
+                    },
+                    "valid": {
+                        "type": "integer"
+                    },
+                    "invalid": {
+                        "type": "integer"
+                    },
+                    "characters": {
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "total",
+                    "valid",
+                    "invalid",
+                    "characters"
+                ],
+                "title": "ValidationSummaryResource"
+            },
+            "XpProgressResource": {
+                "type": "object",
+                "properties": {
+                    "experience_points": {
+                        "type": "integer"
+                    },
+                    "level": {
+                        "type": "integer"
+                    },
+                    "next_level_xp": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "xp_to_next_level": {
+                        "type": "integer"
+                    },
+                    "xp_progress_percent": {
+                        "type": "number"
+                    },
+                    "is_max_level": {
+                        "type": "boolean"
+                    },
+                    "leveled_up": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "experience_points",
+                    "level",
+                    "next_level_xp",
+                    "xp_to_next_level",
+                    "xp_progress_percent",
+                    "is_max_level"
+                ],
+                "title": "XpProgressResource"
             }
         },
         "responses": {

--- a/api.json
+++ b/api.json
@@ -2147,119 +2147,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object",
-                                            "properties": {
-                                                "class": {
-                                                    "type": [
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "slug": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "id",
-                                                        "name",
-                                                        "slug"
-                                                    ]
-                                                },
-                                                "class_slug": {
-                                                    "type": "string"
-                                                },
-                                                "is_dangling": {
-                                                    "type": "boolean"
-                                                },
-                                                "subclass": {
-                                                    "type": [
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "slug": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "id",
-                                                        "name",
-                                                        "slug"
-                                                    ]
-                                                },
-                                                "subclass_slug": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "level": {
-                                                    "type": "integer"
-                                                },
-                                                "is_primary": {
-                                                    "type": "boolean"
-                                                },
-                                                "order": {
-                                                    "type": "integer"
-                                                },
-                                                "hit_dice": {
-                                                    "type": [
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "properties": {
-                                                        "die": {
-                                                            "type": "string"
-                                                        },
-                                                        "max": {
-                                                            "type": "integer"
-                                                        },
-                                                        "spent": {
-                                                            "type": "integer"
-                                                        },
-                                                        "available": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "die",
-                                                        "max",
-                                                        "spent",
-                                                        "available"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "class",
-                                                "class_slug",
-                                                "is_dangling",
-                                                "subclass",
-                                                "subclass_slug",
-                                                "level",
-                                                "is_primary",
-                                                "order",
-                                                "hit_dice"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "data"
-                                    ]
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2306,110 +2194,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object",
-                                            "properties": {
-                                                "previous_level": {
-                                                    "type": "integer"
-                                                },
-                                                "new_level": {
-                                                    "type": "integer"
-                                                },
-                                                "hp_increase": {
-                                                    "type": "integer"
-                                                },
-                                                "new_max_hp": {
-                                                    "type": "integer"
-                                                },
-                                                "features_gained": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "integer"
-                                                            },
-                                                            "name": {
-                                                                "type": "string"
-                                                            },
-                                                            "description": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "id",
-                                                            "name",
-                                                            "description"
-                                                        ]
-                                                    }
-                                                },
-                                                "spell_slots": {
-                                                    "type": "object",
-                                                    "additionalProperties": {
-                                                        "type": "integer"
-                                                    }
-                                                },
-                                                "asi_pending": {
-                                                    "type": "boolean"
-                                                },
-                                                "hp_choice_pending": {
-                                                    "type": "boolean"
-                                                },
-                                                "pending_choice_summary": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "total_pending": {
-                                                            "type": "integer"
-                                                        },
-                                                        "required_pending": {
-                                                            "type": "integer"
-                                                        },
-                                                        "optional_pending": {
-                                                            "type": "integer"
-                                                        },
-                                                        "by_type": {
-                                                            "type": "object",
-                                                            "additionalProperties": {
-                                                                "type": "integer"
-                                                            }
-                                                        },
-                                                        "by_source": {
-                                                            "type": "object",
-                                                            "additionalProperties": {
-                                                                "type": "integer"
-                                                            }
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "total_pending",
-                                                        "required_pending",
-                                                        "optional_pending",
-                                                        "by_type",
-                                                        "by_source"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "previous_level",
-                                                "new_level",
-                                                "hp_increase",
-                                                "new_max_hp",
-                                                "features_gained",
-                                                "spell_slots",
-                                                "asi_pending",
-                                                "hp_choice_pending",
-                                                "pending_choice_summary"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "data"
-                                    ]
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2463,119 +2248,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object",
-                                            "properties": {
-                                                "class": {
-                                                    "type": [
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "slug": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "id",
-                                                        "name",
-                                                        "slug"
-                                                    ]
-                                                },
-                                                "class_slug": {
-                                                    "type": "string"
-                                                },
-                                                "is_dangling": {
-                                                    "type": "boolean"
-                                                },
-                                                "subclass": {
-                                                    "type": [
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "slug": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "id",
-                                                        "name",
-                                                        "slug"
-                                                    ]
-                                                },
-                                                "subclass_slug": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "level": {
-                                                    "type": "integer"
-                                                },
-                                                "is_primary": {
-                                                    "type": "boolean"
-                                                },
-                                                "order": {
-                                                    "type": "integer"
-                                                },
-                                                "hit_dice": {
-                                                    "type": [
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "properties": {
-                                                        "die": {
-                                                            "type": "string"
-                                                        },
-                                                        "max": {
-                                                            "type": "integer"
-                                                        },
-                                                        "spent": {
-                                                            "type": "integer"
-                                                        },
-                                                        "available": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "die",
-                                                        "max",
-                                                        "spent",
-                                                        "available"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "class",
-                                                "class_slug",
-                                                "is_dangling",
-                                                "subclass",
-                                                "subclass_slug",
-                                                "level",
-                                                "is_primary",
-                                                "order",
-                                                "hit_dice"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "data"
-                                    ]
+                                    "type": "object"
                                 }
                             }
                         }
@@ -7780,7 +7453,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `MediaResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -7789,64 +7462,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "collection": {
-                                                        "type": "string"
-                                                    },
-                                                    "file_name": {
-                                                        "type": "string"
-                                                    },
-                                                    "mime_type": {
-                                                        "type": "string"
-                                                    },
-                                                    "size": {
-                                                        "type": "integer"
-                                                    },
-                                                    "urls": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "original": {
-                                                                "type": "string"
-                                                            },
-                                                            "thumb": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "medium": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "original",
-                                                            "thumb",
-                                                            "medium"
-                                                        ]
-                                                    },
-                                                    "created_at": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "collection",
-                                                    "file_name",
-                                                    "mime_type",
-                                                    "size",
-                                                    "urls",
-                                                    "created_at"
-                                                ]
+                                                "$ref": "#/components/schemas/MediaResource"
                                             }
                                         }
                                     },
@@ -8291,7 +7907,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `SpellResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -8300,50 +7916,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "level": {
-                                                        "type": "integer"
-                                                    },
-                                                    "school": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "integer"
-                                                            },
-                                                            "name": {
-                                                                "type": "string"
-                                                            },
-                                                            "code": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "id",
-                                                            "name",
-                                                            "code"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "level",
-                                                    "school"
-                                                ]
+                                                "$ref": "#/components/schemas/SpellResource"
                                             }
                                         }
                                     },
@@ -9492,7 +9065,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Paginated set",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -9501,39 +9074,130 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "category": {
-                                                        "type": "string"
-                                                    },
-                                                    "subcategory": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
+                                                "type": "string"
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "first": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "last": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "prev": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "next": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "first",
+                                                "last",
+                                                "prev",
+                                                "next"
+                                            ]
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "properties": {
+                                                "current_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "from": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "minimum": 1
+                                                },
+                                                "last_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "links": {
+                                                    "type": "array",
+                                                    "description": "Generated paginator links.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "url": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "label": {
+                                                                "type": "string"
+                                                            },
+                                                            "active": {
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "url",
+                                                            "label",
+                                                            "active"
                                                         ]
                                                     }
                                                 },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "category",
-                                                    "subcategory"
-                                                ]
-                                            }
+                                                "path": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ],
+                                                    "description": "Base path for paginator generated URLs."
+                                                },
+                                                "per_page": {
+                                                    "type": "integer",
+                                                    "description": "Number of items shown per page.",
+                                                    "minimum": 0
+                                                },
+                                                "to": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "description": "Number of the last item in the slice.",
+                                                    "minimum": 1
+                                                },
+                                                "total": {
+                                                    "type": "integer",
+                                                    "description": "Total number of items being paginated.",
+                                                    "minimum": 0
+                                                }
+                                            },
+                                            "required": [
+                                                "current_page",
+                                                "from",
+                                                "last_page",
+                                                "links",
+                                                "path",
+                                                "per_page",
+                                                "to",
+                                                "total"
+                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data"
+                                        "data",
+                                        "links",
+                                        "meta"
                                     ]
                                 }
                             }
@@ -9619,7 +9283,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Paginated set of `ClassResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -9628,57 +9292,130 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "hit_die": {
-                                                        "type": "integer"
-                                                    },
-                                                    "description": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
+                                                "$ref": "#/components/schemas/ClassResource"
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "first": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "last": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "prev": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "next": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "first",
+                                                "last",
+                                                "prev",
+                                                "next"
+                                            ]
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "properties": {
+                                                "current_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "from": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "minimum": 1
+                                                },
+                                                "last_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "links": {
+                                                    "type": "array",
+                                                    "description": "Generated paginator links.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "url": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "label": {
+                                                                "type": "string"
+                                                            },
+                                                            "active": {
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "url",
+                                                            "label",
+                                                            "active"
                                                         ]
-                                                    },
-                                                    "archetype": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "parent_class_id": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "is_base_class": {
-                                                        "type": "boolean"
                                                     }
                                                 },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "hit_die",
-                                                    "description",
-                                                    "archetype",
-                                                    "parent_class_id",
-                                                    "is_base_class"
-                                                ]
-                                            }
+                                                "path": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ],
+                                                    "description": "Base path for paginator generated URLs."
+                                                },
+                                                "per_page": {
+                                                    "type": "integer",
+                                                    "description": "Number of items shown per page.",
+                                                    "minimum": 0
+                                                },
+                                                "to": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "description": "Number of the last item in the slice.",
+                                                    "minimum": 1
+                                                },
+                                                "total": {
+                                                    "type": "integer",
+                                                    "description": "Total number of items being paginated.",
+                                                    "minimum": 0
+                                                }
+                                            },
+                                            "required": [
+                                                "current_page",
+                                                "from",
+                                                "last_page",
+                                                "links",
+                                                "path",
+                                                "per_page",
+                                                "to",
+                                                "total"
+                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data"
+                                        "data",
+                                        "links",
+                                        "meta"
                                     ]
                                 }
                             }
@@ -9723,7 +9460,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Paginated set of `RaceResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -9732,39 +9469,130 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "speed": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
+                                                "$ref": "#/components/schemas/RaceResource"
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "first": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "last": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "prev": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "next": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "first",
+                                                "last",
+                                                "prev",
+                                                "next"
+                                            ]
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "properties": {
+                                                "current_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "from": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "minimum": 1
+                                                },
+                                                "last_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "links": {
+                                                    "type": "array",
+                                                    "description": "Generated paginator links.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "url": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "label": {
+                                                                "type": "string"
+                                                            },
+                                                            "active": {
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "url",
+                                                            "label",
+                                                            "active"
                                                         ]
-                                                    },
-                                                    "is_subrace": {
-                                                        "type": "boolean"
                                                     }
                                                 },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "speed",
-                                                    "is_subrace"
-                                                ]
-                                            }
+                                                "path": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ],
+                                                    "description": "Base path for paginator generated URLs."
+                                                },
+                                                "per_page": {
+                                                    "type": "integer",
+                                                    "description": "Number of items shown per page.",
+                                                    "minimum": 0
+                                                },
+                                                "to": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "description": "Number of the last item in the slice.",
+                                                    "minimum": 1
+                                                },
+                                                "total": {
+                                                    "type": "integer",
+                                                    "description": "Total number of items being paginated.",
+                                                    "minimum": 0
+                                                }
+                                            },
+                                            "required": [
+                                                "current_page",
+                                                "from",
+                                                "last_page",
+                                                "links",
+                                                "path",
+                                                "per_page",
+                                                "to",
+                                                "total"
+                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data"
+                                        "data",
+                                        "links",
+                                        "meta"
                                     ]
                                 }
                             }
@@ -9809,7 +9637,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Paginated set of `BackgroundResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -9818,42 +9646,130 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "feature_name": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "feature_description": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
+                                                "$ref": "#/components/schemas/BackgroundResource"
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "first": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "last": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "prev": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "next": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "first",
+                                                "last",
+                                                "prev",
+                                                "next"
+                                            ]
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "properties": {
+                                                "current_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "from": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "minimum": 1
+                                                },
+                                                "last_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "links": {
+                                                    "type": "array",
+                                                    "description": "Generated paginator links.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "url": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "label": {
+                                                                "type": "string"
+                                                            },
+                                                            "active": {
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "url",
+                                                            "label",
+                                                            "active"
                                                         ]
                                                     }
                                                 },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "feature_name",
-                                                    "feature_description"
-                                                ]
-                                            }
+                                                "path": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ],
+                                                    "description": "Base path for paginator generated URLs."
+                                                },
+                                                "per_page": {
+                                                    "type": "integer",
+                                                    "description": "Number of items shown per page.",
+                                                    "minimum": 0
+                                                },
+                                                "to": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "description": "Number of the last item in the slice.",
+                                                    "minimum": 1
+                                                },
+                                                "total": {
+                                                    "type": "integer",
+                                                    "description": "Total number of items being paginated.",
+                                                    "minimum": 0
+                                                }
+                                            },
+                                            "required": [
+                                                "current_page",
+                                                "from",
+                                                "last_page",
+                                                "links",
+                                                "path",
+                                                "per_page",
+                                                "to",
+                                                "total"
+                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data"
+                                        "data",
+                                        "links",
+                                        "meta"
                                     ]
                                 }
                             }
@@ -10097,7 +10013,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `SpellResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -10106,50 +10022,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "level": {
-                                                        "type": "integer"
-                                                    },
-                                                    "school": {
-                                                        "type": [
-                                                            "object",
-                                                            "null"
-                                                        ],
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "integer"
-                                                            },
-                                                            "name": {
-                                                                "type": "string"
-                                                            },
-                                                            "code": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "id",
-                                                            "name",
-                                                            "code"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "level",
-                                                    "school"
-                                                ]
+                                                "$ref": "#/components/schemas/SpellResource"
                                             }
                                         }
                                     },
@@ -10408,7 +10281,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Paginated set",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -10417,28 +10290,130 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "code": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
+                                                "type": "string"
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "first": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "last": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "prev": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "next": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "first",
+                                                "last",
+                                                "prev",
+                                                "next"
+                                            ]
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "properties": {
+                                                "current_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "from": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "minimum": 1
+                                                },
+                                                "last_page": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                },
+                                                "links": {
+                                                    "type": "array",
+                                                    "description": "Generated paginator links.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "url": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "label": {
+                                                                "type": "string"
+                                                            },
+                                                            "active": {
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "url",
+                                                            "label",
+                                                            "active"
+                                                        ]
                                                     }
                                                 },
-                                                "required": [
-                                                    "id",
-                                                    "code",
-                                                    "name"
-                                                ]
-                                            }
+                                                "path": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ],
+                                                    "description": "Base path for paginator generated URLs."
+                                                },
+                                                "per_page": {
+                                                    "type": "integer",
+                                                    "description": "Number of items shown per page.",
+                                                    "minimum": 0
+                                                },
+                                                "to": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ],
+                                                    "description": "Number of the last item in the slice.",
+                                                    "minimum": 1
+                                                },
+                                                "total": {
+                                                    "type": "integer",
+                                                    "description": "Total number of items being paginated.",
+                                                    "minimum": 0
+                                                }
+                                            },
+                                            "required": [
+                                                "current_page",
+                                                "from",
+                                                "last_page",
+                                                "links",
+                                                "path",
+                                                "per_page",
+                                                "to",
+                                                "total"
+                                            ]
                                         }
                                     },
                                     "required": [
-                                        "data"
+                                        "data",
+                                        "links",
+                                        "meta"
                                     ]
                                 }
                             }
@@ -11552,7 +11527,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `ClassResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -11561,31 +11536,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "hit_die": {
-                                                        "type": "integer"
-                                                    },
-                                                    "is_base_class": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "hit_die",
-                                                    "is_base_class"
-                                                ]
+                                                "$ref": "#/components/schemas/ClassResource"
                                             }
                                         }
                                     },
@@ -11623,7 +11574,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `MonsterResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -11632,37 +11583,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "challenge_rating": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "type": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "challenge_rating",
-                                                    "type"
-                                                ]
+                                                "$ref": "#/components/schemas/MonsterResource"
                                             }
                                         }
                                     },
@@ -11700,7 +11621,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `ItemResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -11709,37 +11630,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "type": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "rarity": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "type",
-                                                    "rarity"
-                                                ]
+                                                "$ref": "#/components/schemas/ItemResource"
                                             }
                                         }
                                     },
@@ -11777,7 +11668,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `RaceResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -11786,34 +11677,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "speed": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "is_subrace": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "slug",
-                                                    "name",
-                                                    "speed",
-                                                    "is_subrace"
-                                                ]
+                                                "$ref": "#/components/schemas/RaceResource"
                                             }
                                         }
                                     },
@@ -12254,7 +12118,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Array of `TagResource`",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -12263,30 +12127,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "integer"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
-                                                    "type": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "name",
-                                                    "slug",
-                                                    "type"
-                                                ]
+                                                "$ref": "#/components/schemas/TagResource"
                                             }
                                         }
                                     },

--- a/app/Http/Controllers/Api/AbilityScoreController.php
+++ b/app/Http/Controllers/Api/AbilityScoreController.php
@@ -44,6 +44,8 @@ class AbilityScoreController extends Controller
      * - **Character Building:** Determine which ability scores to prioritize based on class (Wizards need INT, Clerics need WIS, Rogues need DEX)
      * - **Ability Score Checks:** Understand what modifiers apply to skill checks and saving throws
      * - **Combat Analysis:** Know which abilities affect attack rolls, damage, and AC (DEX for AC, STR for melee attacks)
+     *
+     * @response AnonymousResourceCollection<AbilityScoreResource>
      */
     #[QueryParameter('q', description: 'Search ability scores by name or code', example: 'strength')]
     public function index(AbilityScoreIndexRequest $request, LookupCacheService $cache): AnonymousResourceCollection

--- a/app/Http/Controllers/Api/BackgroundController.php
+++ b/app/Http/Controllers/Api/BackgroundController.php
@@ -13,6 +13,7 @@ use App\Models\Background;
 use App\Services\BackgroundSearchService;
 use App\Services\Cache\EntityCacheService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client;
 
 class BackgroundController extends Controller
@@ -97,10 +98,11 @@ class BackgroundController extends Controller
      * @param  BackgroundIndexRequest  $request  Validated request with filtering parameters
      * @param  BackgroundSearchService  $service  Service layer for background queries
      * @param  Client  $meilisearch  Meilisearch client for advanced filtering
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *
+     * @response AnonymousResourceCollection<BackgroundResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Integer fields (=,!=,>,>=,<,<=): id. String fields (=,!=): name, slug. Boolean fields (=,!=,IS NULL): grants_language_choice. Array fields (IN,NOT IN,IS EMPTY): source_codes, tag_slugs, skill_proficiencies, tool_proficiency_types. See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'skill_proficiencies IN [Insight, Religion] AND source_codes IN [PHB]')]
-    public function index(BackgroundIndexRequest $request, BackgroundSearchService $service, Client $meilisearch)
+    public function index(BackgroundIndexRequest $request, BackgroundSearchService $service, Client $meilisearch): AnonymousResourceCollection
     {
         $dto = BackgroundSearchDTO::fromRequest($request);
 
@@ -126,7 +128,7 @@ class BackgroundController extends Controller
      * traits with random tables (personality, ideals, bonds, flaws), languages, and sources.
      * Supports selective relationship loading via the 'include' parameter.
      */
-    public function show(BackgroundShowRequest $request, Background $background, EntityCacheService $cache, BackgroundSearchService $service)
+    public function show(BackgroundShowRequest $request, Background $background, EntityCacheService $cache, BackgroundSearchService $service): BackgroundResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/CharacterClassController.php
+++ b/app/Http/Controllers/Api/CharacterClassController.php
@@ -99,7 +99,7 @@ class CharacterClassController extends Controller
      * - Character's total level cannot exceed 20
      * - Must meet multiclass prerequisites (unless force=true)
      *
-     * @response 201 array{data: array{class: array{id: int, name: string, slug: string}|null, class_slug: string, is_dangling: bool, subclass: array{id: int, name: string, slug: string}|null, subclass_slug: string|null, level: int, is_primary: bool, order: int, hit_dice: array{die: string, max: int, spent: int, available: int}|null}}
+     * @response CharacterClassPivotResource
      */
     public function store(CharacterClassAddRequest $request, Character $character): JsonResponse
     {
@@ -158,8 +158,6 @@ class CharacterClassController extends Controller
      *
      * @param  Character  $character  The character
      * @param  string  $classIdOrSlug  Class ID or slug
-     *
-     * @response 204 scenario="success"
      */
     public function destroy(Character $character, string $classSlugOrFullSlug): HttpResponse
     {

--- a/app/Http/Controllers/Api/CharacterClassController.php
+++ b/app/Http/Controllers/Api/CharacterClassController.php
@@ -161,16 +161,14 @@ class CharacterClassController extends Controller
      *
      * @response 204 scenario="success"
      */
-    public function destroy(Character $character, string $classSlugOrFullSlug): JsonResponse|HttpResponse
+    public function destroy(Character $character, string $classSlugOrFullSlug): HttpResponse
     {
         // Accept either slug (phb:fighter) or simple slug (fighter)
         $class = CharacterClass::where('slug', $classSlugOrFullSlug)
             ->first();
 
         if (! $class) {
-            return response()->json([
-                'message' => 'Class not found',
-            ], Response::HTTP_NOT_FOUND);
+            abort(404, 'Class not found');
         }
 
         return DB::transaction(function () use ($character, $class) {
@@ -180,15 +178,11 @@ class CharacterClassController extends Controller
             $pivot = $character->characterClasses()->where('class_slug', $class->slug)->first();
 
             if (! $pivot) {
-                return response()->json([
-                    'message' => 'Class not found on character',
-                ], Response::HTTP_NOT_FOUND);
+                abort(404, 'Class not found on character');
             }
 
             if ($classCount <= 1) {
-                return response()->json([
-                    'message' => 'Cannot remove the only class',
-                ], Response::HTTP_UNPROCESSABLE_ENTITY);
+                abort(422, 'Cannot remove the only class');
             }
 
             $pivot->delete();

--- a/app/Http/Controllers/Api/CharacterClassController.php
+++ b/app/Http/Controllers/Api/CharacterClassController.php
@@ -235,8 +235,7 @@ class CharacterClassController extends Controller
      *
      * @param  Character  $character  The character
      * @param  string  $classIdOrSlug  Class ID or slug
-     *
-     * @response array{data: array{previous_level: int, new_level: int, hp_increase: int, new_max_hp: int, features_gained: array<array{id: int, name: string, description: string|null}>, spell_slots: array<string, int>, asi_pending: bool, hp_choice_pending: bool, pending_choice_summary: array{total_pending: int, required_pending: int, optional_pending: int, by_type: array<string, int>, by_source: array<string, int>}}}
+     * @return \Illuminate\Http\JsonResponse<LevelUpResource>
      */
     public function levelUp(Character $character, string $classSlugOrFullSlug): JsonResponse
     {
@@ -319,8 +318,7 @@ class CharacterClassController extends Controller
      * @param  CharacterClassAddRequest  $request  The validated request
      * @param  Character  $character  The character
      * @param  string  $classIdOrSlug  The class ID or slug to replace
-     *
-     * @response array{data: array{class: array{id: int, name: string, slug: string}|null, class_slug: string, is_dangling: bool, subclass: array{id: int, name: string, slug: string}|null, subclass_slug: string|null, level: int, is_primary: bool, order: int, hit_dice: array{die: string, max: int, spent: int, available: int}|null}}
+     * @return \Illuminate\Http\JsonResponse<CharacterClassPivotResource>
      */
     public function replace(CharacterClassAddRequest $request, Character $character, string $classSlugOrFullSlug): JsonResponse
     {
@@ -399,11 +397,10 @@ class CharacterClassController extends Controller
      * @param  CharacterSubclassSetRequest  $request  The validated request
      * @param  Character  $character  The character
      * @param  string  $classSlugOrFullSlug  Class slug
+     * @return \Illuminate\Http\JsonResponse<CharacterClassPivotResource>
      *
      * @throws InvalidSubclassException If subclass doesn't belong to the class
      * @throws SubclassLevelRequirementException If character level is below requirement
-     *
-     * @response array{data: array{class: array{id: int, name: string, slug: string}|null, class_slug: string, is_dangling: bool, subclass: array{id: int, name: string, slug: string}|null, subclass_slug: string|null, level: int, is_primary: bool, order: int, hit_dice: array{die: string, max: int, spent: int, available: int}|null}}
      */
     public function setSubclass(CharacterSubclassSetRequest $request, Character $character, string $classSlugOrFullSlug): JsonResponse
     {

--- a/app/Http/Controllers/Api/CharacterClassController.php
+++ b/app/Http/Controllers/Api/CharacterClassController.php
@@ -22,6 +22,7 @@ use App\Services\LevelUpService;
 use App\Services\ReplaceClassService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -160,7 +161,7 @@ class CharacterClassController extends Controller
      *
      * @response 204 scenario="success"
      */
-    public function destroy(Character $character, string $classSlugOrFullSlug): JsonResponse
+    public function destroy(Character $character, string $classSlugOrFullSlug): JsonResponse|HttpResponse
     {
         // Accept either slug (phb:fighter) or simple slug (fighter)
         $class = CharacterClass::where('slug', $classSlugOrFullSlug)
@@ -192,7 +193,7 @@ class CharacterClassController extends Controller
 
             $pivot->delete();
 
-            return response()->json(null, Response::HTTP_NO_CONTENT);
+            return response()->noContent();
         });
     }
 

--- a/app/Http/Controllers/Api/CharacterExperienceController.php
+++ b/app/Http/Controllers/Api/CharacterExperienceController.php
@@ -31,27 +31,6 @@ class CharacterExperienceController extends Controller
      * @operationId characters.showXp
      *
      * @tags Characters
-     *
-     * @response 200 {
-     *   "data": {
-     *     "experience_points": 10000,
-     *     "level": 5,
-     *     "next_level_xp": 14000,
-     *     "xp_to_next_level": 4000,
-     *     "xp_progress_percent": 46.67,
-     *     "is_max_level": false
-     *   }
-     * }
-     * @response 200 scenario="Max level" {
-     *   "data": {
-     *     "experience_points": 400000,
-     *     "level": 20,
-     *     "next_level_xp": null,
-     *     "xp_to_next_level": 0,
-     *     "xp_progress_percent": 100,
-     *     "is_max_level": true
-     *   }
-     * }
      */
     public function show(Character $character): XpProgressResource
     {
@@ -86,21 +65,6 @@ class CharacterExperienceController extends Controller
      * @operationId characters.addXp
      *
      * @tags Characters
-     *
-     * @bodyParam amount integer required XP to add (min: 0). Example: 500
-     * @bodyParam auto_level boolean Trigger level-up if threshold crossed. Example: true
-     *
-     * @response 200 {
-     *   "data": {
-     *     "experience_points": 500,
-     *     "level": 2,
-     *     "next_level_xp": 900,
-     *     "xp_to_next_level": 400,
-     *     "xp_progress_percent": 33.3,
-     *     "is_max_level": false,
-     *     "leveled_up": false
-     *   }
-     * }
      */
     public function addXp(AddExperienceRequest $request, Character $character): XpProgressResource
     {

--- a/app/Http/Controllers/Api/CharacterExportController.php
+++ b/app/Http/Controllers/Api/CharacterExportController.php
@@ -48,21 +48,7 @@ class CharacterExportController extends Controller
      *
      * @operationId importCharacter
      *
-     * @response 201 array{
-     *     data: array{
-     *         success: bool,
-     *         character: array{
-     *             public_id: string,
-     *             name: string,
-     *             race: string|null
-     *         },
-     *         warnings: array<string>
-     *     }
-     * }
-     * @response 422 array{
-     *     message: string,
-     *     errors: array<string, array<string>>
-     * }
+     * @response CharacterImportResultResource
      */
     public function import(CharacterImportRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/CharacterSpellController.php
+++ b/app/Http/Controllers/Api/CharacterSpellController.php
@@ -125,7 +125,7 @@ class CharacterSpellController extends Controller
      * - Spell must not already be known by character
      * - Dangling references allowed per #288
      *
-     * @response 201 array{data: array{id: int, spell: array{id: int, name: string, slug: string, level: int, school: string|null, casting_time: string, range: string, components: string, duration: string, concentration: bool, ritual: bool}|null, spell_slug: string, is_dangling: bool, preparation_status: string, source: string, level_acquired: int|null, is_prepared: bool, is_always_prepared: bool}}
+     * @response CharacterSpellResource
      */
     public function store(CharacterSpellStoreRequest $request, Character $character): JsonResponse
     {

--- a/app/Http/Controllers/Api/CharacterValidationController.php
+++ b/app/Http/Controllers/Api/CharacterValidationController.php
@@ -33,21 +33,6 @@ class CharacterValidationController extends Controller
      * ```
      * GET /api/v1/characters/brave-wizard-x7k2/validate
      * ```
-     *
-     * @response 200 {
-     *   "data": {
-     *     "valid": false,
-     *     "dangling_references": {
-     *       "race": "phb:high-elf",
-     *       "spells": ["phb:wish", "phb:meteor-swarm"]
-     *     },
-     *     "summary": {
-     *       "total_references": 15,
-     *       "valid_references": 12,
-     *       "dangling_count": 3
-     *     }
-     *   }
-     * }
      */
     public function show(Character $character): CharacterValidationResource
     {
@@ -66,21 +51,6 @@ class CharacterValidationController extends Controller
      * ```
      * GET /api/v1/characters/validate-all
      * ```
-     *
-     * @response 200 {
-     *   "data": {
-     *     "total": 42,
-     *     "valid": 38,
-     *     "invalid": 4,
-     *     "characters": [
-     *       {
-     *         "public_id": "brave-wizard-x7k2",
-     *         "name": "Gandalf",
-     *         "dangling_references": {"race": "phb:high-elf"}
-     *       }
-     *     ]
-     *   }
-     * }
      */
     public function index(): ValidationSummaryResource
     {

--- a/app/Http/Controllers/Api/ClassController.php
+++ b/app/Http/Controllers/Api/ClassController.php
@@ -17,6 +17,7 @@ use App\Services\Cache\EntityCacheService;
 use App\Services\ClassProgressionTableGenerator;
 use App\Services\ClassSearchService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client;
 
 class ClassController extends Controller
@@ -338,9 +339,11 @@ class ClassController extends Controller
      *
      * For complete operator documentation and syntax, see:
      * https://www.meilisearch.com/docs/reference/api/search#filter
+     *
+     * @response AnonymousResourceCollection<ClassResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Supports all operators by data type: Integer (=,!=,>,>=,<,<=,TO), String (=,!=), Boolean (=,!=,IS NULL,EXISTS), Array (IN,NOT IN,IS EMPTY). Fields: id, slug, hit_die, spell_count, max_spell_level, optional_feature_count, primary_ability, spellcasting_ability, parent_class_name, is_base_class, is_subclass, has_spells, is_spellcaster, has_optional_features, source_codes, tag_slugs, saving_throw_proficiencies, armor_proficiencies, weapon_proficiencies, tool_proficiencies, skill_proficiencies, optional_feature_types. See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'is_base_class = true AND armor_proficiencies IN ["Heavy Armor"]')]
-    public function index(ClassIndexRequest $request, ClassSearchService $service, Client $meilisearch)
+    public function index(ClassIndexRequest $request, ClassSearchService $service, Client $meilisearch): AnonymousResourceCollection
     {
         $dto = ClassSearchDTO::fromRequest($request);
 
@@ -518,7 +521,7 @@ class ClassController extends Controller
      * The `computed` object is **only included on show endpoint** for performance.
      * Index endpoint returns base fields and relationships without computed data.
      */
-    public function show(ClassShowRequest $request, CharacterClass $class, EntityCacheService $cache, ClassSearchService $service)
+    public function show(ClassShowRequest $request, CharacterClass $class, EntityCacheService $cache, ClassSearchService $service): ClassResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/ConditionController.php
+++ b/app/Http/Controllers/Api/ConditionController.php
@@ -53,6 +53,8 @@ class ConditionController extends Controller
      * - **Spell Selection:** Choose control spells based on conditions they inflict (Hold Person = Paralyzed)
      * - **Monster Abilities:** Understand dangerous monster attacks (Ghoul claws = Paralyzed, Medusa gaze = Petrified)
      * - **Condition Removal:** Prepare Lesser Restoration (removes Blinded, Deafened, Paralyzed, Poisoned)
+     *
+     * @response AnonymousResourceCollection<ConditionResource>
      */
     #[QueryParameter('q', description: 'Search by name', example: 'frightened')]
     public function index(ConditionIndexRequest $request, LookupCacheService $cache): AnonymousResourceCollection

--- a/app/Http/Controllers/Api/DamageTypeController.php
+++ b/app/Http/Controllers/Api/DamageTypeController.php
@@ -41,6 +41,8 @@ class DamageTypeController extends Controller
      * - **Resistance Planning:** Check enemy resistances before combat (many undead resist necrotic)
      * - **Spell Selection:** Build diverse spell lists with multiple damage types
      * - **Vulnerability Exploitation:** Target known vulnerabilities (trolls vs. fire/acid)
+     *
+     * @response AnonymousResourceCollection<DamageTypeResource>
      */
     #[QueryParameter('q', description: 'Search damage types by name', example: 'fire')]
     public function index(DamageTypeIndexRequest $request, LookupCacheService $cache): AnonymousResourceCollection

--- a/app/Http/Controllers/Api/FeatController.php
+++ b/app/Http/Controllers/Api/FeatController.php
@@ -11,6 +11,7 @@ use App\Models\Feat;
 use App\Services\Cache\EntityCacheService;
 use App\Services\FeatSearchService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client;
 
 class FeatController extends Controller
@@ -115,10 +116,11 @@ class FeatController extends Controller
      * @param  FeatIndexRequest  $request  Validated request with filtering parameters
      * @param  FeatSearchService  $service  Service layer for feat queries
      * @param  Client  $meilisearch  Meilisearch client for advanced filtering
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *
+     * @response AnonymousResourceCollection<FeatResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Supports all operators by data type: Integer (=,!=,>,>=,<,<=,TO), String (=,!=), Boolean (=,!=,IS NULL,EXISTS), Array (IN,NOT IN,IS EMPTY). Filterable fields: id, slug, source_codes, tag_slugs, has_prerequisites, grants_proficiencies, is_half_feat, improved_abilities, prerequisite_types, parent_feat_slug. See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'is_half_feat = true AND improved_abilities IN [STR]')]
-    public function index(FeatIndexRequest $request, FeatSearchService $service, Client $meilisearch)
+    public function index(FeatIndexRequest $request, FeatSearchService $service, Client $meilisearch): AnonymousResourceCollection
     {
         $dto = FeatSearchDTO::fromRequest($request);
 
@@ -143,7 +145,7 @@ class FeatController extends Controller
      * Returns detailed information about a specific feat including modifiers, proficiencies,
      * conditions, prerequisites, and source citations. Supports selective relationship loading.
      */
-    public function show(FeatShowRequest $request, Feat $feat, EntityCacheService $cache, FeatSearchService $service)
+    public function show(FeatShowRequest $request, Feat $feat, EntityCacheService $cache, FeatSearchService $service): FeatResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/ItemController.php
+++ b/app/Http/Controllers/Api/ItemController.php
@@ -13,6 +13,7 @@ use App\Models\Item;
 use App\Services\Cache\EntityCacheService;
 use App\Services\ItemSearchService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client;
 
 class ItemController extends Controller
@@ -143,10 +144,11 @@ class ItemController extends Controller
      * @param  ItemIndexRequest  $request  Validated request with filtering parameters
      * @param  ItemSearchService  $service  Service layer for item queries
      * @param  Client  $meilisearch  Meilisearch client for advanced filtering
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *
+     * @response AnonymousResourceCollection<ItemResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Supports all operators by data type: Integer (=,!=,>,>=,<,<=,TO), String (=,!=), Boolean (=,!=,IS NULL,EXISTS), Array (IN,NOT IN,IS EMPTY). Filterable fields: id, slug, type_name, type_code, rarity, requires_attunement, is_magic, weight, cost_cp, source_codes, damage_dice, versatile_damage, damage_type, range_normal, range_long, armor_class, strength_requirement, stealth_disadvantage, charges_max, has_charges, recharge_timing, recharge_formula, spell_slugs, tag_slugs, property_codes, modifier_categories, proficiency_names, saving_throw_abilities, has_prerequisites, proficiency_category, magic_bonus. See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'proficiency_category = martial_melee AND magic_bonus >= 1')]
-    public function index(ItemIndexRequest $request, ItemSearchService $service, Client $meilisearch)
+    public function index(ItemIndexRequest $request, ItemSearchService $service, Client $meilisearch): AnonymousResourceCollection
     {
         $dto = ItemSearchDTO::fromRequest($request);
 
@@ -172,7 +174,7 @@ class ItemController extends Controller
      * properties, abilities, random tables, modifiers, proficiencies, and prerequisites.
      * Supports selective relationship loading via the 'include' parameter.
      */
-    public function show(ItemShowRequest $request, Item $item, EntityCacheService $cache, ItemSearchService $service)
+    public function show(ItemShowRequest $request, Item $item, EntityCacheService $cache, ItemSearchService $service): ItemResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/LanguageController.php
+++ b/app/Http/Controllers/Api/LanguageController.php
@@ -56,6 +56,8 @@ class LanguageController extends Controller
      * - **Character Creation:** Choose languages based on race and background
      * - **Campaign Planning:** Identify languages needed for specific settings (Underdark, Planes, etc.)
      * - **Roleplay:** Determine if characters can communicate with NPCs or creatures
+     *
+     * @response AnonymousResourceCollection<LanguageResource>
      */
     #[QueryParameter('q', description: 'Search by name', example: 'elvish')]
     public function index(LanguageIndexRequest $request, LookupCacheService $cache): AnonymousResourceCollection

--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Media\MediaUploadRequest;
 use App\Http\Resources\MediaResource;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Spatie\MediaLibrary\HasMedia;
 
@@ -28,10 +29,8 @@ class MediaController extends Controller
      * ```
      * GET /api/v1/characters/5/media/portrait
      * ```
-     *
-     * @response array{data: array<int, array{id: int, collection: string, file_name: string, mime_type: string, size: int, urls: array{original: string, thumb: string|null, medium: string|null}, created_at: string|null}>}
      */
-    public function index(Request $request, string $modelType, int $modelId, string $collection)
+    public function index(Request $request, string $modelType, int $modelId, string $collection): AnonymousResourceCollection
     {
         $model = $this->resolveModel($modelType, $modelId);
         $this->validateCollection($modelType, $collection);

--- a/app/Http/Controllers/Api/MonsterController.php
+++ b/app/Http/Controllers/Api/MonsterController.php
@@ -277,10 +277,8 @@ class MonsterController extends Controller
      * **Data Source:**
      * Powered by SpellcasterStrategy which syncs 1,098 spell relationships
      * across 129 spellcasting monsters with 100% match rate.
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, level: int, school: array{id: int, name: string, code: string}|null}>}
      */
-    public function spells(Monster $monster)
+    public function spells(Monster $monster): AnonymousResourceCollection
     {
         $monster->load(['spells' => function ($query) {
             $query->orderBy('level')->orderBy('name');

--- a/app/Http/Controllers/Api/MonsterController.php
+++ b/app/Http/Controllers/Api/MonsterController.php
@@ -14,6 +14,7 @@ use App\Models\Monster;
 use App\Services\Cache\EntityCacheService;
 use App\Services\MonsterSearchService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client;
 
 class MonsterController extends Controller
@@ -208,10 +209,11 @@ class MonsterController extends Controller
      * @param  MonsterIndexRequest  $request  Validated request with filtering parameters
      * @param  MonsterSearchService  $service  Service layer for monster queries
      * @param  Client  $meilisearch  Meilisearch client for advanced filtering
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *
+     * @response AnonymousResourceCollection<MonsterResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Supports all operators by data type: Integer (=,!=,>,>=,<,<=,TO), String (=,!=), Boolean (=,!=,IS NULL,EXISTS), Array (IN,NOT IN,IS EMPTY). Fields: challenge_rating, armor_class, hit_points_average, experience_points, strength, dexterity, constitution, intelligence, wisdom, charisma, speed_walk, speed_fly, speed_swim, speed_burrow, speed_climb, passive_perception, legendary_resistance_uses, type, size_code, size_name, alignment, armor_type, slug, has_legendary_actions, has_lair_actions, is_spellcaster, has_reactions, has_legendary_resistance, has_magic_resistance, can_hover, is_npc, source_codes, tag_slugs, spell_slugs. See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'challenge_rating >= 10 AND has_legendary_actions = true')]
-    public function index(MonsterIndexRequest $request, MonsterSearchService $service, Client $meilisearch)
+    public function index(MonsterIndexRequest $request, MonsterSearchService $service, Client $meilisearch): AnonymousResourceCollection
     {
         $dto = MonsterSearchDTO::fromRequest($request);
 
@@ -237,7 +239,7 @@ class MonsterController extends Controller
      * legendary actions, spellcasting, modifiers, conditions, and source citations.
      * Supports selective relationship loading via the 'include' parameter.
      */
-    public function show(MonsterShowRequest $request, Monster $monster, EntityCacheService $cache, MonsterSearchService $service)
+    public function show(MonsterShowRequest $request, Monster $monster, EntityCacheService $cache, MonsterSearchService $service): MonsterResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/OptionalFeatureController.php
+++ b/app/Http/Controllers/Api/OptionalFeatureController.php
@@ -11,6 +11,7 @@ use App\Models\OptionalFeature;
 use App\Services\Cache\EntityCacheService;
 use App\Services\OptionalFeatureSearchService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client;
 
 class OptionalFeatureController extends Controller
@@ -86,10 +87,11 @@ class OptionalFeatureController extends Controller
      * @param  OptionalFeatureIndexRequest  $request  Validated request with filtering parameters
      * @param  OptionalFeatureSearchService  $service  Service layer for optional feature queries
      * @param  Client  $meilisearch  Meilisearch client for advanced filtering
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *
+     * @response AnonymousResourceCollection<OptionalFeatureResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Supports all operators by data type: Integer (=,!=,>,>=,<,<=,TO), String (=,!=), Boolean (=,!=,IS NULL,EXISTS), Array (IN,NOT IN,IS EMPTY). See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'feature_type = eldritch_invocation AND level_requirement <= 5')]
-    public function index(OptionalFeatureIndexRequest $request, OptionalFeatureSearchService $service, Client $meilisearch)
+    public function index(OptionalFeatureIndexRequest $request, OptionalFeatureSearchService $service, Client $meilisearch): AnonymousResourceCollection
     {
         $dto = OptionalFeatureSearchDTO::fromRequest($request);
 
@@ -114,7 +116,7 @@ class OptionalFeatureController extends Controller
      * Returns detailed information about a specific optional feature including relationships
      * like classes, sources, and tags. Supports selective relationship loading via the 'include' parameter.
      */
-    public function show(OptionalFeatureShowRequest $request, OptionalFeature $optionalFeature, EntityCacheService $cache, OptionalFeatureSearchService $service)
+    public function show(OptionalFeatureShowRequest $request, OptionalFeature $optionalFeature, EntityCacheService $cache, OptionalFeatureSearchService $service): OptionalFeatureResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/PartyController.php
+++ b/app/Http/Controllers/Api/PartyController.php
@@ -114,11 +114,11 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function removeCharacter(Request $request, Party $party, Character $character): JsonResponse|Response
+    public function removeCharacter(Request $request, Party $party, Character $character): Response
     {
         // Check if character is in party
         if (! $party->characters()->where('character_id', $character->id)->exists()) {
-            return response()->json(['message' => 'Character not in party'], Response::HTTP_NOT_FOUND);
+            abort(404, 'Character not in party');
         }
 
         $party->characters()->detach($character->id);

--- a/app/Http/Controllers/Api/PartyController.php
+++ b/app/Http/Controllers/Api/PartyController.php
@@ -81,11 +81,11 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function destroy(Request $request, Party $party): JsonResponse
+    public function destroy(Request $request, Party $party): Response
     {
         $party->delete();
 
-        return response()->json(null, Response::HTTP_NO_CONTENT);
+        return response()->noContent();
     }
 
     /**
@@ -114,7 +114,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function removeCharacter(Request $request, Party $party, Character $character): JsonResponse
+    public function removeCharacter(Request $request, Party $party, Character $character): JsonResponse|Response
     {
         // Check if character is in party
         if (! $party->characters()->where('character_id', $character->id)->exists()) {
@@ -123,7 +123,7 @@ class PartyController extends Controller
 
         $party->characters()->detach($character->id);
 
-        return response()->json(null, Response::HTTP_NO_CONTENT);
+        return response()->noContent();
     }
 
     /**

--- a/app/Http/Controllers/Api/PartyEncounterMonsterController.php
+++ b/app/Http/Controllers/Api/PartyEncounterMonsterController.php
@@ -96,7 +96,7 @@ class PartyEncounterMonsterController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function destroy(Party $party, EncounterMonster $encounterMonster): JsonResponse
+    public function destroy(Party $party, EncounterMonster $encounterMonster): Response
     {
         // Verify the monster belongs to this party
         if ($encounterMonster->party_id !== $party->id) {
@@ -105,7 +105,7 @@ class PartyEncounterMonsterController extends Controller
 
         $encounterMonster->delete();
 
-        return response()->json(null, Response::HTTP_NO_CONTENT);
+        return response()->noContent();
     }
 
     /**
@@ -113,11 +113,11 @@ class PartyEncounterMonsterController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function clear(Party $party): JsonResponse
+    public function clear(Party $party): Response
     {
         $party->encounterMonsters()->delete();
 
-        return response()->json(null, Response::HTTP_NO_CONTENT);
+        return response()->noContent();
     }
 
     /**

--- a/app/Http/Controllers/Api/PartyEncounterPresetController.php
+++ b/app/Http/Controllers/Api/PartyEncounterPresetController.php
@@ -74,7 +74,7 @@ class PartyEncounterPresetController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function destroy(Party $party, EncounterPreset $encounterPreset): JsonResponse
+    public function destroy(Party $party, EncounterPreset $encounterPreset): Response
     {
         if ($encounterPreset->party_id !== $party->id) {
             abort(404, 'Preset not found in this party');
@@ -82,7 +82,7 @@ class PartyEncounterPresetController extends Controller
 
         $encounterPreset->delete();
 
-        return response()->json(null, Response::HTTP_NO_CONTENT);
+        return response()->noContent();
     }
 
     /**

--- a/app/Http/Controllers/Api/ProficiencyTypeController.php
+++ b/app/Http/Controllers/Api/ProficiencyTypeController.php
@@ -12,7 +12,7 @@ use App\Http\Resources\RaceResource;
 use App\Models\ProficiencyType;
 use App\Services\Cache\LookupCacheService;
 use Dedoc\Scramble\Attributes\QueryParameter;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ProficiencyTypeController extends Controller
 {
@@ -51,13 +51,11 @@ class ProficiencyTypeController extends Controller
      * - **Multiclass Planning:** "What martial weapons can a Rogue use after Fighter dip?"
      * - **Character Building:** Find which proficiencies your race/class/background grants
      * - **Equipment Shopping:** Browse weapon proficiencies to know what you can use effectively
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, category: string, subcategory: string|null}>}
      */
     #[QueryParameter('q', description: 'Search proficiencies by name', example: 'longsword')]
     #[QueryParameter('category', description: 'Filter by category (weapon, armor, tool, language, skill, saving-throw)', example: 'weapon')]
     #[QueryParameter('subcategory', description: 'Filter by subcategory within category (e.g., simple, martial)', example: 'martial')]
-    public function index(ProficiencyTypeIndexRequest $request, LookupCacheService $cache)
+    public function index(ProficiencyTypeIndexRequest $request, LookupCacheService $cache): AnonymousResourceCollection
     {
         $query = ProficiencyType::query();
 
@@ -184,10 +182,8 @@ class ProficiencyTypeController extends Controller
      * - Results are alphabetically sorted for consistent browsing
      * - Includes base classes AND subclasses (e.g., Eldritch Knight Fighter counts separately)
      * - Check `parent_class_id` in response to distinguish base vs subclass
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, hit_die: int, description: string|null, archetype: string|null, parent_class_id: int|null, is_base_class: bool}>}
      */
-    public function classes(ProficiencyTypeShowRequest $request, ProficiencyType $proficiencyType): JsonResponse
+    public function classes(ProficiencyTypeShowRequest $request, ProficiencyType $proficiencyType): AnonymousResourceCollection
     {
         $perPage = $request->validated('per_page', 50);
 
@@ -195,7 +191,7 @@ class ProficiencyTypeController extends Controller
             ->with(['sources', 'tags'])
             ->paginate($perPage);
 
-        return ClassResource::collection($classes)->toResponse($request);
+        return ClassResource::collection($classes);
     }
 
     /**
@@ -247,10 +243,8 @@ class ProficiencyTypeController extends Controller
      * - Results include base races AND subraces (e.g., High Elf, Wood Elf count separately)
      * - Check `parent_race_id` in response to distinguish base race vs subrace
      * - Results alphabetically sorted for consistent browsing
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, speed: int|null, is_subrace: bool}>}
      */
-    public function races(ProficiencyTypeShowRequest $request, ProficiencyType $proficiencyType): JsonResponse
+    public function races(ProficiencyTypeShowRequest $request, ProficiencyType $proficiencyType): AnonymousResourceCollection
     {
         $perPage = $request->validated('per_page', 50);
 
@@ -258,7 +252,7 @@ class ProficiencyTypeController extends Controller
             ->with(['sources', 'tags', 'size'])
             ->paginate($perPage);
 
-        return RaceResource::collection($races)->toResponse($request);
+        return RaceResource::collection($races);
     }
 
     /**
@@ -317,10 +311,8 @@ class ProficiencyTypeController extends Controller
      * - Results alphabetically sorted for consistent navigation
      * - All backgrounds are base-level (no "sub-backgrounds" like races/classes have)
      * - Check background description for thematic fit beyond mechanical proficiencies
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, feature_name: string|null, feature_description: string|null}>}
      */
-    public function backgrounds(ProficiencyTypeShowRequest $request, ProficiencyType $proficiencyType): JsonResponse
+    public function backgrounds(ProficiencyTypeShowRequest $request, ProficiencyType $proficiencyType): AnonymousResourceCollection
     {
         $perPage = $request->validated('per_page', 50);
 
@@ -328,6 +320,6 @@ class ProficiencyTypeController extends Controller
             ->with(['sources', 'tags'])
             ->paginate($perPage);
 
-        return BackgroundResource::collection($backgrounds)->toResponse($request);
+        return BackgroundResource::collection($backgrounds);
     }
 }

--- a/app/Http/Controllers/Api/RaceController.php
+++ b/app/Http/Controllers/Api/RaceController.php
@@ -14,6 +14,7 @@ use App\Models\Race;
 use App\Services\Cache\EntityCacheService;
 use App\Services\RaceSearchService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client as MeilisearchClient;
 
 class RaceController extends Controller
@@ -105,10 +106,11 @@ class RaceController extends Controller
      * @param  RaceIndexRequest  $request  Validated request with filtering parameters
      * @param  RaceSearchService  $service  Service layer for race queries
      * @param  MeilisearchClient  $meilisearch  Meilisearch client for advanced filtering
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *
+     * @response AnonymousResourceCollection<RaceResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Supports all operators by data type: Integer (=,!=,>,>=,<,<=,TO), String (=,!=), Boolean (=,!=,IS NULL,EXISTS), Array (IN,NOT IN,IS EMPTY). See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'ability_int_bonus >= 2 AND speed >= 30')]
-    public function index(RaceIndexRequest $request, RaceSearchService $service, MeilisearchClient $meilisearch)
+    public function index(RaceIndexRequest $request, RaceSearchService $service, MeilisearchClient $meilisearch): AnonymousResourceCollection
     {
         $dto = RaceSearchDTO::fromRequest($request);
 
@@ -133,7 +135,7 @@ class RaceController extends Controller
      * subraces, ability modifiers, proficiencies, traits, languages, and spells.
      * Supports selective relationship loading via the 'include' parameter.
      */
-    public function show(RaceShowRequest $request, Race $race, EntityCacheService $cache, RaceSearchService $service)
+    public function show(RaceShowRequest $request, Race $race, EntityCacheService $cache, RaceSearchService $service): RaceResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/RaceController.php
+++ b/app/Http/Controllers/Api/RaceController.php
@@ -165,10 +165,8 @@ class RaceController extends Controller
      * - Tiefling: Thaumaturgy (0), Hellish Rebuke (1), Darkness (2)
      * - High Elf: 1 wizard cantrip (player's choice)
      * - Forest Gnome: Minor Illusion (0)
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, level: int, school: array{id: int, name: string, code: string}|null}>}
      */
-    public function spells(Race $race)
+    public function spells(Race $race): AnonymousResourceCollection
     {
         $race->load(['spells' => function ($query) {
             $query->orderBy('level')->orderBy('name');

--- a/app/Http/Controllers/Api/SizeController.php
+++ b/app/Http/Controllers/Api/SizeController.php
@@ -11,6 +11,7 @@ use App\Models\Size;
 use App\Services\Cache\LookupCacheService;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class SizeController extends Controller
 {
@@ -52,11 +53,9 @@ class SizeController extends Controller
      * - **Encounter Design:** "What space requirements do I need for a Large boss fight?" (10ft × 10ft minimum)
      * - **Mount Planning:** "My Small Halfling needs a Medium mount - what are the options?" (Pony, Wolf, Mastiff)
      * - **Dungeon Navigation:** "Will a Large PC fit through standard 5ft doors?" (Yes, but squeezing)
-     *
-     * @response array{data: array<int, array{id: int, code: string, name: string}>}
      */
     #[QueryParameter('q', description: 'Search by name', example: 'medium')]
-    public function index(SizeIndexRequest $request, LookupCacheService $cache)
+    public function index(SizeIndexRequest $request, LookupCacheService $cache): AnonymousResourceCollection
     {
         $query = Size::query();
 

--- a/app/Http/Controllers/Api/SpellController.php
+++ b/app/Http/Controllers/Api/SpellController.php
@@ -17,6 +17,7 @@ use App\Models\Spell;
 use App\Services\Cache\EntityCacheService;
 use App\Services\SpellSearchService;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use MeiliSearch\Client;
 
 class SpellController extends Controller
@@ -115,10 +116,11 @@ class SpellController extends Controller
      * @param  SpellIndexRequest  $request  Validated request with filtering parameters
      * @param  SpellSearchService  $service  Service layer for spell queries
      * @param  Client  $meilisearch  Meilisearch client for advanced filtering
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *
+     * @response AnonymousResourceCollection<SpellResource>
      */
     #[QueryParameter('filter', description: 'Meilisearch filter expression. Supports all operators by data type: Integer (=,!=,>,>=,<,<=,TO), String (=,!=), Boolean (=,!=,IS NULL,EXISTS), Array (IN,NOT IN,IS EMPTY). Filterable fields include: id, level, school_code, school_name, concentration, ritual, requires_verbal, requires_somatic, requires_material, class_slugs, tag_slugs, source_codes, damage_types, saving_throws, effect_types, material_cost_gp, material_consumed, aoe_type, aoe_size. See docs/MEILISEARCH-FILTER-OPERATORS.md for details.', example: 'aoe_type = sphere AND aoe_size >= 20')]
-    public function index(SpellIndexRequest $request, SpellSearchService $service, Client $meilisearch)
+    public function index(SpellIndexRequest $request, SpellSearchService $service, Client $meilisearch): AnonymousResourceCollection
     {
         $dto = SpellSearchDTO::fromRequest($request);
 
@@ -144,7 +146,7 @@ class SpellController extends Controller
      * like spell school, sources, damage effects, and associated classes.
      * Supports selective relationship loading via the 'include' parameter.
      */
-    public function show(SpellShowRequest $request, Spell $spell, EntityCacheService $cache, SpellSearchService $service)
+    public function show(SpellShowRequest $request, Spell $spell, EntityCacheService $cache, SpellSearchService $service): SpellResource
     {
         return $this->showWithCache(
             request: $request,

--- a/app/Http/Controllers/Api/SpellController.php
+++ b/app/Http/Controllers/Api/SpellController.php
@@ -181,10 +181,8 @@ class SpellController extends Controller
      * across 131 classes/subclasses and 477 spells imported from official D&D sourcebooks.
      *
      * @param  Spell  $spell  The spell to find classes for (accepts ID or slug)
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, hit_die: int, is_base_class: bool}>}
      */
-    public function classes(Spell $spell)
+    public function classes(Spell $spell): AnonymousResourceCollection
     {
         $spell->load(['classes' => function ($query) {
             $query->orderBy('name');
@@ -217,10 +215,8 @@ class SpellController extends Controller
      * monster imports with 100% spell name match rate.
      *
      * @param  Spell  $spell  The spell to find monsters for (accepts ID or slug)
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, challenge_rating: string|null, type: string|null}>}
      */
-    public function monsters(Spell $spell)
+    public function monsters(Spell $spell): AnonymousResourceCollection
     {
         $spell->load(['monsters' => function ($query) {
             $query->orderBy('name');
@@ -253,10 +249,8 @@ class SpellController extends Controller
      * ChargedItemStrategy during item imports using case-insensitive spell name matching.
      *
      * @param  Spell  $spell  The spell to find items for (accepts ID or slug)
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, type: string|null, rarity: string|null}>}
      */
-    public function items(Spell $spell)
+    public function items(Spell $spell): AnonymousResourceCollection
     {
         $spell->load(['items' => function ($query) {
             $query->orderBy('name');
@@ -289,10 +283,8 @@ class SpellController extends Controller
      * official D&D sourcebooks.
      *
      * @param  Spell  $spell  The spell to find races for (accepts ID or slug)
-     *
-     * @response array{data: array<int, array{id: int, slug: string, name: string, speed: int|null, is_subrace: bool}>}
      */
-    public function races(Spell $spell)
+    public function races(Spell $spell): AnonymousResourceCollection
     {
         $spell->load(['races' => function ($query) {
             $query->orderBy('name');

--- a/app/Http/Controllers/Api/SpellSchoolController.php
+++ b/app/Http/Controllers/Api/SpellSchoolController.php
@@ -45,6 +45,8 @@ class SpellSchoolController extends Controller
      * - **Wizard Specialization:** Choose a school to gain bonus features (Evocation for damage, Divination for utility)
      * - **Spell Selection:** Browse spells by school to build a thematic caster
      * - **Counterspell Decisions:** Identify spell schools to prioritize countering
+     *
+     * @response AnonymousResourceCollection<SpellSchoolResource>
      */
     #[QueryParameter('q', description: 'Search schools by name', example: 'evocation')]
     public function index(SpellSchoolIndexRequest $request, LookupCacheService $cache): AnonymousResourceCollection

--- a/app/Http/Controllers/Api/TagController.php
+++ b/app/Http/Controllers/Api/TagController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\TagResource;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Spatie\Tags\Tag;
 
 /**
@@ -67,11 +68,9 @@ class TagController extends Controller
      * **Data Source:**
      * Tag system powered by Spatie Laravel Tags package. All tags are synced during entity imports
      * and tagged dynamically through the application. Total unique tags: 100+
-     *
-     * @response array{data: array<int, array{id: int, name: string, slug: string, type: string|null}>}
      */
     #[QueryParameter('type', description: 'Filter tags by entity type: spell, monster, item, race, class, feat, background', example: 'spell')]
-    public function index()
+    public function index(): AnonymousResourceCollection
     {
         $query = Tag::query()->ordered();
 


### PR DESCRIPTION
## Summary

Replace `response()->json(null, Response::HTTP_NO_CONTENT)` with the idiomatic Laravel helper `response()->noContent()` across 7 DELETE endpoints.

### Changed

| Controller | Method |
|------------|--------|
| `PartyController` | `destroy()`, `removeCharacter()` |
| `PartyEncounterMonsterController` | `destroy()`, `clear()` |
| `PartyEncounterPresetController` | `destroy()` |
| `CharacterClassController` | `destroy()` |
| `CharacterConditionController` | `destroy()` |

Also updated return types to use `Response` instead of `JsonResponse` where applicable, and added necessary imports.

## Test Plan

- [x] Full feature-db test suite passes (700+ tests)
- [x] Code formatted with Pint

Closes #740