### PR TITLE
feat(api): add unified combat and character sheet endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Issue #760**: Add unified combat and character sheet endpoints
+  - `GET /characters/{id}/combat`: Combat-focused aggregate returning all battle data in one response
+    - Character identity, combat stats (AC, HP, initiative, speed), saving throws
+    - Equipped weapons with attack/damage bonuses, spell slots, prepared spells
+    - Class resources (Action Surge, Rage, etc.), active conditions, death saves
+    - Defenses (resistances, immunities, vulnerabilities), per-class spellcasting
+  - `GET /characters/{id}/sheet`: Complete character sheet aggregate
+    - Full CharacterResource, CharacterStatsResource, all spells, all equipment
+    - All features, notes (grouped by category), proficiencies, languages
+  - Reduces frontend round-trips from 4+ API calls to single request
+
 - **Issue #757**: Enhanced `CharacterEquipmentResource` with weapon, armor, and magic item details
   - **Weapon fields**: `damage_type`, `properties`, `range` (object with `normal`/`long`), `versatile_damage`
   - **Armor fields**: `armor_type` (`light`/`medium`/`heavy`), `max_dex_bonus` (null/2/0), `stealth_disadvantage`, `strength_requirement`

--- a/app/Http/Resources/CharacterCombatResource.php
+++ b/app/Http/Resources/CharacterCombatResource.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\DTOs\CharacterStatsDTO;
+use App\Models\Character;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Combat-focused aggregate resource for battle interfaces.
+ *
+ * Returns all combat-relevant data in a single response, reducing
+ * frontend round-trips for combat scenarios.
+ *
+ * @property Character $resource
+ */
+class CharacterCombatResource extends JsonResource
+{
+    public function __construct(
+        Character $character,
+        private CharacterStatsDTO $stats
+    ) {
+        parent::__construct($character);
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            // Character identity
+            'character' => [
+                'id' => $this->resource->id,
+                'public_id' => $this->resource->public_id,
+                'name' => $this->resource->name,
+                'level' => $this->resource->total_level,
+            ],
+
+            // Core combat stats (from DTO)
+            'combat_stats' => [
+                'armor_class' => $this->stats->armorClass,
+                'hit_points' => [
+                    'current' => $this->stats->currentHitPoints,
+                    'max' => $this->stats->maxHitPoints,
+                    'temp' => $this->stats->tempHitPoints,
+                ],
+                'initiative_bonus' => $this->stats->initiativeBonus,
+                'proficiency_bonus' => $this->stats->proficiencyBonus,
+                'speed' => $this->stats->speed,
+            ],
+
+            // Saving throws (from DTO)
+            'saving_throws' => $this->stats->savingThrows,
+
+            // Weapons with attack/damage (from DTO)
+            'weapons' => $this->stats->weapons,
+            'unarmed_strike' => $this->stats->unarmedStrike,
+
+            // Spell slots (from DTO)
+            'spell_slots' => [
+                'standard' => (object) ($this->stats->spellSlots['slots'] ?? []),
+                'pact_magic' => $this->stats->spellSlots['pact_magic'] ?? null,
+            ],
+
+            // Prepared spells (combat-relevant subset)
+            'prepared_spells' => $this->getPreparedSpells(),
+
+            // Class resources (Action Surge, Rage, etc.)
+            'resources' => $this->getResources(),
+
+            // Active conditions
+            'conditions' => CharacterConditionResource::collection(
+                $this->resource->conditions
+            ),
+
+            // Death saves
+            'death_saves' => [
+                'successes' => $this->resource->death_save_successes,
+                'failures' => $this->resource->death_save_failures,
+                'is_conscious' => $this->resource->current_hit_points > 0,
+                'is_dead' => (bool) $this->resource->is_dead,
+            ],
+
+            // Defenses (from DTO)
+            'defenses' => [
+                'resistances' => $this->stats->damageResistances,
+                'immunities' => $this->stats->damageImmunities,
+                'vulnerabilities' => $this->stats->damageVulnerabilities,
+                'condition_immunities' => $this->stats->conditionImmunities,
+            ],
+
+            // Spellcasting per-class (for multiclass)
+            'spellcasting' => $this->stats->spellcasting,
+        ];
+    }
+
+    /**
+     * Get prepared spells with combat-relevant details.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getPreparedSpells(): array
+    {
+        return $this->resource->spells
+            ->filter(fn ($cs) => $cs->isPrepared())
+            ->map(fn ($cs) => [
+                'id' => $cs->id,
+                'name' => $cs->spell?->name,
+                'level' => $cs->spell?->level,
+                'school' => $cs->spell?->spellSchool?->name,
+                'concentration' => (bool) $cs->spell?->needs_concentration,
+                'ritual' => (bool) $cs->spell?->is_ritual,
+                'casting_time' => $cs->spell?->casting_time,
+                'range' => $cs->spell?->range,
+                'damage_types' => $cs->spell?->effects
+                    ?->pluck('damageType.name')
+                    ->filter()
+                    ->unique()
+                    ->values()
+                    ->toArray() ?? [],
+            ])
+            ->values()
+            ->toArray();
+    }
+
+    /**
+     * Get class resources with recharge timing.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getResources(): array
+    {
+        return $this->resource->counters->map(fn ($counter) => [
+            'name' => $counter->counter_name,
+            'uses' => $counter->current_uses ?? $counter->max_uses,
+            'max' => $counter->max_uses,
+            'recharge' => match ($counter->reset_timing) {
+                'S' => 'short_rest',
+                'L' => 'long_rest',
+                'D' => 'dawn',
+                default => $counter->reset_timing,
+            },
+        ])->values()->toArray();
+    }
+}

--- a/app/Http/Resources/CharacterSheetResource.php
+++ b/app/Http/Resources/CharacterSheetResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\DTOs\CharacterStatsDTO;
+use App\Models\Character;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Complete character sheet aggregate resource.
+ *
+ * Returns all character data in a single response, reducing
+ * frontend round-trips for character sheet displays.
+ *
+ * @property Character $resource
+ */
+class CharacterSheetResource extends JsonResource
+{
+    public function __construct(
+        Character $character,
+        private CharacterStatsDTO $stats
+    ) {
+        parent::__construct($character);
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            // Full character data (reuse existing resource)
+            'character' => (new CharacterResource($this->resource))->resolve(),
+
+            // Computed stats
+            'stats' => (new CharacterStatsResource($this->stats))->resolve(),
+
+            // All spells
+            'spells' => CharacterSpellResource::collection($this->resource->spells)->resolve(),
+
+            // All equipment
+            'equipment' => CharacterEquipmentResource::collection($this->resource->equipment)->resolve(),
+
+            // All features
+            'features' => CharacterFeatureResource::collection($this->resource->features)->resolve(),
+
+            // Notes grouped by category
+            'notes' => (new CharacterNotesGroupedResource($this->resource->notes))->resolve()['data'] ?? [],
+
+            // Proficiencies
+            'proficiencies' => CharacterProficiencyResource::collection($this->resource->proficiencies)->resolve(),
+
+            // Languages
+            'languages' => CharacterLanguageResource::collection($this->resource->languages)->resolve(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -266,6 +266,10 @@ Route::prefix('v1')->group(function () {
         ->name('characters.stats');
     Route::get('characters/{character}/summary', [CharacterController::class, 'summary'])
         ->name('characters.summary');
+    Route::get('characters/{character}/combat', [CharacterController::class, 'combat'])
+        ->name('characters.combat');
+    Route::get('characters/{character}/sheet', [CharacterController::class, 'sheet'])
+        ->name('characters.sheet');
     Route::get('characters/{character}/ability-bonuses', [CharacterController::class, 'abilityBonuses'])
         ->name('characters.ability-bonuses');
     Route::get('characters/{character}/validate', [CharacterValidationController::class, 'show'])

--- a/tests/Feature/Api/CharacterCombatEndpointTest.php
+++ b/tests/Feature/Api/CharacterCombatEndpointTest.php
@@ -1,0 +1,524 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Enums\SpellSlotType;
+use App\Models\Character;
+use App\Models\CharacterClass;
+use App\Models\CharacterClassPivot;
+use App\Models\CharacterCondition;
+use App\Models\CharacterCounter;
+use App\Models\CharacterSpell;
+use App\Models\CharacterSpellSlot;
+use App\Models\Condition;
+use App\Models\Race;
+use App\Models\Spell;
+use App\Models\SpellSchool;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Tests for the unified combat endpoint.
+ *
+ * GET /api/v1/characters/{id}/combat
+ *
+ * Returns all combat-relevant data in a single response for battle interfaces.
+ */
+class CharacterCombatEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =====================
+    // Structure Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_combat_data_structure(): void
+    {
+        $race = Race::factory()->create();
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create([
+                'race_slug' => $race->slug,
+                'current_hit_points' => 35,
+                'max_hit_points' => 45,
+                'temp_hit_points' => 5,
+            ]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'character' => ['id', 'public_id', 'name', 'level'],
+                    'combat_stats' => [
+                        'armor_class',
+                        'hit_points' => ['current', 'max', 'temp'],
+                        'initiative_bonus',
+                        'proficiency_bonus',
+                        'speed',
+                    ],
+                    'saving_throws',
+                    'weapons',
+                    'unarmed_strike',
+                    'spell_slots',
+                    'prepared_spells',
+                    'resources',
+                    'conditions',
+                    'death_saves' => ['successes', 'failures', 'is_conscious', 'is_dead'],
+                    'defenses' => [
+                        'resistances',
+                        'immunities',
+                        'vulnerabilities',
+                        'condition_immunities',
+                    ],
+                    'spellcasting',
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function it_returns_basic_character_info(): void
+    {
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create(['name' => 'Thorin Battleaxe']);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 7,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.character.name', 'Thorin Battleaxe')
+            ->assertJsonPath('data.character.level', 7)
+            ->assertJsonPath('data.character.id', $character->id)
+            ->assertJsonPath('data.character.public_id', $character->public_id);
+    }
+
+    // =====================
+    // Combat Stats Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_hit_points_state(): void
+    {
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create([
+                'current_hit_points' => 25,
+                'max_hit_points' => 50,
+                'temp_hit_points' => 10,
+            ]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.combat_stats.hit_points.current', 25)
+            ->assertJsonPath('data.combat_stats.hit_points.max', 50)
+            ->assertJsonPath('data.combat_stats.hit_points.temp', 10);
+    }
+
+    #[Test]
+    public function it_returns_proficiency_bonus_based_on_level(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5, // Level 5 = +3 proficiency bonus
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.combat_stats.proficiency_bonus', 3);
+    }
+
+    // =====================
+    // Death Saves Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_death_saves_state(): void
+    {
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create([
+                'current_hit_points' => 0,
+                'death_save_successes' => 2,
+                'death_save_failures' => 1,
+            ]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.death_saves.successes', 2)
+            ->assertJsonPath('data.death_saves.failures', 1)
+            ->assertJsonPath('data.death_saves.is_conscious', false)
+            ->assertJsonPath('data.death_saves.is_dead', false);
+    }
+
+    #[Test]
+    public function it_shows_conscious_when_hp_above_zero(): void
+    {
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create(['current_hit_points' => 10]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.death_saves.is_conscious', true);
+    }
+
+    #[Test]
+    public function it_shows_dead_when_character_is_dead(): void
+    {
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create([
+                'current_hit_points' => 0,
+                'is_dead' => true,
+            ]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.death_saves.is_dead', true);
+    }
+
+    // =====================
+    // Conditions Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_active_conditions(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+        $poisoned = Condition::factory()->create(['slug' => 'test:poisoned-'.uniqid(), 'name' => 'Poisoned']);
+        $blinded = Condition::factory()->create(['slug' => 'test:blinded-'.uniqid(), 'name' => 'Blinded']);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        CharacterCondition::factory()->create([
+            'character_id' => $character->id,
+            'condition_slug' => $poisoned->slug,
+        ]);
+
+        CharacterCondition::factory()->create([
+            'character_id' => $character->id,
+            'condition_slug' => $blinded->slug,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk();
+
+        $conditions = $response->json('data.conditions');
+        $this->assertCount(2, $conditions);
+    }
+
+    #[Test]
+    public function it_returns_empty_conditions_when_none_active(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.conditions', []);
+    }
+
+    // =====================
+    // Resources Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_class_resources(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+        $class = CharacterClass::factory()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'class_slug' => $class->slug,
+            'level' => 2,
+            'is_primary' => true,
+        ]);
+
+        // Create Action Surge counter
+        CharacterCounter::create([
+            'character_id' => $character->id,
+            'source_type' => 'class',
+            'source_slug' => $class->slug,
+            'counter_name' => 'Action Surge',
+            'current_uses' => 1,
+            'max_uses' => 1,
+            'reset_timing' => 'S', // Short rest
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk();
+
+        $resources = $response->json('data.resources');
+        $this->assertCount(1, $resources);
+        $this->assertEquals('Action Surge', $resources[0]['name']);
+        $this->assertEquals(1, $resources[0]['uses']);
+        $this->assertEquals(1, $resources[0]['max']);
+        $this->assertEquals('short_rest', $resources[0]['recharge']);
+    }
+
+    #[Test]
+    public function it_returns_empty_resources_when_none_exist(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.resources', []);
+    }
+
+    // =====================
+    // Spell Slots Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_spell_slots(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        CharacterSpellSlot::factory()->create([
+            'character_id' => $character->id,
+            'spell_level' => 1,
+            'max_slots' => 4,
+            'used_slots' => 1,
+            'slot_type' => SpellSlotType::STANDARD,
+        ]);
+
+        CharacterSpellSlot::factory()->create([
+            'character_id' => $character->id,
+            'spell_level' => 2,
+            'max_slots' => 3,
+            'used_slots' => 0,
+            'slot_type' => SpellSlotType::STANDARD,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk();
+
+        $spellSlots = $response->json('data.spell_slots');
+        $this->assertArrayHasKey('standard', $spellSlots);
+    }
+
+    // =====================
+    // Prepared Spells Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_only_prepared_spells(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+        $school = SpellSchool::factory()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        $fireball = Spell::factory()->create([
+            'name' => 'Fireball',
+            'slug' => 'test:fireball-'.uniqid(),
+            'level' => 3,
+            'needs_concentration' => false,
+            'spell_school_id' => $school->id,
+        ]);
+
+        $shield = Spell::factory()->create([
+            'name' => 'Shield',
+            'slug' => 'test:shield-'.uniqid(),
+            'level' => 1,
+            'needs_concentration' => false,
+            'spell_school_id' => $school->id,
+        ]);
+
+        $unprepared = Spell::factory()->create([
+            'name' => 'Magic Missile',
+            'slug' => 'test:magic-missile-'.uniqid(),
+            'level' => 1,
+            'spell_school_id' => $school->id,
+        ]);
+
+        // Prepared spell
+        CharacterSpell::create([
+            'character_id' => $character->id,
+            'spell_slug' => $fireball->slug,
+            'preparation_status' => 'prepared',
+            'source' => 'class',
+        ]);
+
+        // Always prepared spell
+        CharacterSpell::create([
+            'character_id' => $character->id,
+            'spell_slug' => $shield->slug,
+            'preparation_status' => 'always_prepared',
+            'source' => 'class',
+        ]);
+
+        // Not prepared spell (known but not prepared)
+        CharacterSpell::create([
+            'character_id' => $character->id,
+            'spell_slug' => $unprepared->slug,
+            'preparation_status' => 'known',
+            'source' => 'class',
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk();
+
+        $preparedSpells = $response->json('data.prepared_spells');
+        $this->assertCount(2, $preparedSpells);
+
+        $spellNames = collect($preparedSpells)->pluck('name')->toArray();
+        $this->assertContains('Fireball', $spellNames);
+        $this->assertContains('Shield', $spellNames);
+        $this->assertNotContains('Magic Missile', $spellNames);
+    }
+
+    #[Test]
+    public function it_returns_prepared_spell_details(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+        $school = SpellSchool::factory()->create(['name' => 'Evocation']);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        $spell = Spell::factory()->create([
+            'name' => 'Fireball',
+            'slug' => 'test:fireball-'.uniqid(),
+            'level' => 3,
+            'needs_concentration' => false,
+            'is_ritual' => false,
+            'casting_time' => '1 action',
+            'range' => '150 feet',
+            'spell_school_id' => $school->id,
+        ]);
+
+        CharacterSpell::create([
+            'character_id' => $character->id,
+            'spell_slug' => $spell->slug,
+            'preparation_status' => 'prepared',
+            'source' => 'class',
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/combat");
+
+        $response->assertOk();
+
+        $preparedSpells = $response->json('data.prepared_spells');
+        $fireball = $preparedSpells[0];
+
+        $this->assertEquals('Fireball', $fireball['name']);
+        $this->assertEquals(3, $fireball['level']);
+        $this->assertEquals('Evocation', $fireball['school']);
+        $this->assertFalse($fireball['concentration']);
+        $this->assertFalse($fireball['ritual']);
+        $this->assertEquals('1 action', $fireball['casting_time']);
+        $this->assertEquals('150 feet', $fireball['range']);
+    }
+
+    // =====================
+    // Access Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_404_for_nonexistent_character(): void
+    {
+        $response = $this->getJson('/api/v1/characters/99999/combat');
+
+        $response->assertNotFound();
+    }
+
+    #[Test]
+    public function it_works_with_public_id(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->public_id}/combat");
+
+        $response->assertOk()
+            ->assertJsonPath('data.character.id', $character->id);
+    }
+}

--- a/tests/Feature/Api/CharacterSheetEndpointTest.php
+++ b/tests/Feature/Api/CharacterSheetEndpointTest.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Character;
+use App\Models\CharacterClassPivot;
+use App\Models\CharacterEquipment;
+use App\Models\CharacterLanguage;
+use App\Models\CharacterNote;
+use App\Models\CharacterProficiency;
+use App\Models\CharacterSpell;
+use App\Models\Item;
+use App\Models\Language;
+use App\Models\ProficiencyType;
+use App\Models\Race;
+use App\Models\Spell;
+use App\Models\SpellSchool;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Tests for the unified character sheet endpoint.
+ *
+ * GET /api/v1/characters/{id}/sheet
+ *
+ * Returns complete character sheet data in a single response.
+ */
+class CharacterSheetEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =====================
+    // Structure Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_sheet_data_structure(): void
+    {
+        $race = Race::factory()->create();
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create(['race_slug' => $race->slug]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'character',
+                    'stats',
+                    'spells',
+                    'equipment',
+                    'features',
+                    'notes',
+                    'proficiencies',
+                    'languages',
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function it_includes_full_character_resource(): void
+    {
+        $race = Race::factory()->create();
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create([
+                'name' => 'Gandalf the Grey',
+                'race_slug' => $race->slug,
+            ]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 10,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk()
+            ->assertJsonPath('data.character.name', 'Gandalf the Grey')
+            ->assertJsonPath('data.character.total_level', 10);
+    }
+
+    #[Test]
+    public function it_includes_stats_resource(): void
+    {
+        $character = Character::factory()
+            ->withStandardArray()
+            ->create([
+                'max_hit_points' => 45,
+                'current_hit_points' => 35,
+            ]);
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk();
+
+        $stats = $response->json('data.stats');
+        $this->assertArrayHasKey('armor_class', $stats);
+        $this->assertArrayHasKey('hit_points', $stats);
+        $this->assertArrayHasKey('saving_throws', $stats);
+        $this->assertArrayHasKey('proficiency_bonus', $stats);
+    }
+
+    // =====================
+    // Spells Tests
+    // =====================
+
+    #[Test]
+    public function it_includes_all_spells_not_just_prepared(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+        $school = SpellSchool::factory()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 5,
+            'is_primary' => true,
+        ]);
+
+        $fireball = Spell::factory()->create([
+            'name' => 'Fireball',
+            'slug' => 'test:fireball-'.uniqid(),
+            'spell_school_id' => $school->id,
+        ]);
+
+        $shield = Spell::factory()->create([
+            'name' => 'Shield',
+            'slug' => 'test:shield-'.uniqid(),
+            'spell_school_id' => $school->id,
+        ]);
+
+        $magicMissile = Spell::factory()->create([
+            'name' => 'Magic Missile',
+            'slug' => 'test:magic-missile-'.uniqid(),
+            'spell_school_id' => $school->id,
+        ]);
+
+        // Prepared spell
+        CharacterSpell::create([
+            'character_id' => $character->id,
+            'spell_slug' => $fireball->slug,
+            'preparation_status' => 'prepared',
+            'source' => 'class',
+        ]);
+
+        // Always prepared spell
+        CharacterSpell::create([
+            'character_id' => $character->id,
+            'spell_slug' => $shield->slug,
+            'preparation_status' => 'always_prepared',
+            'source' => 'class',
+        ]);
+
+        // Known but not prepared
+        CharacterSpell::create([
+            'character_id' => $character->id,
+            'spell_slug' => $magicMissile->slug,
+            'preparation_status' => 'known',
+            'source' => 'class',
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk();
+
+        $spells = $response->json('data.spells');
+        $this->assertCount(3, $spells);
+    }
+
+    // =====================
+    // Equipment Tests
+    // =====================
+
+    #[Test]
+    public function it_includes_all_equipment(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $sword = Item::factory()->create([
+            'name' => 'Longsword',
+            'slug' => 'test:longsword-'.uniqid(),
+        ]);
+
+        $armor = Item::factory()->create([
+            'name' => 'Chain Mail',
+            'slug' => 'test:chain-mail-'.uniqid(),
+        ]);
+
+        $potion = Item::factory()->create([
+            'name' => 'Healing Potion',
+            'slug' => 'test:healing-potion-'.uniqid(),
+        ]);
+
+        CharacterEquipment::create([
+            'character_id' => $character->id,
+            'item_slug' => $sword->slug,
+            'quantity' => 1,
+            'equipped' => true,
+            'location' => 'main_hand',
+        ]);
+
+        CharacterEquipment::create([
+            'character_id' => $character->id,
+            'item_slug' => $armor->slug,
+            'quantity' => 1,
+            'equipped' => true,
+            'location' => 'armor',
+        ]);
+
+        CharacterEquipment::create([
+            'character_id' => $character->id,
+            'item_slug' => $potion->slug,
+            'quantity' => 3,
+            'equipped' => false,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk();
+
+        $equipment = $response->json('data.equipment');
+        $this->assertCount(3, $equipment);
+    }
+
+    // =====================
+    // Languages & Proficiencies Tests
+    // =====================
+
+    #[Test]
+    public function it_includes_languages(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        // Use unique names and slugs to avoid conflicts
+        $uniqueId = uniqid();
+        $lang1 = Language::factory()->create([
+            'name' => 'TestLang1-'.$uniqueId,
+            'slug' => 'test:lang1-'.$uniqueId,
+        ]);
+
+        $lang2 = Language::factory()->create([
+            'name' => 'TestLang2-'.$uniqueId,
+            'slug' => 'test:lang2-'.$uniqueId,
+        ]);
+
+        CharacterLanguage::create([
+            'character_id' => $character->id,
+            'language_slug' => $lang1->slug,
+            'source' => 'race',
+        ]);
+
+        CharacterLanguage::create([
+            'character_id' => $character->id,
+            'language_slug' => $lang2->slug,
+            'source' => 'race',
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk();
+
+        $languages = $response->json('data.languages');
+        $this->assertCount(2, $languages);
+    }
+
+    #[Test]
+    public function it_includes_proficiencies(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $profType = ProficiencyType::factory()->create();
+
+        CharacterProficiency::create([
+            'character_id' => $character->id,
+            'proficiency_type_id' => $profType->id,
+            'target_type' => 'skill',
+            'target_slug' => 'phb:athletics',
+            'source' => 'class',
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk();
+
+        $proficiencies = $response->json('data.proficiencies');
+        $this->assertCount(1, $proficiencies);
+    }
+
+    // =====================
+    // Notes Tests
+    // =====================
+
+    #[Test]
+    public function it_includes_notes_grouped(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        CharacterNote::create([
+            'character_id' => $character->id,
+            'category' => 'personality_traits',
+            'content' => 'Always tells the truth',
+        ]);
+
+        CharacterNote::create([
+            'character_id' => $character->id,
+            'category' => 'ideals',
+            'content' => 'Justice above all',
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->id}/sheet");
+
+        $response->assertOk();
+
+        $notes = $response->json('data.notes');
+        $this->assertIsArray($notes);
+    }
+
+    // =====================
+    // Access Tests
+    // =====================
+
+    #[Test]
+    public function it_returns_404_for_nonexistent_character(): void
+    {
+        $response = $this->getJson('/api/v1/characters/99999/sheet');
+
+        $response->assertNotFound();
+    }
+
+    #[Test]
+    public function it_works_with_public_id(): void
+    {
+        $character = Character::factory()->withStandardArray()->create();
+
+        CharacterClassPivot::factory()->create([
+            'character_id' => $character->id,
+            'level' => 1,
+            'is_primary' => true,
+        ]);
+
+        $response = $this->getJson("/api/v1/characters/{$character->public_id}/sheet");
+
+        $response->assertOk()
+            ->assertJsonPath('data.character.id', $character->id);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #760 - Add combat-focused and character sheet unified endpoints

- **`GET /characters/{id}/combat`** - Combat-focused aggregate endpoint
  - Returns all combat-relevant data in a single response
  - Character identity, combat stats (AC, HP, initiative, speed)
  - Saving throws, equipped weapons with attack/damage bonuses
  - Spell slots, prepared spells, class resources (Action Surge, Rage, etc.)
  - Active conditions, death saves, defenses (resistances/immunities/vulnerabilities)
  - Per-class spellcasting info for multiclass characters

- **`GET /characters/{id}/sheet`** - Complete character sheet aggregate
  - Full CharacterResource data
  - Computed stats (CharacterStatsResource)
  - All spells (not just prepared)
  - All equipment
  - All features
  - Notes grouped by category
  - Proficiencies and languages

## Benefits

- Reduces frontend round-trips from 4+ API calls to single request
- Optimized eager loading prevents N+1 queries
- Combat endpoint is lightweight (~2KB) for fast battle updates
- Sheet endpoint aggregates everything needed for full character display

## Test plan

- [x] 16 tests for `/combat` endpoint
- [x] 10 tests for `/sheet` endpoint
- [x] All 26 new tests passing
- [x] Feature-DB suite (704 tests) passing
- [x] Unit-DB suite (1390 tests) passing
- [x] Code formatted with Pint

Closes dfox288/ledger-of-heroes#760