### PR TITLE
chore: upgrade laravel/scout to ^11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Upgraded `laravel/scout` to v11.1.0** (`^10.22` → `^11.1`). Scout 11's two breaking changes don't apply here (we don't touch `Builder::$wheres` directly, and we use the Meilisearch engine not Algolia). Bonus: v11.1 fixes Meilisearch `IS NOT NULL` filtering. Upgrade guide: https://github.com/laravel/scout/blob/11.x/UPGRADE.md. All five test suites match baseline pass counts.
 - **Upgraded to Laravel 13** (`laravel/framework` `^12.52` → `^13.0`, resolved to v13.5.0). `laravel/tinker` bumped `^2.10.1` → `^3.0` — tinker 2.x caps at Laravel 12. Symfony components moved 7.4 → 8.0 as part of the L13 toolchain. Framework upgrade guide: https://laravel.com/docs/13.x/upgrade.
 - No application code changes were required: the project's API-only surface meant none of the L13 breaking changes (CSRF middleware rename, JobAttempted listener signature, Eloquent boot() instantiation ban, custom queue-driver contract additions) applied. All five test suites returned identical pass counts to the pre-upgrade baseline.
 - **Deployment note**: Laravel 13 jobs serialized by Laravel 12 workers may fail. Drain existing queues before deploying or run mixed-version workers temporarily.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "http-interop/http-factory-guzzle": "^1.2",
         "laravel/framework": "^13.0",
         "laravel/sanctum": "^4.2",
-        "laravel/scout": "^10.22",
+        "laravel/scout": "^11.1",
         "laravel/tinker": "^3.0",
         "meilisearch/meilisearch-php": "^1.16",
         "spatie/laravel-medialibrary": "^11.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fab6a23969eccd229be0d05a6546e638",
+    "content-hash": "1d51cf2eebc3bb1cdcc15afbb28948b2",
     "packages": [
         {
             "name": "brick/math",
@@ -1615,16 +1615,16 @@
         },
         {
             "name": "laravel/scout",
-            "version": "v10.25.0",
+            "version": "v11.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/scout.git",
-                "reference": "f28630dca44a63d80c15e596bedc5af42c8985d5"
+                "reference": "9865fca4129d79c271da6a89afb44359e9ee9020"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/scout/zipball/f28630dca44a63d80c15e596bedc5af42c8985d5",
-                "reference": "f28630dca44a63d80c15e596bedc5af42c8985d5",
+                "url": "https://api.github.com/repos/laravel/scout/zipball/9865fca4129d79c271da6a89afb44359e9ee9020",
+                "reference": "9865fca4129d79c271da6a89afb44359e9ee9020",
                 "shasum": ""
             },
             "require": {
@@ -1663,7 +1663,7 @@
                     ]
                 },
                 "branch-alias": {
-                    "dev-master": "10.x-dev"
+                    "dev-master": "11.x-dev"
                 }
             },
             "autoload": {
@@ -1691,7 +1691,7 @@
                 "issues": "https://github.com/laravel/scout/issues",
                 "source": "https://github.com/laravel/scout"
             },
-            "time": "2026-03-10T16:16:46+00:00"
+            "time": "2026-03-18T14:50:59+00:00"
         },
         {
             "name": "laravel/serializable-closure",


### PR DESCRIPTION
## Summary

Upgrade `laravel/scout` from v10.25.0 → **v11.1.0**. Scout 11 adds L13 support, but since we were already on L13 (#234) the bump is genuinely about the new features and the Meilisearch `IS NOT NULL` fix, not compatibility.

## What changed

- `laravel/scout`: `^10.22` → `^11.1`
- `composer.lock` diff is a single version bump — zero transitive churn

## Zero application code changes

Scout 11 has two documented breaking changes ([upgrade guide](https://github.com/laravel/scout/blob/11.x/UPGRADE.md)); neither applies:

| Scout 11 breaking change | Why it didn't apply |
|---|---|
| `Builder::$wheres` shape: `[field => value]` → `[['field', 'op', 'value']]` | We use `Model::search($q)->filter(...)->paginate()` and never reach into `$wheres` directly. Our `AbstractSearchService` / `MeilisearchFilterCompiler` go through Scout's public API. |
| Algolia `numericFilters` → `filters` | Meilisearch engine — Algolia-specific change is n/a. |

## Bonus: bug fixes for us

- **v11.1.0 fixes Meilisearch `IS NOT NULL` filtering** — Scout was sending a malformed clause that would fail against Meilisearch. Our `MeilisearchFilterCompiler` handles `IS NOT NULL` locally, but this removes a latent footgun for any future queries that hit Scout's built-in path.
- New: `where($field, $operator, $value)` with comparison operators (`>`, `<`, `>=`, `<=`, `!=`) — could be useful for simplifying internal non-user-facing queries later.
- New: backed-enum support in Meilisearch filter values.

## Test suite state

All five suites match the post-L13 baseline **exactly**:

| Suite | Result |
|---|---|
| Unit-Pure | **954 pass** |
| Unit-DB | **1390 pass / 9 skip** |
| Feature-DB | **704 pass** |
| Feature-Search | **510 pass / 38 skip** (7727 assertions — back to the pre-L13 count) |
| Importers | same **6 pre-existing failures** as main (unrelated) |

## Test plan

- [x] `just test-pure` — green
- [x] `just test-unit` — green
- [x] `just test-feature` — green
- [x] `just test-search` — green (Scout + Meilisearch exercised here)
- [x] `just test-importers` — same 6 pre-existing failures as main
- [x] `composer audit` — 0 advisories

## Remaining major bumps (not this PR)

- `phpunit/phpunit` 12.5 → 13.1 — **blocked** (Pest 4 pins `^12.5.22`; no stable Pest 5 yet).
- `phpunit/phpcov` 11 → 13 — blocked by the same constraint (phpcov 13 requires phpunit 13).

Both can be revisited once Pest ships a stable release with phpunit 13 support.