### PR TITLE
refactor: controller audit improvements

### DIFF
--- a/app/Exceptions/SpellManagementException.php
+++ b/app/Exceptions/SpellManagementException.php
@@ -96,4 +96,31 @@ class SpellManagementException extends Exception
             422
         );
     }
+
+    public static function alreadyKnownBySlug(string $spellSlug): self
+    {
+        return new self(
+            'Character already knows this spell.',
+            'spell',
+            422
+        );
+    }
+
+    public static function characterSpellNotFound(int $characterSpellId): self
+    {
+        return new self(
+            'Character spell not found.',
+            null,
+            404
+        );
+    }
+
+    public static function cannotPrepareDanglingReference(string $spellSlug): self
+    {
+        return new self(
+            'Cannot prepare a dangling spell reference.',
+            null,
+            422
+        );
+    }
 }

--- a/app/Http/Controllers/Api/PartyController.php
+++ b/app/Http/Controllers/Api/PartyController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Party\PartyAddCharacterRequest;
+use App\Http\Requests\Party\PartyIndexRequest;
+use App\Http\Requests\Party\PartyShowRequest;
+use App\Http\Requests\Party\PartyStatsRequest;
 use App\Http\Requests\Party\PartyStoreRequest;
 use App\Http\Requests\Party\PartyUpdateRequest;
 use App\Http\Resources\PartyResource;
@@ -11,7 +14,6 @@ use App\Http\Resources\PartyStatsResource;
 use App\Models\Character;
 use App\Models\Party;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 
@@ -22,7 +24,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add user scoping when auth is implemented.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(PartyIndexRequest $request): AnonymousResourceCollection
     {
         $parties = Party::withCount('characters')
             ->orderBy('updated_at', 'desc')
@@ -54,7 +56,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function show(Request $request, Party $party): PartyResource|JsonResponse
+    public function show(PartyShowRequest $request, Party $party): PartyResource
     {
         $party->load([
             'characters.characterClasses.characterClass',
@@ -69,7 +71,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function update(PartyUpdateRequest $request, Party $party): PartyResource|JsonResponse
+    public function update(PartyUpdateRequest $request, Party $party): PartyResource
     {
         $party->update($request->validated());
 
@@ -81,7 +83,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function destroy(Request $request, Party $party): Response
+    public function destroy(Party $party): Response
     {
         $party->delete();
 
@@ -93,7 +95,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function addCharacter(PartyAddCharacterRequest $request, Party $party): PartyResource|JsonResponse
+    public function addCharacter(PartyAddCharacterRequest $request, Party $party): JsonResponse
     {
         $party->characters()->attach($request->validated('character_id'), [
             'joined_at' => now(),
@@ -114,7 +116,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function removeCharacter(Request $request, Party $party, Character $character): Response
+    public function removeCharacter(Party $party, Character $character): Response
     {
         // Check if character is in party
         if (! $party->characters()->where('character_id', $character->id)->exists()) {
@@ -131,7 +133,7 @@ class PartyController extends Controller
      *
      * TODO: Re-add ownership check when auth is implemented.
      */
-    public function stats(Request $request, Party $party): PartyStatsResource|JsonResponse
+    public function stats(PartyStatsRequest $request, Party $party): PartyStatsResource
     {
         // Load characters with relationships needed for stats
         $party->load([

--- a/app/Http/Requests/Party/PartyIndexRequest.php
+++ b/app/Http/Requests/Party/PartyIndexRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Party;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PartyIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Party/PartyShowRequest.php
+++ b/app/Http/Requests/Party/PartyShowRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Party;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PartyShowRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Party/PartyStatsRequest.php
+++ b/app/Http/Requests/Party/PartyStatsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Party;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PartyStatsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary

- **PartyController**: Add dedicated Form Requests for consistency with gold standard pattern
- **CharacterSpellController**: Replace inline JsonResponse error returns with proper exception throwing
- **ClassController**: Extract `spells()` query logic to service layer (47 → 5 lines)
- **CharacterController**: Refactor constructor dependencies using method injection

## Changes

### PartyController
- Created `PartyIndexRequest`, `PartyShowRequest`, `PartyStatsRequest`
- Updated controller to use dedicated Form Requests instead of bare `Request`
- Cleaned up return types (removed `|JsonResponse` where not needed)

### CharacterSpellController
- Added exception factory methods to `SpellManagementException`:
  - `alreadyKnownBySlug()`
  - `characterSpellNotFound()`
  - `cannotPrepareDanglingReference()`
- Replaced inline `response()->json()` error returns with exception throws
- Let exceptions with `render()` methods bubble up naturally

### ClassController
- Added `getClassSpells()` method to `ClassSearchService`
- Moved filtering logic (search, level, school, concentration, ritual) to service
- Controller method reduced from 47 lines to 5 lines

### CharacterController
- Reduced constructor from 13 services to 3 (assignment services only)
- Used method injection for read-only endpoints:
  - `stats()`, `combat()`, `sheet()` - inject stat/spell services
  - `summary()` - inject choice/calculation services
  - `abilityBonuses()` - inject ability bonus service

## Test plan

- [x] Unit tests pass (1390 passed)
- [x] CharacterSpell tests pass (55 passed)
- [x] Party tests pass (11 passed)
- [x] Code formatted with Pint