### PR TITLE
docs: Document search service inheritance pattern

### DIFF
--- a/.claude/rules/05-code-patterns.md
+++ b/.claude/rules/05-code-patterns.md
@@ -42,6 +42,24 @@ SpellIndexRequest      // GET /api/v1/spells
 SpellShowRequest       // GET /api/v1/spells/{id}
 ```
 
+## Search Service Pattern
+
+All entity search services should extend `AbstractSearchService`:
+
+```php
+final class SpellSearchService extends AbstractSearchService
+{
+    private const INDEX_RELATIONSHIPS = ['spellSchool', 'sources.source'];
+    private const SHOW_RELATIONSHIPS = [...self::INDEX_RELATIONSHIPS, 'tags'];
+
+    protected function getModelClass(): string { return Spell::class; }
+    public function getIndexRelationships(): array { return self::INDEX_RELATIONSHIPS; }
+    public function getShowRelationships(): array { return self::SHOW_RELATIONSHIPS; }
+}
+```
+
+See `../wrapper/docs/backend/reference/SEARCH-SERVICE-ARCHITECTURE.md` for full documentation.
+
 ---
 
 ## Anti-Patterns (DO NOT USE)

--- a/.claude/rules/06-search-filtering.md
+++ b/.claude/rules/06-search-filtering.md
@@ -26,3 +26,14 @@ When adding new filterable fields:
 2. Add to `searchableOptions()` → `filterableAttributes`
 3. Re-index: `just scout-import ModelName`
 4. Document in Controller PHPDoc
+
+## Service Layer Architecture
+
+Search services should extend `AbstractSearchService` for consistent behavior.
+
+**Gold standard:** `SpellSearchService`
+
+See `../wrapper/docs/backend/reference/SEARCH-SERVICE-ARCHITECTURE.md` for:
+- When to extend AbstractSearchService
+- Required methods to implement
+- How to add a new searchable entity

--- a/app/Services/AbstractSearchService.php
+++ b/app/Services/AbstractSearchService.php
@@ -9,10 +9,62 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use MeiliSearch\Client;
 
 /**
- * Base class for search services using Meilisearch
+ * Base class for entity search services using Meilisearch.
  *
- * Provides common searchWithMeilisearch() implementation and relationship management.
- * Subclasses must define their model class and relationships.
+ * ## When to Extend This Class
+ *
+ * Extend AbstractSearchService when creating a search service for any entity that:
+ * - Uses Laravel Scout with Meilisearch for full-text search
+ * - Needs consistent pagination, filtering, and sorting behavior
+ * - Returns Eloquent models with eager-loaded relationships
+ *
+ * ## Required Methods to Implement
+ *
+ * 1. `getModelClass(): string` - Return the fully qualified model class name
+ * 2. `getIndexRelationships(): array` - Relationships for list/index endpoints (lightweight)
+ * 3. `getShowRelationships(): array` - Relationships for show/detail endpoints (comprehensive)
+ *
+ * ## Available Methods (Inherited)
+ *
+ * - `searchWithMeilisearch(object $dto, Client $client)` - Main search with Meilisearch
+ * - `buildDatabaseQuery(object $dto)` - Eloquent query for non-search pagination
+ * - `buildScoutQuery(object $dto)` - Scout search builder (override if needed)
+ * - `applySorting(Builder $query, object $dto)` - Apply sorting to Eloquent query
+ * - `getDefaultRelationships()` - Alias for getIndexRelationships()
+ *
+ * ## Example Implementation
+ *
+ * ```php
+ * final class SpellSearchService extends AbstractSearchService
+ * {
+ *     private const INDEX_RELATIONSHIPS = ['spellSchool', 'sources.source', 'classes'];
+ *     private const SHOW_RELATIONSHIPS = [...self::INDEX_RELATIONSHIPS, 'tags', 'monsters'];
+ *
+ *     protected function getModelClass(): string
+ *     {
+ *         return Spell::class;
+ *     }
+ *
+ *     public function getIndexRelationships(): array
+ *     {
+ *         return self::INDEX_RELATIONSHIPS;
+ *     }
+ *
+ *     public function getShowRelationships(): array
+ *     {
+ *         return self::SHOW_RELATIONSHIPS;
+ *     }
+ * }
+ * ```
+ *
+ * ## When NOT to Extend
+ *
+ * - Cross-entity search (see GlobalSearchService)
+ * - Services with fundamentally different search behavior
+ * - Non-Meilisearch search implementations
+ *
+ * @see \App\Services\SpellSearchService Gold standard implementation
+ * @see ../wrapper/docs/backend/reference/SEARCH-SERVICE-ARCHITECTURE.md Full documentation
  */
 abstract class AbstractSearchService
 {


### PR DESCRIPTION
## Summary
- Add comprehensive PHPDoc to AbstractSearchService explaining when to extend, required methods, and available helpers
- Create new reference doc (SEARCH-SERVICE-ARCHITECTURE.md) with full architecture overview
- Update project rules (05-code-patterns.md, 06-search-filtering.md) with references to new documentation

## Changes
1. **AbstractSearchService PHPDoc** - Documents when to extend, required methods to implement, example implementation, and when NOT to extend
2. **SEARCH-SERVICE-ARCHITECTURE.md** - New reference doc covering:
   - Architecture overview
   - Current state (which services extend, which don't)
   - Step-by-step guide for adding new searchable entities
   - Best practices and anti-patterns
3. **Project rules updates** - Added search service pattern section and cross-references

## Notes
- This documents the pattern; Issue #814 tracks the refactoring work to consolidate services

Closes #817