### PR TITLE
style: apply Pint fully_qualified_strict_types repo-wide

### DIFF
--- a/app/Console/Commands/ExtractFixturesCommand.php
+++ b/app/Console/Commands/ExtractFixturesCommand.php
@@ -2,6 +2,17 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Background;
+use App\Models\CharacterClass;
+use App\Models\Feat;
+use App\Models\Item;
+use App\Models\ItemType;
+use App\Models\Monster;
+use App\Models\OptionalFeature;
+use App\Models\Race;
+use App\Models\Size;
+use App\Models\Spell;
+use App\Models\SpellSchool;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
@@ -86,15 +97,15 @@ class ExtractFixturesCommand extends Command
 
         // One per level
         foreach (range(0, 9) as $level) {
-            $spell = \App\Models\Spell::where('level', $level)->first();
+            $spell = Spell::where('level', $level)->first();
             if ($spell) {
                 $spellIds->push($spell->id);
             }
         }
 
         // One per school
-        \App\Models\SpellSchool::all()->each(function ($school) use ($spellIds) {
-            $spell = \App\Models\Spell::where('spell_school_id', $school->id)
+        SpellSchool::all()->each(function ($school) use ($spellIds) {
+            $spell = Spell::where('spell_school_id', $school->id)
                 ->whereNotIn('id', $spellIds->toArray())
                 ->first();
             if ($spell) {
@@ -103,14 +114,14 @@ class ExtractFixturesCommand extends Command
         });
 
         // Concentration spells
-        $concentration = \App\Models\Spell::where('needs_concentration', true)
+        $concentration = Spell::where('needs_concentration', true)
             ->whereNotIn('id', $spellIds->toArray())
             ->take(3)
             ->pluck('id');
         $spellIds = $spellIds->merge($concentration);
 
         // Ritual spells
-        $ritual = \App\Models\Spell::where('is_ritual', true)
+        $ritual = Spell::where('is_ritual', true)
             ->whereNotIn('id', $spellIds->toArray())
             ->take(3)
             ->pluck('id');
@@ -119,7 +130,7 @@ class ExtractFixturesCommand extends Command
         // Fill remaining with random spells
         $remaining = $limit - $spellIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\Spell::whereNotIn('id', $spellIds->toArray())
+            $additional = Spell::whereNotIn('id', $spellIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
@@ -127,14 +138,14 @@ class ExtractFixturesCommand extends Command
         }
 
         // Load full models with relationships
-        $spells = \App\Models\Spell::whereIn('id', $spellIds->unique())
+        $spells = Spell::whereIn('id', $spellIds->unique())
             ->with(['spellSchool', 'classes', 'sources.source', 'effects.damageType'])
             ->get();
 
         return $spells->map(fn ($spell) => $this->formatSpell($spell))->toArray();
     }
 
-    protected function formatSpell(\App\Models\Spell $spell): array
+    protected function formatSpell(Spell $spell): array
     {
         return [
             'name' => $spell->name,
@@ -175,15 +186,15 @@ class ExtractFixturesCommand extends Command
         $crTiers = [0, 0.125, 0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30];
 
         foreach ($crTiers as $cr) {
-            $monster = \App\Models\Monster::where('challenge_rating', $cr)->first();
+            $monster = Monster::where('challenge_rating', $cr)->first();
             if ($monster) {
                 $monsterIds->push($monster->id);
             }
         }
 
         // One per size
-        \App\Models\Size::all()->each(function ($size) use ($monsterIds) {
-            $monster = \App\Models\Monster::where('size_id', $size->id)
+        Size::all()->each(function ($size) use ($monsterIds) {
+            $monster = Monster::where('size_id', $size->id)
                 ->whereNotIn('id', $monsterIds->toArray())
                 ->first();
             if ($monster) {
@@ -192,8 +203,8 @@ class ExtractFixturesCommand extends Command
         });
 
         // One per type
-        \App\Models\Monster::distinct('type')->pluck('type')->each(function ($type) use ($monsterIds) {
-            $monster = \App\Models\Monster::where('type', $type)
+        Monster::distinct('type')->pluck('type')->each(function ($type) use ($monsterIds) {
+            $monster = Monster::where('type', $type)
                 ->whereNotIn('id', $monsterIds->toArray())
                 ->first();
             if ($monster) {
@@ -204,21 +215,21 @@ class ExtractFixturesCommand extends Command
         // Fill remaining
         $remaining = $limit - $monsterIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\Monster::whereNotIn('id', $monsterIds->toArray())
+            $additional = Monster::whereNotIn('id', $monsterIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
             $monsterIds = $monsterIds->merge($additional);
         }
 
-        $monsters = \App\Models\Monster::whereIn('id', $monsterIds->unique())
+        $monsters = Monster::whereIn('id', $monsterIds->unique())
             ->with(['size', 'sources.source', 'modifiers.damageType'])
             ->get();
 
         return $monsters->map(fn ($m) => $this->formatMonster($m))->toArray();
     }
 
-    protected function formatMonster(\App\Models\Monster $monster): array
+    protected function formatMonster(Monster $monster): array
     {
         // Group modifiers by category
         $damageVulnerabilities = $monster->modifiers
@@ -297,13 +308,13 @@ class ExtractFixturesCommand extends Command
         // 4. Spellcasters vs non-spellcasters
 
         // All base classes
-        $baseClasses = \App\Models\CharacterClass::whereNull('parent_class_id')
+        $baseClasses = CharacterClass::whereNull('parent_class_id')
             ->pluck('id');
         $classIds = $classIds->merge($baseClasses);
 
         // One subclass per base class
         foreach ($baseClasses as $baseClassId) {
-            $subclass = \App\Models\CharacterClass::where('parent_class_id', $baseClassId)
+            $subclass = CharacterClass::where('parent_class_id', $baseClassId)
                 ->whereNotIn('id', $classIds->toArray())
                 ->first();
             if ($subclass) {
@@ -313,7 +324,7 @@ class ExtractFixturesCommand extends Command
 
         // One per hit die value
         foreach ([6, 8, 10, 12] as $hitDie) {
-            $class = \App\Models\CharacterClass::where('hit_die', $hitDie)
+            $class = CharacterClass::where('hit_die', $hitDie)
                 ->whereNotIn('id', $classIds->toArray())
                 ->first();
             if ($class) {
@@ -322,7 +333,7 @@ class ExtractFixturesCommand extends Command
         }
 
         // Spellcasters
-        $spellcasters = \App\Models\CharacterClass::whereNotNull('spellcasting_ability_id')
+        $spellcasters = CharacterClass::whereNotNull('spellcasting_ability_id')
             ->whereNotIn('id', $classIds->toArray())
             ->take(3)
             ->pluck('id');
@@ -331,7 +342,7 @@ class ExtractFixturesCommand extends Command
         // Fill remaining with random classes
         $remaining = $limit - $classIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\CharacterClass::whereNotIn('id', $classIds->toArray())
+            $additional = CharacterClass::whereNotIn('id', $classIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
@@ -339,7 +350,7 @@ class ExtractFixturesCommand extends Command
         }
 
         // Load full models with relationships
-        $classes = \App\Models\CharacterClass::whereIn('id', $classIds->unique())
+        $classes = CharacterClass::whereIn('id', $classIds->unique())
             ->with([
                 'spellcastingAbility',
                 'parentClass',
@@ -354,7 +365,7 @@ class ExtractFixturesCommand extends Command
         return $classes->map(fn ($class) => $this->formatClass($class))->toArray();
     }
 
-    protected function formatClass(\App\Models\CharacterClass $class): array
+    protected function formatClass(CharacterClass $class): array
     {
         return [
             'name' => $class->name,
@@ -399,8 +410,8 @@ class ExtractFixturesCommand extends Command
         // 4. Fill remaining
 
         // One per size
-        \App\Models\Size::all()->each(function ($size) use ($raceIds) {
-            $race = \App\Models\Race::where('size_id', $size->id)
+        Size::all()->each(function ($size) use ($raceIds) {
+            $race = Race::where('size_id', $size->id)
                 ->whereNull('parent_race_id')
                 ->first();
             if ($race) {
@@ -409,7 +420,7 @@ class ExtractFixturesCommand extends Command
         });
 
         // Races with subraces (base races that have children)
-        $racesWithSubraces = \App\Models\Race::whereNull('parent_race_id')
+        $racesWithSubraces = Race::whereNull('parent_race_id')
             ->whereHas('subraces')
             ->whereNotIn('id', $raceIds->toArray())
             ->take(3)
@@ -418,7 +429,7 @@ class ExtractFixturesCommand extends Command
 
         // Add at least one subrace for each race with subraces
         foreach ($racesWithSubraces as $baseRaceId) {
-            $subrace = \App\Models\Race::where('parent_race_id', $baseRaceId)
+            $subrace = Race::where('parent_race_id', $baseRaceId)
                 ->whereNotIn('id', $raceIds->toArray())
                 ->first();
             if ($subrace) {
@@ -429,7 +440,7 @@ class ExtractFixturesCommand extends Command
         // Fill remaining with random races
         $remaining = $limit - $raceIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\Race::whereNotIn('id', $raceIds->toArray())
+            $additional = Race::whereNotIn('id', $raceIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
@@ -437,7 +448,7 @@ class ExtractFixturesCommand extends Command
         }
 
         // Load full models with relationships
-        $races = \App\Models\Race::whereIn('id', $raceIds->unique())
+        $races = Race::whereIn('id', $raceIds->unique())
             ->with([
                 'size',
                 'parent',
@@ -453,7 +464,7 @@ class ExtractFixturesCommand extends Command
         return $races->map(fn ($race) => $this->formatRace($race))->toArray();
     }
 
-    protected function formatRace(\App\Models\Race $race): array
+    protected function formatRace(Race $race): array
     {
         // Extract ability score bonuses
         $abilityBonuses = $race->modifiers
@@ -506,15 +517,15 @@ class ExtractFixturesCommand extends Command
 
         // One per rarity
         foreach ($rarities as $rarity) {
-            $item = \App\Models\Item::where('rarity', $rarity)->first();
+            $item = Item::where('rarity', $rarity)->first();
             if ($item) {
                 $itemIds->push($item->id);
             }
         }
 
         // One per item type
-        \App\Models\ItemType::all()->each(function ($type) use ($itemIds) {
-            $item = \App\Models\Item::where('item_type_id', $type->id)
+        ItemType::all()->each(function ($type) use ($itemIds) {
+            $item = Item::where('item_type_id', $type->id)
                 ->whereNotIn('id', $itemIds->toArray())
                 ->first();
             if ($item) {
@@ -523,42 +534,42 @@ class ExtractFixturesCommand extends Command
         });
 
         // Magical items (not already included)
-        $magicalItems = \App\Models\Item::where('is_magic', true)
+        $magicalItems = Item::where('is_magic', true)
             ->whereNotIn('id', $itemIds->toArray())
             ->take(5)
             ->pluck('id');
         $itemIds = $itemIds->merge($magicalItems);
 
         // Mundane items (not already included)
-        $mundaneItems = \App\Models\Item::where('is_magic', false)
+        $mundaneItems = Item::where('is_magic', false)
             ->whereNotIn('id', $itemIds->toArray())
             ->take(5)
             ->pluck('id');
         $itemIds = $itemIds->merge($mundaneItems);
 
         // Items requiring attunement
-        $attunementItems = \App\Models\Item::where('requires_attunement', true)
+        $attunementItems = Item::where('requires_attunement', true)
             ->whereNotIn('id', $itemIds->toArray())
             ->take(3)
             ->pluck('id');
         $itemIds = $itemIds->merge($attunementItems);
 
         // Items with charges
-        $chargedItems = \App\Models\Item::whereNotNull('charges_max')
+        $chargedItems = Item::whereNotNull('charges_max')
             ->whereNotIn('id', $itemIds->toArray())
             ->take(3)
             ->pluck('id');
         $itemIds = $itemIds->merge($chargedItems);
 
         // Weapons with damage dice
-        $weapons = \App\Models\Item::whereNotNull('damage_dice')
+        $weapons = Item::whereNotNull('damage_dice')
             ->whereNotIn('id', $itemIds->toArray())
             ->take(5)
             ->pluck('id');
         $itemIds = $itemIds->merge($weapons);
 
         // Armor with AC
-        $armor = \App\Models\Item::whereNotNull('armor_class')
+        $armor = Item::whereNotNull('armor_class')
             ->whereNotIn('id', $itemIds->toArray())
             ->take(3)
             ->pluck('id');
@@ -567,7 +578,7 @@ class ExtractFixturesCommand extends Command
         // Fill remaining with random items
         $remaining = $limit - $itemIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\Item::whereNotIn('id', $itemIds->toArray())
+            $additional = Item::whereNotIn('id', $itemIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
@@ -575,7 +586,7 @@ class ExtractFixturesCommand extends Command
         }
 
         // Load full models with relationships
-        $items = \App\Models\Item::whereIn('id', $itemIds->unique())
+        $items = Item::whereIn('id', $itemIds->unique())
             ->with([
                 'itemType',
                 'damageType',
@@ -587,7 +598,7 @@ class ExtractFixturesCommand extends Command
         return $items->map(fn ($item) => $this->formatItem($item))->toArray();
     }
 
-    protected function formatItem(\App\Models\Item $item): array
+    protected function formatItem(Item $item): array
     {
         return [
             'name' => $item->name,
@@ -634,7 +645,7 @@ class ExtractFixturesCommand extends Command
         // 5. Fill remaining with random feats
 
         // Feats with ability score improvements
-        $featsWithASI = \App\Models\Feat::whereHas('modifiers', function ($q) {
+        $featsWithASI = Feat::whereHas('modifiers', function ($q) {
             $q->where('modifier_category', 'ability_score');
         })
             ->take(10)
@@ -642,21 +653,21 @@ class ExtractFixturesCommand extends Command
         $featIds = $featIds->merge($featsWithASI);
 
         // Feats with prerequisites (via text)
-        $featsWithPrereqText = \App\Models\Feat::whereNotNull('prerequisites_text')
+        $featsWithPrereqText = Feat::whereNotNull('prerequisites_text')
             ->whereNotIn('id', $featIds->toArray())
             ->take(5)
             ->pluck('id');
         $featIds = $featIds->merge($featsWithPrereqText);
 
         // Feats with prerequisites (via relationships)
-        $featsWithPrereqRelation = \App\Models\Feat::has('prerequisites')
+        $featsWithPrereqRelation = Feat::has('prerequisites')
             ->whereNotIn('id', $featIds->toArray())
             ->take(5)
             ->pluck('id');
         $featIds = $featIds->merge($featsWithPrereqRelation);
 
         // Feats without prerequisites
-        $featsWithoutPrereqs = \App\Models\Feat::whereNull('prerequisites_text')
+        $featsWithoutPrereqs = Feat::whereNull('prerequisites_text')
             ->doesntHave('prerequisites')
             ->whereNotIn('id', $featIds->toArray())
             ->take(5)
@@ -664,7 +675,7 @@ class ExtractFixturesCommand extends Command
         $featIds = $featIds->merge($featsWithoutPrereqs);
 
         // Feats with ability score choices (is_choice = true)
-        $featsWithChoices = \App\Models\Feat::whereHas('modifiers', function ($q) {
+        $featsWithChoices = Feat::whereHas('modifiers', function ($q) {
             $q->where('modifier_category', 'ability_score')
                 ->where('is_choice', true);
         })
@@ -674,7 +685,7 @@ class ExtractFixturesCommand extends Command
         $featIds = $featIds->merge($featsWithChoices);
 
         // Feats with proficiencies
-        $featsWithProficiencies = \App\Models\Feat::has('proficiencies')
+        $featsWithProficiencies = Feat::has('proficiencies')
             ->whereNotIn('id', $featIds->toArray())
             ->take(5)
             ->pluck('id');
@@ -683,7 +694,7 @@ class ExtractFixturesCommand extends Command
         // Fill remaining with random feats
         $remaining = $limit - $featIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\Feat::whereNotIn('id', $featIds->toArray())
+            $additional = Feat::whereNotIn('id', $featIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
@@ -691,7 +702,7 @@ class ExtractFixturesCommand extends Command
         }
 
         // Load full models with relationships
-        $feats = \App\Models\Feat::whereIn('id', $featIds->unique())
+        $feats = Feat::whereIn('id', $featIds->unique())
             ->with([
                 'sources.source',
                 'prerequisites.prerequisite',
@@ -703,7 +714,7 @@ class ExtractFixturesCommand extends Command
         return $feats->map(fn ($feat) => $this->formatFeat($feat))->toArray();
     }
 
-    protected function formatFeat(\App\Models\Feat $feat): array
+    protected function formatFeat(Feat $feat): array
     {
         // Extract prerequisites
         $prerequisites = $feat->prerequisites->map(function ($prereq) {
@@ -770,16 +781,16 @@ class ExtractFixturesCommand extends Command
         // 4. Fill remaining with random backgrounds
 
         // Get all backgrounds (they're typically few in number)
-        $allBackgrounds = \App\Models\Background::all();
+        $allBackgrounds = Background::all();
 
         // Backgrounds with skill proficiencies
-        $backgroundsWithSkills = \App\Models\Background::has('proficiencies')
+        $backgroundsWithSkills = Background::has('proficiencies')
             ->take(10)
             ->pluck('id');
         $backgroundIds = $backgroundIds->merge($backgroundsWithSkills);
 
         // Backgrounds with tool proficiencies
-        $backgroundsWithTools = \App\Models\Background::whereHas('proficiencies', function ($q) {
+        $backgroundsWithTools = Background::whereHas('proficiencies', function ($q) {
             $q->where('proficiency_type', 'tool');
         })
             ->whereNotIn('id', $backgroundIds->toArray())
@@ -788,7 +799,7 @@ class ExtractFixturesCommand extends Command
         $backgroundIds = $backgroundIds->merge($backgroundsWithTools);
 
         // Backgrounds with language proficiencies
-        $backgroundsWithLanguages = \App\Models\Background::whereHas('proficiencies', function ($q) {
+        $backgroundsWithLanguages = Background::whereHas('proficiencies', function ($q) {
             $q->where('proficiency_type', 'language');
         })
             ->whereNotIn('id', $backgroundIds->toArray())
@@ -797,7 +808,7 @@ class ExtractFixturesCommand extends Command
         $backgroundIds = $backgroundIds->merge($backgroundsWithLanguages);
 
         // Backgrounds with features (traits)
-        $backgroundsWithFeatures = \App\Models\Background::has('traits')
+        $backgroundsWithFeatures = Background::has('traits')
             ->whereNotIn('id', $backgroundIds->toArray())
             ->take(5)
             ->pluck('id');
@@ -806,7 +817,7 @@ class ExtractFixturesCommand extends Command
         // Fill remaining with random backgrounds
         $remaining = $limit - $backgroundIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\Background::whereNotIn('id', $backgroundIds->toArray())
+            $additional = Background::whereNotIn('id', $backgroundIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
@@ -814,7 +825,7 @@ class ExtractFixturesCommand extends Command
         }
 
         // Load full models with relationships
-        $backgrounds = \App\Models\Background::whereIn('id', $backgroundIds->unique())
+        $backgrounds = Background::whereIn('id', $backgroundIds->unique())
             ->with([
                 'sources.source',
                 'proficiencies.skill',
@@ -828,7 +839,7 @@ class ExtractFixturesCommand extends Command
         return $backgrounds->map(fn ($background) => $this->formatBackground($background))->toArray();
     }
 
-    protected function formatBackground(\App\Models\Background $background): array
+    protected function formatBackground(Background $background): array
     {
         // Extract skill proficiencies
         $skillProficiencies = $background->proficiencies
@@ -938,35 +949,35 @@ class ExtractFixturesCommand extends Command
         ];
 
         foreach ($featureTypes as $type) {
-            $feature = \App\Models\OptionalFeature::where('feature_type', $type)->first();
+            $feature = OptionalFeature::where('feature_type', $type)->first();
             if ($feature) {
                 $featureIds->push($feature->id);
             }
         }
 
         // Features with level requirements
-        $withLevelReq = \App\Models\OptionalFeature::whereNotNull('level_requirement')
+        $withLevelReq = OptionalFeature::whereNotNull('level_requirement')
             ->whereNotIn('id', $featureIds->toArray())
             ->take(5)
             ->pluck('id');
         $featureIds = $featureIds->merge($withLevelReq);
 
         // Features with prerequisites
-        $withPrereqs = \App\Models\OptionalFeature::whereNotNull('prerequisite_text')
+        $withPrereqs = OptionalFeature::whereNotNull('prerequisite_text')
             ->whereNotIn('id', $featureIds->toArray())
             ->take(5)
             ->pluck('id');
         $featureIds = $featureIds->merge($withPrereqs);
 
         // Features with resource costs
-        $withResources = \App\Models\OptionalFeature::whereNotNull('resource_type')
+        $withResources = OptionalFeature::whereNotNull('resource_type')
             ->whereNotIn('id', $featureIds->toArray())
             ->take(5)
             ->pluck('id');
         $featureIds = $featureIds->merge($withResources);
 
         // Features with spell mechanics
-        $withSpellMechanics = \App\Models\OptionalFeature::whereNotNull('casting_time')
+        $withSpellMechanics = OptionalFeature::whereNotNull('casting_time')
             ->whereNotIn('id', $featureIds->toArray())
             ->take(5)
             ->pluck('id');
@@ -975,7 +986,7 @@ class ExtractFixturesCommand extends Command
         // Fill remaining with random features
         $remaining = $limit - $featureIds->count();
         if ($remaining > 0) {
-            $additional = \App\Models\OptionalFeature::whereNotIn('id', $featureIds->toArray())
+            $additional = OptionalFeature::whereNotIn('id', $featureIds->toArray())
                 ->inRandomOrder()
                 ->take($remaining)
                 ->pluck('id');
@@ -983,7 +994,7 @@ class ExtractFixturesCommand extends Command
         }
 
         // Load full models with relationships
-        $features = \App\Models\OptionalFeature::whereIn('id', $featureIds->unique())
+        $features = OptionalFeature::whereIn('id', $featureIds->unique())
             ->with([
                 'classes',
                 'classPivots',
@@ -996,7 +1007,7 @@ class ExtractFixturesCommand extends Command
         return $features->map(fn ($feature) => $this->formatOptionalFeature($feature))->toArray();
     }
 
-    protected function formatOptionalFeature(\App\Models\OptionalFeature $feature): array
+    protected function formatOptionalFeature(OptionalFeature $feature): array
     {
         // Extract prerequisites
         $prerequisites = $feature->prerequisites->map(function ($prereq) {

--- a/app/Console/Commands/ImportAllDataCommand.php
+++ b/app/Console/Commands/ImportAllDataCommand.php
@@ -2,6 +2,13 @@
 
 namespace App\Console\Commands;
 
+use App\Models\CharacterClass;
+use App\Models\ClassFeature;
+use App\Models\EntityChoice;
+use App\Models\EntitySpell;
+use App\Services\Cache\EntityCacheService;
+use App\Services\Importers\ClassImporter;
+use App\Services\Importers\ItemImporter;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
@@ -85,7 +92,7 @@ class ImportAllDataCommand extends Command
 
             // Link pack contents after all items are imported
             $this->info('  Linking pack contents...');
-            $importer = app(\App\Services\Importers\ItemImporter::class);
+            $importer = app(ItemImporter::class);
             $packsLinked = $importer->importAllPackContents();
             $this->info("  ✓ Linked contents for {$packsLinked} equipment pack(s)");
         }
@@ -335,7 +342,7 @@ class ImportAllDataCommand extends Command
                 $classesImported++;
 
                 // Count subclasses for this class
-                $subclassCount = \App\Models\CharacterClass::where('slug', 'like', "{$className}%")
+                $subclassCount = CharacterClass::where('slug', 'like', "{$className}%")
                     ->count();
                 if ($subclassCount > 1) {
                     $subclassesImported += ($subclassCount - 1); // -1 for base class
@@ -365,10 +372,10 @@ class ImportAllDataCommand extends Command
      */
     private function linkSubclassSpells(): void
     {
-        $importer = new \App\Services\Importers\ClassImporter;
+        $importer = new ClassImporter;
 
         // Get all subclasses (classes with parent_class_id)
-        $subclasses = \App\Models\CharacterClass::whereNotNull('parent_class_id')->get();
+        $subclasses = CharacterClass::whereNotNull('parent_class_id')->get();
 
         $linkedFeatureIds = [];
 
@@ -390,8 +397,8 @@ class ImportAllDataCommand extends Command
         }
 
         // Single query for total count instead of per-feature queries
-        $totalSpells = \App\Models\EntitySpell::whereIn('reference_id', $linkedFeatureIds)
-            ->where('reference_type', \App\Models\ClassFeature::class)
+        $totalSpells = EntitySpell::whereIn('reference_id', $linkedFeatureIds)
+            ->where('reference_type', ClassFeature::class)
             ->count();
 
         $linkedCount = count($linkedFeatureIds);
@@ -413,7 +420,7 @@ class ImportAllDataCommand extends Command
 
         // Get all class features with descriptions matching the pattern
         // Use LIKE for SQLite compatibility (tests use SQLite)
-        $features = \App\Models\ClassFeature::where('description', 'like', '%cantrip of your choice%')
+        $features = ClassFeature::where('description', 'like', '%cantrip of your choice%')
             ->orWhere('description', 'like', '%spell of your choice%')
             ->get();
 
@@ -422,7 +429,7 @@ class ImportAllDataCommand extends Command
 
         foreach ($features as $feature) {
             // Check if this feature already has a spell choice in entity_choices
-            $existingChoice = \App\Models\EntityChoice::where('reference_type', \App\Models\ClassFeature::class)
+            $existingChoice = EntityChoice::where('reference_type', ClassFeature::class)
                 ->where('reference_id', $feature->id)
                 ->where('choice_type', 'spell')
                 ->exists();
@@ -440,13 +447,13 @@ class ImportAllDataCommand extends Command
                 $isCantrip = $spellType === 'cantrip';
 
                 // Find the class by name (base class only)
-                $spellListClass = \App\Models\CharacterClass::where('name', $className)
+                $spellListClass = CharacterClass::where('name', $className)
                     ->whereNull('parent_class_id')
                     ->first();
 
                 if ($spellListClass) {
-                    \App\Models\EntityChoice::create([
-                        'reference_type' => \App\Models\ClassFeature::class,
+                    EntityChoice::create([
+                        'reference_type' => ClassFeature::class,
                         'reference_id' => $feature->id,
                         'choice_type' => 'spell',
                         'choice_group' => 'feature_spell_choice',
@@ -572,7 +579,7 @@ class ImportAllDataCommand extends Command
         // Clear entity caches after import
         $this->newLine();
         $this->info('Clearing entity caches...');
-        app(\App\Services\Cache\EntityCacheService::class)->clearAll();
+        app(EntityCacheService::class)->clearAll();
         $this->info('✓ Entity caches cleared');
     }
 

--- a/app/Console/Commands/ImportFixtureCharactersCommand.php
+++ b/app/Console/Commands/ImportFixtureCharactersCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Character;
 use App\Services\CharacterImportService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -145,7 +146,7 @@ class ImportFixtureCharactersCommand extends Command
                 }
 
                 // Check if already exists
-                if (\App\Models\Character::where('public_id', $publicId)->exists()) {
+                if (Character::where('public_id', $publicId)->exists()) {
                     if (! $force) {
                         $this->warn("  ⏭️  Skipped: {$publicId} (already exists, use --force to replace)");
                         $skipped++;
@@ -193,7 +194,7 @@ class ImportFixtureCharactersCommand extends Command
         $classTestPattern = ' L[0-9]+$';
         $multiclassPattern = ' [0-9]+ / ';  // Contains " X / " pattern
 
-        $characters = \App\Models\Character::where(function ($query) use ($classTestPattern, $multiclassPattern) {
+        $characters = Character::where(function ($query) use ($classTestPattern, $multiclassPattern) {
             $query->where('name', 'regexp', $classTestPattern)
                 ->orWhere('name', 'regexp', $multiclassPattern);
         })->get();

--- a/app/Console/Commands/TestLevelUpFlowCommand.php
+++ b/app/Console/Commands/TestLevelUpFlowCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Character;
 use App\Services\LevelUpFlowTesting\LevelUpFlowExecutor;
 use App\Services\LevelUpFlowTesting\LevelUpReportGenerator;
 use App\Services\WizardFlowTesting\CharacterRandomizer;
@@ -215,7 +216,7 @@ class TestLevelUpFlowCommand extends Command
         $deleted = 0;
         foreach ($report['summary']['characters_used'] as $char) {
             try {
-                \App\Models\Character::where('id', $char['id'])->delete();
+                Character::where('id', $char['id'])->delete();
                 $deleted++;
             } catch (\Throwable $e) {
                 $this->warn("Failed to delete character {$char['public_id']}: {$e->getMessage()}");

--- a/app/Console/Commands/TestWizardFlowCommand.php
+++ b/app/Console/Commands/TestWizardFlowCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Character;
 use App\Services\WizardFlowTesting\CharacterRandomizer;
 use App\Services\WizardFlowTesting\FlowExecutor;
 use App\Services\WizardFlowTesting\FlowGenerator;
@@ -214,7 +215,7 @@ class TestWizardFlowCommand extends Command
         $deleted = 0;
         foreach ($report['summary']['characters_created'] as $char) {
             try {
-                \App\Models\Character::where('id', $char['id'])->delete();
+                Character::where('id', $char['id'])->delete();
                 $deleted++;
             } catch (\Throwable $e) {
                 $this->warn("Failed to delete character {$char['public_id']}: {$e->getMessage()}");

--- a/app/DTOs/CharacterStatsDTO.php
+++ b/app/DTOs/CharacterStatsDTO.php
@@ -5,6 +5,7 @@ namespace App\DTOs;
 use App\Models\Character;
 use App\Models\ClassFeature;
 use App\Models\Feat;
+use App\Models\Race;
 use App\Models\Skill;
 use App\Services\CharacterStatCalculator;
 use App\Services\HitDiceService;
@@ -700,7 +701,7 @@ class CharacterStatsDTO
     /**
      * Extract defensive traits from an entity (Race or Feat) that uses HasConditions and HasModifiers traits.
      *
-     * @param  \App\Models\Race|\App\Models\Feat  $entity
+     * @param  Race|Feat  $entity
      */
     private static function extractDefensiveTraitsFromEntity(
         $entity,
@@ -828,7 +829,7 @@ class CharacterStatsDTO
 
         // Get feats from character features
         $featFeatures = $character->features->filter(
-            fn ($f) => $f->feature_type === \App\Models\Feat::class
+            fn ($f) => $f->feature_type === Feat::class
         );
 
         foreach ($featFeatures as $characterFeature) {

--- a/app/Http/Controllers/Api/AbilityScoreController.php
+++ b/app/Http/Controllers/Api/AbilityScoreController.php
@@ -172,7 +172,7 @@ class AbilityScoreController extends Controller
      * - Save DCs range from 13 (level 1) to 19+ (level 17+)
      *
      * @param  AbilityScore  $abilityScore  The ability score (by ID, code, or name)
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function spells(AbilityScore $abilityScore)
     {

--- a/app/Http/Controllers/Api/AlignmentController.php
+++ b/app/Http/Controllers/Api/AlignmentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\LookupResource;
 use App\Models\Monster;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Str;
 
@@ -65,7 +66,7 @@ class AlignmentController extends Controller
      *
      * @response AnonymousResourceCollection<LookupResource>
      *
-     * @return \Illuminate\Http\JsonResponse JSON response with alignment array [slug, name]
+     * @return JsonResponse JSON response with alignment array [slug, name]
      */
     #[QueryParameter('q', description: 'Search by alignment name (partial match)', example: 'good')]
     #[QueryParameter('per_page', description: 'Results per page, 1-100', example: '50')]

--- a/app/Http/Controllers/Api/CharacterClassController.php
+++ b/app/Http/Controllers/Api/CharacterClassController.php
@@ -235,7 +235,7 @@ class CharacterClassController extends Controller
      *
      * @param  Character  $character  The character
      * @param  string  $classIdOrSlug  Class ID or slug
-     * @return \Illuminate\Http\JsonResponse<LevelUpResource>
+     * @return JsonResponse<LevelUpResource>
      */
     public function levelUp(Character $character, string $classSlugOrFullSlug): JsonResponse
     {
@@ -318,7 +318,7 @@ class CharacterClassController extends Controller
      * @param  CharacterClassAddRequest  $request  The validated request
      * @param  Character  $character  The character
      * @param  string  $classIdOrSlug  The class ID or slug to replace
-     * @return \Illuminate\Http\JsonResponse<CharacterClassPivotResource>
+     * @return JsonResponse<CharacterClassPivotResource>
      */
     public function replace(CharacterClassAddRequest $request, Character $character, string $classSlugOrFullSlug): JsonResponse
     {
@@ -397,7 +397,7 @@ class CharacterClassController extends Controller
      * @param  CharacterSubclassSetRequest  $request  The validated request
      * @param  Character  $character  The character
      * @param  string  $classSlugOrFullSlug  Class slug
-     * @return \Illuminate\Http\JsonResponse<CharacterClassPivotResource>
+     * @return JsonResponse<CharacterClassPivotResource>
      *
      * @throws InvalidSubclassException If subclass doesn't belong to the class
      * @throws SubclassLevelRequirementException If character level is below requirement

--- a/app/Http/Controllers/Api/Concerns/CachesEntityShow.php
+++ b/app/Http/Controllers/Api/Concerns/CachesEntityShow.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Concerns;
 
 use App\Services\Cache\EntityCacheService;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Trait CachesEntityShow
@@ -39,7 +40,7 @@ trait CachesEntityShow
      * 3. Load relationships (from include param or defaults)
      * 4. Return API resource
      *
-     * @param  \Illuminate\Foundation\Http\FormRequest  $request  Validated request
+     * @param  FormRequest  $request  Validated request
      * @param  Model  $entity  Entity from route model binding
      * @param  EntityCacheService  $cache  Cache service
      * @param  string  $cacheMethod  Cache method name (getSpell, getClass, etc.)

--- a/app/Http/Controllers/Api/ConditionController.php
+++ b/app/Http/Controllers/Api/ConditionController.php
@@ -162,7 +162,7 @@ class ConditionController extends Controller
      * - Duration: Varies from 1 round to 1 minute (concentration) to permanent
      *
      * @param  Condition  $condition  The condition (by ID or slug)
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function spells(Condition $condition)
     {
@@ -231,7 +231,7 @@ class ConditionController extends Controller
      * - CR correlation: Higher CR monsters inflict more conditions simultaneously
      *
      * @param  Condition  $condition  The condition (by ID or slug)
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function monsters(Condition $condition)
     {

--- a/app/Http/Controllers/Api/DamageTypeController.php
+++ b/app/Http/Controllers/Api/DamageTypeController.php
@@ -140,7 +140,7 @@ class DamageTypeController extends Controller
      * - Most resisted: Fire, Poison (many creatures have resistance/immunity)
      *
      * @param  DamageType  $damageType  The damage type (by ID, code, or name)
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function spells(DamageType $damageType)
     {
@@ -197,7 +197,7 @@ class DamageTypeController extends Controller
      * - Magic weapons override resistances to non-magical damage
      *
      * @param  DamageType  $damageType  The damage type (by ID, code, or name)
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function items(DamageType $damageType)
     {

--- a/app/Http/Controllers/Api/ItemPropertyController.php
+++ b/app/Http/Controllers/Api/ItemPropertyController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\ItemPropertyIndexRequest;
 use App\Http\Resources\ItemPropertyResource;
 use App\Models\ItemProperty;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ItemPropertyController extends Controller
 {
@@ -45,7 +46,7 @@ class ItemPropertyController extends Controller
      * - **Build Optimization:** Find versatile weapons for flexibility
      * - **Feat Planning:** Identify heavy weapons for Great Weapon Master
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     #[QueryParameter('q', description: 'Search properties by name', example: 'finesse')]
     public function index(ItemPropertyIndexRequest $request)

--- a/app/Http/Controllers/Api/ItemTypeController.php
+++ b/app/Http/Controllers/Api/ItemTypeController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\ItemTypeIndexRequest;
 use App\Http\Resources\ItemTypeResource;
 use App\Models\ItemType;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ItemTypeController extends Controller
 {
@@ -45,7 +46,7 @@ class ItemTypeController extends Controller
      * - **Character Equipment:** Find all weapons or armor available
      * - **Magic Item Shopping:** Browse wondrous items, rings, or wands
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     #[QueryParameter('q', description: 'Search item types by name', example: 'weapon')]
     public function index(ItemTypeIndexRequest $request)

--- a/app/Http/Controllers/Api/ProficiencyTypeController.php
+++ b/app/Http/Controllers/Api/ProficiencyTypeController.php
@@ -13,6 +13,7 @@ use App\Models\ProficiencyType;
 use App\Services\Cache\LookupCacheService;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class ProficiencyTypeController extends Controller
 {
@@ -82,7 +83,7 @@ class ProficiencyTypeController extends Controller
         if (! $request->has('q') && ! $request->has('category') && ! $request->has('subcategory')) {
             $allProficiencyTypes = $cache->getProficiencyTypes();
             $currentPage = $request->input('page', 1);
-            $paginated = new \Illuminate\Pagination\LengthAwarePaginator(
+            $paginated = new LengthAwarePaginator(
                 $allProficiencyTypes->forPage($currentPage, $perPage),
                 $allProficiencyTypes->count(),
                 $perPage,

--- a/app/Http/Controllers/Api/SizeController.php
+++ b/app/Http/Controllers/Api/SizeController.php
@@ -12,6 +12,7 @@ use App\Services\Cache\LookupCacheService;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class SizeController extends Controller
 {
@@ -72,7 +73,7 @@ class SizeController extends Controller
         if (! $request->has('q')) {
             $allSizes = $cache->getSizes();
             $currentPage = $request->input('page', 1);
-            $paginated = new \Illuminate\Pagination\LengthAwarePaginator(
+            $paginated = new LengthAwarePaginator(
                 $allSizes->forPage($currentPage, $perPage),
                 $allSizes->count(),
                 $perPage,
@@ -186,7 +187,7 @@ class SizeController extends Controller
      * - Gargantuan: 20ft × 20ft space (16 squares)
      * - **Squeezing:** Can squeeze through spaces half your width at half speed (Small through 1.25ft)
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function races(Request $request, Size $size)
     {
@@ -294,7 +295,7 @@ class SizeController extends Controller
      * - **Cavern/outdoor:** Only limitation is Gargantuan (20ft × 20ft minimum)
      * - **Flying creatures:** Size matters less (can maneuver in 3D space)
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function monsters(Request $request, Size $size)
     {

--- a/app/Http/Controllers/Api/SkillController.php
+++ b/app/Http/Controllers/Api/SkillController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\SkillIndexRequest;
 use App\Http\Resources\SkillResource;
 use App\Models\Skill;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class SkillController extends Controller
 {
@@ -44,7 +45,7 @@ class SkillController extends Controller
      * - **Class Selection:** Rogues excel at DEX skills, Clerics at WIS skills, Bards at CHA skills
      * - **Background Selection:** Backgrounds grant 2 skill proficiencies - pick ones matching your build
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     #[QueryParameter('q', description: 'Search skills by name', example: 'perception')]
     #[QueryParameter('ability', description: 'Filter by ability score code (STR, DEX, CON, INT, WIS, CHA)', example: 'DEX')]

--- a/app/Http/Controllers/Api/SourceController.php
+++ b/app/Http/Controllers/Api/SourceController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\SourceIndexRequest;
 use App\Http\Resources\SourceResource;
 use App\Models\Source;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class SourceController extends Controller
 {
@@ -42,7 +43,7 @@ class SourceController extends Controller
      * - Publication reference: "What year was Xanathar's Guide published?"
      *
      * @param  SourceIndexRequest  $request  Validated request with search and pagination parameters
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     #[QueryParameter('q', description: 'Search by sourcebook name or code (e.g., "handbook", "PHB", "xanathar")', example: 'handbook')]
     #[QueryParameter('per_page', description: 'Results per page (1-100, default: 50)', example: '20')]
@@ -84,7 +85,7 @@ class SourceController extends Controller
      * - Content attribution: "Link to the original source website and author information"
      *
      * @param  Source  $source  The sourcebook to retrieve (accepts ID or code)
-     * @return \App\Http\Resources\SourceResource
+     * @return SourceResource
      */
     public function show(Source $source)
     {

--- a/app/Http/Controllers/Api/SpellSchoolController.php
+++ b/app/Http/Controllers/Api/SpellSchoolController.php
@@ -141,7 +141,7 @@ class SpellSchoolController extends Controller
      * - Conjuration: ~45 spells (summoning & teleportation)
      *
      * @param  SpellSchool  $spellSchool  The school of magic (by ID, code, or slug)
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return AnonymousResourceCollection
      */
     public function spells(Request $request, SpellSchool $spellSchool)
     {

--- a/app/Http/Requests/Character/CharacterImportRequest.php
+++ b/app/Http/Requests/Character/CharacterImportRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Character;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
 
 /**
  * Validate character import request data.
@@ -179,9 +180,9 @@ class CharacterImportRequest extends FormRequest
     /**
      * Add custom validation to ensure proficiency fields are mutually exclusive.
      */
-    public function withValidator(\Illuminate\Validation\Validator $validator): void
+    public function withValidator(Validator $validator): void
     {
-        $validator->after(function (\Illuminate\Validation\Validator $validator) {
+        $validator->after(function (Validator $validator) {
             $proficiencies = $this->input('character.proficiencies', []);
 
             // Skill proficiencies should not have a 'type' field

--- a/app/Http/Requests/Character/CharacterSpellUpdateRequest.php
+++ b/app/Http/Requests/Character/CharacterSpellUpdateRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Character;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CharacterSpellUpdateRequest extends FormRequest
@@ -12,7 +13,7 @@ class CharacterSpellUpdateRequest extends FormRequest
     }
 
     /**
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/Character/Combat/RecoverHitDiceRequest.php
+++ b/app/Http/Requests/Character/Combat/RecoverHitDiceRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Character\Combat;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class RecoverHitDiceRequest extends FormRequest
@@ -17,7 +18,7 @@ class RecoverHitDiceRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/Character/Combat/SpendHitDiceRequest.php
+++ b/app/Http/Requests/Character/Combat/SpendHitDiceRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Character\Combat;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class SpendHitDiceRequest extends FormRequest
@@ -17,7 +18,7 @@ class SpendHitDiceRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/Character/Combat/UpdateSpellSlotRequest.php
+++ b/app/Http/Requests/Character/Combat/UpdateSpellSlotRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Character\Combat;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -13,7 +14,7 @@ class UpdateSpellSlotRequest extends FormRequest
     }
 
     /**
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/Character/Combat/UseSpellSlotRequest.php
+++ b/app/Http/Requests/Character/Combat/UseSpellSlotRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Character\Combat;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UseSpellSlotRequest extends FormRequest
@@ -17,7 +18,7 @@ class UseSpellSlotRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/LanguageShowRequest.php
+++ b/app/Http/Requests/LanguageShowRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class LanguageShowRequest extends FormRequest
@@ -17,7 +18,7 @@ class LanguageShowRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class LoginRequest extends FormRequest
@@ -17,7 +18,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/ProficiencyTypeShowRequest.php
+++ b/app/Http/Requests/ProficiencyTypeShowRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ProficiencyTypeShowRequest extends FormRequest
@@ -17,7 +18,7 @@ class ProficiencyTypeShowRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class RegisterRequest extends FormRequest
@@ -17,7 +18,7 @@ class RegisterRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Resources/AbilityBonusCollectionResource.php
+++ b/app/Http/Resources/AbilityBonusCollectionResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 
 /**
  * API Resource for a collection of ability bonuses with summary totals.
@@ -11,7 +12,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * Wraps multiple ability bonuses with calculated totals per ability score.
  * The totals only include resolved bonuses (fixed bonuses and resolved choices).
  *
- * @property array{bonuses: \Illuminate\Support\Collection, totals: array<string, int>} $resource
+ * @property array{bonuses: Collection, totals: array<string, int>} $resource
  */
 class AbilityBonusCollectionResource extends JsonResource
 {

--- a/app/Http/Resources/CharacterEquipmentResource.php
+++ b/app/Http/Resources/CharacterEquipmentResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use App\Enums\ItemGroup;
 use App\Enums\ItemTypeCode;
 use App\Http\Resources\Concerns\FormatsRelatedModels;
+use App\Models\CharacterEquipment;
 use App\Models\Item;
 use App\Services\CharacterStatCalculator;
 use App\Services\ProficiencyCheckerService;
@@ -12,7 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
- * @mixin \App\Models\CharacterEquipment
+ * @mixin CharacterEquipment
  */
 class CharacterEquipmentResource extends JsonResource
 {

--- a/app/Http/Resources/CharacterResource.php
+++ b/app/Http/Resources/CharacterResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use App\Http\Resources\Concerns\FormatsRelatedModels;
 use App\Models\Character;
 use App\Services\CharacterStatCalculator;
+use App\Services\CounterService;
 use App\Services\MulticlassSpellSlotCalculator;
 use App\Services\ProficiencyCheckerService;
 use Illuminate\Http\Request;
@@ -334,7 +335,7 @@ class CharacterResource extends JsonResource
      */
     private function getCountersData(): array
     {
-        $counterService = app(\App\Services\CounterService::class);
+        $counterService = app(CounterService::class);
         $counters = $counterService->getCountersForCharacter($this->resource);
 
         return [

--- a/app/Http/Resources/EntityChoiceResource.php
+++ b/app/Http/Resources/EntityChoiceResource.php
@@ -7,6 +7,7 @@ use App\Models\Item;
 use App\Models\ProficiencyType;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 
 /**
  * Resource for entity choices (equipment, proficiency, spell, language, ability_score).
@@ -57,7 +58,7 @@ class EntityChoiceResource extends JsonResource
      * - Items resolved with name, slug, quantity, is_fixed
      * - Category choices (e.g., "any simple weapon") marked with is_category
      *
-     * @param  \Illuminate\Support\Collection<int, EntityChoice>  $choices
+     * @param  Collection<int, EntityChoice>  $choices
      * @return array<int, array{choice_group: string, quantity: int, level_granted: int, is_required: bool, options: array}>
      */
     public static function groupedByChoiceGroup($choices): array

--- a/app/Http/Resources/MulticlassRequirementResource.php
+++ b/app/Http/Resources/MulticlassRequirementResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 
 /**
  * Resource for multiclass ability score requirements.
@@ -41,7 +42,7 @@ class MulticlassRequirementResource extends JsonResource
     /**
      * Create a collection with type metadata for frontend.
      *
-     * @param  \Illuminate\Support\Collection  $requirements
+     * @param  Collection  $requirements
      * @return array{type: string, requirements: array}
      */
     public static function collectionWithType($requirements): array

--- a/app/Http/Resources/PartyCharacterStatsResource.php
+++ b/app/Http/Resources/PartyCharacterStatsResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use App\Enums\ItemTypeCode;
 use App\Models\Character;
 use App\Services\CharacterStatCalculator;
+use App\Services\CounterService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -431,7 +432,7 @@ class PartyCharacterStatsResource extends JsonResource
      */
     private function formatCounters(): array
     {
-        $counterService = app(\App\Services\CounterService::class);
+        $counterService = app(CounterService::class);
 
         return $counterService->getCountersForCharacter($this->resource)->toArray();
     }

--- a/app/Http/Resources/PendingChoicesResource.php
+++ b/app/Http/Resources/PendingChoicesResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 
 /**
  * API Resource for a collection of pending choices with summary.
@@ -11,7 +12,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * Wraps multiple PendingChoice DTOs with summary metadata including
  * total count, remaining choices, and counts by type.
  *
- * @property array{choices: \Illuminate\Support\Collection, summary: array} $resource
+ * @property array{choices: Collection, summary: array} $resource
  */
 class PendingChoicesResource extends JsonResource
 {

--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -8,6 +8,7 @@ use App\Events\CharacterUpdated;
 use App\Services\CharacterChoiceService;
 use App\Services\CharacterStatCalculator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -81,7 +82,7 @@ class Character extends Model implements HasMedia
      *
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @return Model|null
      */
     public function resolveRouteBinding($value, $field = null)
     {
@@ -749,9 +750,9 @@ class Character extends Model implements HasMedia
     /**
      * Get equipped weapons.
      *
-     * @return \Illuminate\Database\Eloquent\Collection<int, CharacterEquipment>
+     * @return Collection<int, CharacterEquipment>
      */
-    public function equippedWeapons(): \Illuminate\Database\Eloquent\Collection
+    public function equippedWeapons(): Collection
     {
         return $this->equipment()
             ->where('equipped', true)

--- a/app/Models/CharacterClass.php
+++ b/app/Models/CharacterClass.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
 use Laravel\Scout\Searchable;
 use Spatie\Tags\HasTags;
 
@@ -519,7 +520,7 @@ class CharacterClass extends BaseModel
      * Features are sorted by level, then by sort_order to maintain proper ordering.
      *
      * @param  bool  $includeInherited  Whether to include parent class features (default: true)
-     * @return \Illuminate\Support\Collection<ClassFeature> Top-level features only
+     * @return Collection<ClassFeature> Top-level features only
      */
     public function getAllFeatures(bool $includeInherited = true)
     {

--- a/app/Models/Feat.php
+++ b/app/Models/Feat.php
@@ -14,6 +14,7 @@ use App\Models\Concerns\HasProficiencyScopes;
 use App\Models\Concerns\HasSearchableHelpers;
 use App\Models\Concerns\HasSources;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use Spatie\Tags\HasTags;
 
@@ -79,7 +80,7 @@ class Feat extends BaseModel
         $baseName = trim(explode('(', $this->name)[0]);
 
         // Convert to slug format
-        return \Illuminate\Support\Str::slug($baseName);
+        return Str::slug($baseName);
     }
 
     // =========================================================================

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,9 +30,24 @@ use App\Models\Spell;
 use App\Models\SpellSchool;
 use App\Observers\CharacterObserver;
 use App\Services\CharacterChoiceService;
+use App\Services\ChoiceHandlers\AbilityScoreChoiceHandler;
+use App\Services\ChoiceHandlers\AsiChoiceHandler;
+use App\Services\ChoiceHandlers\EquipmentChoiceHandler;
+use App\Services\ChoiceHandlers\EquipmentModeChoiceHandler;
+use App\Services\ChoiceHandlers\ExpertiseChoiceHandler;
+use App\Services\ChoiceHandlers\FeatChoiceHandler;
+use App\Services\ChoiceHandlers\HitPointRollChoiceHandler;
+use App\Services\ChoiceHandlers\LanguageChoiceHandler;
+use App\Services\ChoiceHandlers\OptionalFeatureChoiceHandler;
+use App\Services\ChoiceHandlers\ProficiencyChoiceHandler;
+use App\Services\ChoiceHandlers\SizeChoiceHandler;
+use App\Services\ChoiceHandlers\SpellChoiceHandler;
+use App\Services\ChoiceHandlers\SubclassChoiceHandler;
+use App\Services\ChoiceHandlers\SubclassVariantChoiceHandler;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use MeiliSearch\Client;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -42,8 +57,8 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         // Bind Meilisearch Client
-        $this->app->singleton(\MeiliSearch\Client::class, function ($app) {
-            return new \MeiliSearch\Client(
+        $this->app->singleton(Client::class, function ($app) {
+            return new Client(
                 config('scout.meilisearch.host'),
                 config('scout.meilisearch.key')
             );
@@ -54,22 +69,22 @@ class AppServiceProvider extends ServiceProvider
             $service = new CharacterChoiceService;
 
             // Register choice handlers
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\ProficiencyChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\LanguageChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\EquipmentModeChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\EquipmentChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\ExpertiseChoiceHandler::class));
+            $service->registerHandler($app->make(ProficiencyChoiceHandler::class));
+            $service->registerHandler($app->make(LanguageChoiceHandler::class));
+            $service->registerHandler($app->make(EquipmentModeChoiceHandler::class));
+            $service->registerHandler($app->make(EquipmentChoiceHandler::class));
+            $service->registerHandler($app->make(ExpertiseChoiceHandler::class));
             // FightingStyleChoiceHandler removed - fighting styles now handled by OptionalFeatureChoiceHandler
             // via "Fighting Styles Known" counter (Issue #491)
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\SubclassChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\SubclassVariantChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\OptionalFeatureChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\SpellChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\HitPointRollChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\AbilityScoreChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\FeatChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\SizeChoiceHandler::class));
-            $service->registerHandler($app->make(\App\Services\ChoiceHandlers\AsiChoiceHandler::class));
+            $service->registerHandler($app->make(SubclassChoiceHandler::class));
+            $service->registerHandler($app->make(SubclassVariantChoiceHandler::class));
+            $service->registerHandler($app->make(OptionalFeatureChoiceHandler::class));
+            $service->registerHandler($app->make(SpellChoiceHandler::class));
+            $service->registerHandler($app->make(HitPointRollChoiceHandler::class));
+            $service->registerHandler($app->make(AbilityScoreChoiceHandler::class));
+            $service->registerHandler($app->make(FeatChoiceHandler::class));
+            $service->registerHandler($app->make(SizeChoiceHandler::class));
+            $service->registerHandler($app->make(AsiChoiceHandler::class));
 
             return $service;
         });

--- a/app/Services/AbstractSearchService.php
+++ b/app/Services/AbstractSearchService.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use MeiliSearch\Client;
+use MeiliSearch\Exceptions\ApiException;
 
 /**
  * Base class for entity search services using Meilisearch.
@@ -64,7 +65,7 @@ use MeiliSearch\Client;
  * - Services with fundamentally different search behavior
  * - Non-Meilisearch search implementations
  *
- * @see \App\Services\SpellSearchService Gold standard implementation
+ * @see SpellSearchService Gold standard implementation
  * @see ../wrapper/docs/backend/reference/SEARCH-SERVICE-ARCHITECTURE.md Full documentation
  */
 abstract class AbstractSearchService
@@ -135,7 +136,7 @@ abstract class AbstractSearchService
             $modelClass = $this->getModelClass();
             $indexName = (new $modelClass)->searchableAs();
             $results = $client->index($indexName)->search($dto->searchQuery ?? '', $searchParams);
-        } catch (\MeiliSearch\Exceptions\ApiException $e) {
+        } catch (ApiException $e) {
             throw new InvalidFilterSyntaxException(
                 filter: $dto->meilisearchFilter ?? 'unknown',
                 meilisearchMessage: $e->getMessage(),

--- a/app/Services/BackgroundSearchService.php
+++ b/app/Services/BackgroundSearchService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Models\Background;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Builder;
 
 /**
  * Service for searching and filtering D&D backgrounds
@@ -40,7 +42,7 @@ final class BackgroundSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -75,7 +77,7 @@ final class BackgroundSearchService extends AbstractSearchService
      *
      * @param  string|object  $searchQueryOrDto  Search query string or DTO object
      */
-    public function buildScoutQuery(string|object $searchQueryOrDto): \Laravel\Scout\Builder
+    public function buildScoutQuery(string|object $searchQueryOrDto): Builder
     {
         $searchQuery = is_string($searchQueryOrDto) ? $searchQueryOrDto : ($searchQueryOrDto->searchQuery ?? '');
 

--- a/app/Services/CharacterExportService.php
+++ b/app/Services/CharacterExportService.php
@@ -3,7 +3,10 @@
 namespace App\Services;
 
 use App\Models\Character;
+use App\Models\CharacterTrait;
+use App\Models\ClassFeature;
 use App\Support\EntityTypeMapping;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * Service for exporting characters as portable JSON.
@@ -262,22 +265,22 @@ class CharacterExportService
     {
         // Eager load characterClass for ClassFeature types to avoid N+1
         $classFeatures = $character->features
-            ->filter(fn ($cf) => $cf->feature instanceof \App\Models\ClassFeature)
+            ->filter(fn ($cf) => $cf->feature instanceof ClassFeature)
             ->map(fn ($cf) => $cf->feature)
             ->filter();
 
         if ($classFeatures->isNotEmpty()) {
-            (new \Illuminate\Database\Eloquent\Collection($classFeatures))->loadMissing('characterClass');
+            (new Collection($classFeatures))->loadMissing('characterClass');
         }
 
         // Eager load reference for CharacterTrait types
         $characterTraits = $character->features
-            ->filter(fn ($cf) => $cf->feature instanceof \App\Models\CharacterTrait)
+            ->filter(fn ($cf) => $cf->feature instanceof CharacterTrait)
             ->map(fn ($cf) => $cf->feature)
             ->filter();
 
         if ($characterTraits->isNotEmpty()) {
-            (new \Illuminate\Database\Eloquent\Collection($characterTraits))->loadMissing('reference');
+            (new Collection($characterTraits))->loadMissing('reference');
         }
 
         return $character->features->map(function ($cf) {

--- a/app/Services/CharacterFeatureService.php
+++ b/app/Services/CharacterFeatureService.php
@@ -4,10 +4,12 @@ namespace App\Services;
 
 use App\Models\Character;
 use App\Models\CharacterClass;
+use App\Models\CharacterClassPivot;
 use App\Models\CharacterFeature;
 use App\Models\CharacterSpell;
 use App\Models\CharacterTrait;
 use App\Models\ClassFeature;
+use Illuminate\Database\Eloquent\Collection;
 
 class CharacterFeatureService
 {
@@ -209,7 +211,7 @@ class CharacterFeatureService
      * Only the variant matching the character's subclass_choices is included.
      *
      * @param  ClassFeature  $feature  The feature to check
-     * @param  \App\Models\CharacterClassPivot  $characterClass  The character's class pivot with subclass_choices
+     * @param  CharacterClassPivot  $characterClass  The character's class pivot with subclass_choices
      * @return bool True if the feature should be included, false if it should be skipped
      */
     private function shouldIncludeVariantFeature(ClassFeature $feature, $characterClass): bool
@@ -443,7 +445,7 @@ class CharacterFeatureService
     /**
      * Get all features for a character with their related feature data.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return Collection
      */
     public function getCharacterFeatures(Character $character)
     {

--- a/app/Services/CharacterImportService.php
+++ b/app/Services/CharacterImportService.php
@@ -18,6 +18,7 @@ use App\Models\CharacterNote;
 use App\Models\CharacterProficiency;
 use App\Models\CharacterSpell;
 use App\Models\CharacterSpellSlot;
+use App\Models\CharacterTrait;
 use App\Models\ClassFeature;
 use App\Models\Condition;
 use App\Models\FeatureSelection;
@@ -551,7 +552,7 @@ class CharacterImportService
         }
 
         // Find the trait by parent entity and name
-        $trait = \App\Models\CharacterTrait::where('reference_type', $entityClass)
+        $trait = CharacterTrait::where('reference_type', $entityClass)
             ->where('reference_id', $entity->id)
             ->where('name', $traitName)
             ->first();

--- a/app/Services/CharacterLanguageService.php
+++ b/app/Services/CharacterLanguageService.php
@@ -10,6 +10,9 @@ use App\Models\Feat;
 use App\Models\Language;
 use App\Models\Race;
 use App\Services\Concerns\PopulatesFromEntity;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use InvalidArgumentException;
 
 class CharacterLanguageService
@@ -19,7 +22,7 @@ class CharacterLanguageService
     /**
      * Get all languages known by a character.
      *
-     * @return \Illuminate\Database\Eloquent\Collection<int, CharacterLanguage>
+     * @return Collection<int, CharacterLanguage>
      */
     public function getCharacterLanguages(Character $character)
     {
@@ -391,7 +394,7 @@ class CharacterLanguageService
      * - Ungrouped records: each is a separate choice with its own quantity
      * - Grouped records: all records in a group represent options for one choice
      *
-     * @param  \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\MorphMany  $query
+     * @param  Builder|MorphMany  $query
      */
     private function calculateChoiceQuantityFromEntityChoices($query): int
     {

--- a/app/Services/CharacterProficiencyService.php
+++ b/app/Services/CharacterProficiencyService.php
@@ -5,9 +5,12 @@ namespace App\Services;
 use App\Enums\CharacterSource;
 use App\Models\Character;
 use App\Models\CharacterProficiency;
+use App\Models\ClassFeature;
 use App\Models\EntityChoice;
+use App\Models\ProficiencyType;
 use App\Models\Skill;
 use App\Services\Concerns\PopulatesFromEntity;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 
 class CharacterProficiencyService
@@ -288,11 +291,11 @@ class CharacterProficiencyService
                 'musical_instrument' => 'musical_instrument',
             ];
             if (isset($standaloneCategories[$proficiencySubcategory])) {
-                $validProficiencyTypeSlugs = \App\Models\ProficiencyType::where('category', $standaloneCategories[$proficiencySubcategory])
+                $validProficiencyTypeSlugs = ProficiencyType::where('category', $standaloneCategories[$proficiencySubcategory])
                     ->pluck('slug')
                     ->toArray();
             } else {
-                $validProficiencyTypeSlugs = \App\Models\ProficiencyType::where('category', $proficiencyType)
+                $validProficiencyTypeSlugs = ProficiencyType::where('category', $proficiencyType)
                     ->where('subcategory', $proficiencySubcategory)
                     ->pluck('slug')
                     ->toArray();
@@ -305,7 +308,7 @@ class CharacterProficiencyService
             }
         } else {
             // Unrestricted without subcategory: all proficiency types of this type are valid
-            $validProficiencyTypeSlugs = \App\Models\ProficiencyType::where('category', $proficiencyType)
+            $validProficiencyTypeSlugs = ProficiencyType::where('category', $proficiencyType)
                 ->pluck('slug')
                 ->toArray();
 
@@ -394,7 +397,7 @@ class CharacterProficiencyService
      * The choice group for subclass_feature is formatted as "FeatureName (Subclass):base_choice_group"
      * We need to extract just the base_choice_group for the lookup.
      */
-    private function getSubclassFeatureEntity(Character $character, string $choiceGroup): ?\App\Models\ClassFeature
+    private function getSubclassFeatureEntity(Character $character, string $choiceGroup): ?ClassFeature
     {
         $subclass = $character->characterClasses->first()?->subclass;
         if (! $subclass) {
@@ -499,7 +502,7 @@ class CharacterProficiencyService
                             }
                         }
                     } elseif ($choice->target_type === 'proficiency_type' && $choice->target_slug) {
-                        $profType = \App\Models\ProficiencyType::where('slug', $choice->target_slug)->first();
+                        $profType = ProficiencyType::where('slug', $choice->target_slug)->first();
                         if ($profType) {
                             $allOptions[] = [
                                 'type' => 'proficiency_type',
@@ -608,9 +611,9 @@ class CharacterProficiencyService
 
         if ($proficiencySubcategory && isset($standaloneCategories[$proficiencySubcategory])) {
             // These are stored as top-level categories, not subcategories
-            $query = \App\Models\ProficiencyType::where('category', $standaloneCategories[$proficiencySubcategory]);
+            $query = ProficiencyType::where('category', $standaloneCategories[$proficiencySubcategory]);
         } else {
-            $query = \App\Models\ProficiencyType::where('category', $proficiencyType);
+            $query = ProficiencyType::where('category', $proficiencyType);
 
             if ($proficiencySubcategory) {
                 $query->where('subcategory', $proficiencySubcategory);
@@ -660,7 +663,7 @@ class CharacterProficiencyService
      *
      * Proficiencies are deduplicated, preferring stored ones (which have an ID).
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getCharacterProficiencies(Character $character)
     {
@@ -682,7 +685,7 @@ class CharacterProficiencyService
     /**
      * Collect granted (fixed) proficiencies from class, subclass, race, and background.
      */
-    private function collectGrantedProficiencies(Character $character): \Illuminate\Support\Collection
+    private function collectGrantedProficiencies(Character $character): Collection
     {
         $proficiencies = collect();
 
@@ -734,7 +737,7 @@ class CharacterProficiencyService
      * @param  mixed  $entity  The source entity (CharacterClass, Race, Background)
      * @param  string  $source  The source identifier ('class', 'race', 'background')
      */
-    private function getEntityGrantedProficiencies($entity, string $source): \Illuminate\Support\Collection
+    private function getEntityGrantedProficiencies($entity, string $source): Collection
     {
         return $entity->proficiencies()
             ->whereNotIn('proficiency_type', ['saving_throw', 'multiclass_requirement'])
@@ -748,7 +751,7 @@ class CharacterProficiencyService
                 // If no linked proficiency type but we have a name, look it up
                 // This handles imported data that uses proficiency_name text instead of proficiency_type_id FK
                 if (! $proficiencyTypeSlug && $proficiency->proficiency_name) {
-                    $proficiencyType = \App\Models\ProficiencyType::where('name', 'like', $proficiency->proficiency_name)->first();
+                    $proficiencyType = ProficiencyType::where('name', 'like', $proficiency->proficiency_name)->first();
                     $proficiencyTypeSlug = $proficiencyType?->slug;
                 }
 
@@ -776,9 +779,9 @@ class CharacterProficiencyService
      * Prefers stored proficiencies (which have an ID).
      *
      * @param  \Illuminate\Database\Eloquent\Collection  $stored
-     * @param  \Illuminate\Support\Collection  $granted
+     * @param  Collection  $granted
      */
-    private function mergeAndDeduplicate($stored, $granted): \Illuminate\Support\Collection
+    private function mergeAndDeduplicate($stored, $granted): Collection
     {
         // Create lookup sets for stored proficiencies
         $storedSkillSlugs = $stored->whereNotNull('skill_slug')->pluck('skill_slug')->toArray();

--- a/app/Services/CharacterStatCalculator.php
+++ b/app/Services/CharacterStatCalculator.php
@@ -3,10 +3,13 @@
 namespace App\Services;
 
 use App\Enums\ItemTypeCode;
+use App\Models\AbilityScore;
 use App\Models\Character;
+use App\Models\CharacterClass;
 use App\Models\Feat;
 use App\Models\Item;
 use App\Models\Modifier;
+use Illuminate\Support\Str;
 
 class CharacterStatCalculator
 {
@@ -105,7 +108,7 @@ class CharacterStatCalculator
     /**
      * Classes that know spells instead of preparing (returns null for preparation limit).
      *
-     * @see \App\Models\CharacterClass::getSpellPreparationMethodAttribute() for canonical source
+     * @see CharacterClass::getSpellPreparationMethodAttribute() for canonical source
      */
     private const KNOWN_CASTERS = ['sorcerer', 'bard', 'warlock', 'ranger'];
 
@@ -283,8 +286,8 @@ class CharacterStatCalculator
         }
 
         // Find ac_unarmored modifiers for any of the character's classes
-        $unarmoredModifier = \App\Models\Modifier::where('modifier_category', 'ac_unarmored')
-            ->where('reference_type', \App\Models\CharacterClass::class)
+        $unarmoredModifier = Modifier::where('modifier_category', 'ac_unarmored')
+            ->where('reference_type', CharacterClass::class)
             ->whereIn('reference_id', function ($query) use ($classSlugs) {
                 $query->select('id')
                     ->from('classes')
@@ -322,7 +325,7 @@ class CharacterStatCalculator
      */
     private function getCharacterAbilityScore(Character $character, int $abilityScoreId): int
     {
-        $abilityScore = \App\Models\AbilityScore::find($abilityScoreId);
+        $abilityScore = AbilityScore::find($abilityScoreId);
         if ($abilityScore === null) {
             return 10;
         }
@@ -381,7 +384,7 @@ class CharacterStatCalculator
      * @param  int  $abilityModifier  The spellcasting ability modifier
      * @return int|null Preparation limit, or null for known casters
      *
-     * @see \App\Models\CharacterClass::getSpellPreparationMethodAttribute()
+     * @see CharacterClass::getSpellPreparationMethodAttribute()
      */
     public function getPreparationLimit(string $classSlug, int $level, int $abilityModifier): ?int
     {
@@ -417,11 +420,11 @@ class CharacterStatCalculator
      * spell slot counts directly from the CharacterClass's levelProgression
      * relationship, supporting any class including those not in hardcoded lists.
      *
-     * @param  \App\Models\CharacterClass  $class  The class with levelProgression loaded
+     * @param  CharacterClass  $class  The class with levelProgression loaded
      * @param  int  $level  The character's level in this class
      * @return array<int, int> Spell slots indexed by spell level (1-9)
      */
-    public function getSpellSlotsFromClass(\App\Models\CharacterClass $class, int $level): array
+    public function getSpellSlotsFromClass(CharacterClass $class, int $level): array
     {
         // Load progression if not already loaded
         if (! $class->relationLoaded('levelProgression')) {
@@ -472,12 +475,12 @@ class CharacterStatCalculator
      * - 'prepared': ability modifier + level (Cleric, Druid, Artificer)
      *               or ability modifier + half level (Paladin, Ranger)
      *
-     * @param  \App\Models\CharacterClass  $class  The class to check
+     * @param  CharacterClass  $class  The class to check
      * @param  int  $level  The character's level in this class
      * @param  int  $abilityModifier  The spellcasting ability modifier
      * @return int|null Preparation limit, or null for known casters
      */
-    public function getPreparationLimitFromClass(\App\Models\CharacterClass $class, int $level, int $abilityModifier): ?int
+    public function getPreparationLimitFromClass(CharacterClass $class, int $level, int $abilityModifier): ?int
     {
         $prepMethod = $class->spell_preparation_method;
 
@@ -689,7 +692,7 @@ class CharacterStatCalculator
         $baseName = preg_replace('/\s*\+\d+$/', '', $item->name);
 
         // Generate the expected proficiency slug (e.g., "core:longsword")
-        $weaponSlug = 'core:'.\Illuminate\Support\Str::slug($baseName);
+        $weaponSlug = 'core:'.Str::slug($baseName);
 
         // Load proficiencies if not loaded
         $character->loadMissing('proficiencies');

--- a/app/Services/ChoiceHandlers/ChoiceTypeHandler.php
+++ b/app/Services/ChoiceHandlers/ChoiceTypeHandler.php
@@ -3,6 +3,9 @@
 namespace App\Services\ChoiceHandlers;
 
 use App\DTOs\PendingChoice;
+use App\Exceptions\ChoiceNotUndoableException;
+use App\Exceptions\InvalidChoiceException;
+use App\Exceptions\InvalidSelectionException;
 use App\Models\Character;
 use Illuminate\Support\Collection;
 
@@ -27,8 +30,8 @@ interface ChoiceTypeHandler
      *
      * @param  array  $selection  The user's selection (format varies by type)
      *
-     * @throws \App\Exceptions\InvalidChoiceException
-     * @throws \App\Exceptions\InvalidSelectionException
+     * @throws InvalidChoiceException
+     * @throws InvalidSelectionException
      */
     public function resolve(Character $character, PendingChoice $choice, array $selection): void;
 
@@ -40,7 +43,7 @@ interface ChoiceTypeHandler
     /**
      * Undo a previously resolved choice.
      *
-     * @throws \App\Exceptions\ChoiceNotUndoableException
+     * @throws ChoiceNotUndoableException
      */
     public function undo(Character $character, PendingChoice $choice): void;
 }

--- a/app/Services/ClassProgressionTableGenerator.php
+++ b/app/Services/ClassProgressionTableGenerator.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Enums\DataTableType;
 use App\Models\CharacterClass;
+use App\Models\EntityDataTable;
 use Illuminate\Support\Collection;
 
 final class ClassProgressionTableGenerator
@@ -79,7 +80,7 @@ final class ClassProgressionTableGenerator
      * Returns tables that have level-based entries (PROGRESSION or DAMAGE type).
      * DAMAGE tables from <roll> elements also contain level progression data.
      *
-     * @return Collection<int, array{feature_name: string, table: \App\Models\EntityDataTable}>
+     * @return Collection<int, array{feature_name: string, table: EntityDataTable}>
      */
     private function getFeatureProgressionTables(CharacterClass $class): Collection
     {

--- a/app/Services/ClassSearchService.php
+++ b/app/Services/ClassSearchService.php
@@ -8,8 +8,10 @@ use App\Models\CharacterClass;
 use App\Services\Search\MeilisearchFilterCompiler;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator as PaginatorContract;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use MeiliSearch\Client;
+use MeiliSearch\Exceptions\ApiException;
 
 /**
  * Service for searching and filtering D&D classes/subclasses
@@ -92,7 +94,7 @@ final class ClassSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -178,7 +180,7 @@ final class ClassSearchService extends AbstractSearchService
         try {
             $indexName = (new CharacterClass)->searchableAs();
             $results = $client->index($indexName)->search($dto->searchQuery ?? '', $searchParams);
-        } catch (\MeiliSearch\Exceptions\ApiException $e) {
+        } catch (ApiException $e) {
             throw new InvalidFilterSyntaxException(
                 filter: $dto->meilisearchFilter ?? 'unknown',
                 meilisearchMessage: $e->getMessage(),

--- a/app/Services/FeatSearchService.php
+++ b/app/Services/FeatSearchService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Models\Feat;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Builder;
 
 final class FeatSearchService extends AbstractSearchService
 {
@@ -46,7 +48,7 @@ final class FeatSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -82,7 +84,7 @@ final class FeatSearchService extends AbstractSearchService
      *
      * @param  string|object  $searchQueryOrDto  Search query string or DTO object
      */
-    public function buildScoutQuery(string|object $searchQueryOrDto): \Laravel\Scout\Builder
+    public function buildScoutQuery(string|object $searchQueryOrDto): Builder
     {
         $searchQuery = is_string($searchQueryOrDto) ? $searchQueryOrDto : ($searchQueryOrDto->searchQuery ?? '');
 

--- a/app/Services/Importers/ClassImporter.php
+++ b/app/Services/Importers/ClassImporter.php
@@ -3,6 +3,7 @@
 namespace App\Services\Importers;
 
 use App\Enums\RequirementLogic;
+use App\Models\AbilityScore;
 use App\Models\CharacterClass;
 use App\Models\EntityChoice;
 use App\Models\EntityCounter;
@@ -308,7 +309,7 @@ class ClassImporter extends BaseImporter
         // Otherwise inherit from parent
         $spellcastingAbilityId = $parentClass->spellcasting_ability_id;
         if (! empty($subclassData['spellcasting_ability'])) {
-            $ability = \App\Models\AbilityScore::where('name', $subclassData['spellcasting_ability'])->first();
+            $ability = AbilityScore::where('name', $subclassData['spellcasting_ability'])->first();
             $spellcastingAbilityId = $ability?->id;
         }
 
@@ -761,7 +762,7 @@ class ClassImporter extends BaseImporter
         foreach ($requirements as $req) {
             $abilityCode = $abilityCodeMap[$req['ability']] ?? null;
             $abilityScore = $abilityCode
-                ? \App\Models\AbilityScore::where('code', $abilityCode)->first()
+                ? AbilityScore::where('code', $abilityCode)->first()
                 : null;
 
             // Format display name: "Strength 13" etc.

--- a/app/Services/Importers/Concerns/CachesLookupTables.php
+++ b/app/Services/Importers/Concerns/CachesLookupTables.php
@@ -4,6 +4,7 @@ namespace App\Services\Importers\Concerns;
 
 use App\Exceptions\Lookup\EntityNotFoundException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * Provides generic caching for lookup table queries.
@@ -47,7 +48,7 @@ trait CachesLookupTables
 
                 // Cache result (even if null)
                 $this->lookupCache[$model][$column][$normalizedValue] = $result;
-            } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            } catch (ModelNotFoundException $e) {
                 $entityType = class_basename($model);
                 throw new EntityNotFoundException($entityType, $normalizedValue, $column);
             }

--- a/app/Services/Importers/Concerns/ImportsClassFeatures.php
+++ b/app/Services/Importers/Concerns/ImportsClassFeatures.php
@@ -3,14 +3,18 @@
 namespace App\Services\Importers\Concerns;
 
 use App\Enums\DataTableType;
+use App\Models\AbilityScore;
 use App\Models\CharacterClass;
 use App\Models\ClassFeature;
 use App\Models\ClassFeatureSpecialTag;
 use App\Models\EntityChoice;
 use App\Models\EntityDataTable;
 use App\Models\EntityDataTableEntry;
+use App\Models\EntitySpell;
 use App\Models\Modifier;
 use App\Models\Proficiency;
+use App\Models\Skill;
+use App\Models\Spell;
 use App\Services\Parsers\Traits\ParsesChoices;
 
 /**
@@ -300,7 +304,7 @@ trait ImportsClassFeatures
 
             // Add ability_code if present (for ability_score category)
             if (isset($modifierData['ability_code'])) {
-                $abilityScore = \App\Models\AbilityScore::where('code', strtoupper($modifierData['ability_code']))->first();
+                $abilityScore = AbilityScore::where('code', strtoupper($modifierData['ability_code']))->first();
                 if ($abilityScore) {
                     $uniqueKeys['ability_score_id'] = $abilityScore->id;
                     $values['ability_score_id'] = $abilityScore->id;
@@ -486,7 +490,7 @@ trait ImportsClassFeatures
 
         foreach ($spellNames as $spellName) {
             // Look up the spell by name (case-insensitive)
-            $spell = \App\Models\Spell::whereRaw('LOWER(name) = ?', [strtolower($spellName)])->first();
+            $spell = Spell::whereRaw('LOWER(name) = ?', [strtolower($spellName)])->first();
 
             if (! $spell) {
                 // Spell not found - skip silently (spell may not be imported yet)
@@ -494,7 +498,7 @@ trait ImportsClassFeatures
             }
 
             // Use updateOrCreate to prevent duplicates on re-import
-            \App\Models\EntitySpell::updateOrCreate(
+            EntitySpell::updateOrCreate(
                 [
                     'reference_type' => ClassFeature::class,
                     'reference_id' => $feature->id,
@@ -547,7 +551,7 @@ trait ImportsClassFeatures
 
         foreach ($skillNames as $skillName) {
             // Look up the skill to get its slug
-            $skill = \App\Models\Skill::whereRaw('LOWER(name) = ?', [strtolower($skillName)])->first();
+            $skill = Skill::whereRaw('LOWER(name) = ?', [strtolower($skillName)])->first();
             $skillSlug = $skill?->slug ?? strtolower(str_replace(' ', '-', $skillName));
 
             $this->createRestrictedProficiencyChoice(
@@ -717,13 +721,13 @@ trait ImportsClassFeatures
         $secondaryAbilityName = $matches[2] ?? null;
 
         // Look up ability score IDs
-        $dex = \App\Models\AbilityScore::where('code', 'DEX')->first();
+        $dex = AbilityScore::where('code', 'DEX')->first();
         $secondaryAbilityScoreId = null;
 
         if ($secondaryAbilityName) {
             // Map ability name to code: Constitution -> CON, Wisdom -> WIS
             $abilityCode = strtoupper(substr($secondaryAbilityName, 0, 3));
-            $secondaryAbility = \App\Models\AbilityScore::where('code', $abilityCode)->first();
+            $secondaryAbility = AbilityScore::where('code', $abilityCode)->first();
             $secondaryAbilityScoreId = $secondaryAbility?->id;
         }
 

--- a/app/Services/Importers/MonsterImporter.php
+++ b/app/Services/Importers/MonsterImporter.php
@@ -7,11 +7,13 @@ use App\Models\CreatureType;
 use App\Models\Monster;
 use App\Models\MonsterAction;
 use App\Models\MonsterLegendaryAction;
+use App\Models\Size;
 use App\Services\Importers\Concerns\CachesLookupTables;
 use App\Services\Importers\Concerns\ImportsConditions;
 use App\Services\Importers\Concerns\ImportsModifiers;
 use App\Services\Importers\Concerns\ImportsSenses;
 use App\Services\Importers\Strategies\Monster\AberrationStrategy;
+use App\Services\Importers\Strategies\Monster\AbstractMonsterStrategy;
 use App\Services\Importers\Strategies\Monster\BeastStrategy;
 use App\Services\Importers\Strategies\Monster\CelestialStrategy;
 use App\Services\Importers\Strategies\Monster\ConstructStrategy;
@@ -62,7 +64,7 @@ class MonsterImporter extends BaseImporter
         ];
     }
 
-    protected function selectStrategy(array $monsterData): \App\Services\Importers\Strategies\Monster\AbstractMonsterStrategy
+    protected function selectStrategy(array $monsterData): AbstractMonsterStrategy
     {
         foreach ($this->strategies as $strategy) {
             if ($strategy->appliesTo($monsterData)) {
@@ -189,7 +191,7 @@ class MonsterImporter extends BaseImporter
     protected function createOrUpdateMonster(array $monsterData): Monster
     {
         // Lookup size
-        $size = $this->cachedFind(\App\Models\Size::class, 'code', strtoupper($monsterData['size']));
+        $size = $this->cachedFind(Size::class, 'code', strtoupper($monsterData['size']));
 
         // Generate source-prefixed slug
         $sources = $monsterData['sources'] ?? [];

--- a/app/Services/Importers/RaceImporter.php
+++ b/app/Services/Importers/RaceImporter.php
@@ -2,10 +2,15 @@
 
 namespace App\Services\Importers;
 
+use App\Enums\DataTableType;
 use App\Enums\ResetTiming;
+use App\Exceptions\Import\FileNotFoundException;
 use App\Models\AbilityScore;
 use App\Models\CharacterTrait;
+use App\Models\DamageType;
 use App\Models\EntityCounter;
+use App\Models\EntityDataTable;
+use App\Models\EntityDataTableEntry;
 use App\Models\Modifier;
 use App\Models\Race;
 use App\Models\Size;
@@ -306,7 +311,7 @@ class RaceImporter extends BaseImporter
         // Transform damage resistances into modifier format
         foreach ($resistancesData as $resistanceData) {
             // Look up damage type by name (case-insensitive for SQLite compatibility)
-            $damageType = \App\Models\DamageType::whereRaw('LOWER(name) = ?', [strtolower($resistanceData['damage_type'])])->first();
+            $damageType = DamageType::whereRaw('LOWER(name) = ?', [strtolower($resistanceData['damage_type'])])->first();
 
             if ($damageType) {
                 $modifiersData[] = [
@@ -387,7 +392,7 @@ class RaceImporter extends BaseImporter
     {
         // Use parent's file validation (throws FileNotFoundException)
         if (! file_exists($filePath)) {
-            throw new \App\Exceptions\Import\FileNotFoundException($filePath);
+            throw new FileNotFoundException($filePath);
         }
 
         $xmlContent = file_get_contents($filePath);
@@ -449,18 +454,18 @@ class RaceImporter extends BaseImporter
 
                 if ($hasLevelScaling && count($rolls) > 1) {
                     // Level-scaling progression: create ONE table with entries per level
-                    $dataTable = \App\Models\EntityDataTable::create([
-                        'reference_type' => \App\Models\CharacterTrait::class,
+                    $dataTable = EntityDataTable::create([
+                        'reference_type' => CharacterTrait::class,
                         'reference_id' => $trait->id,
                         'table_name' => $description,
                         'dice_type' => null, // Dice stored in entries for progressions
-                        'table_type' => \App\Enums\DataTableType::PROGRESSION,
+                        'table_type' => DataTableType::PROGRESSION,
                         'description' => "From trait: {$traitData['name']}",
                     ]);
 
                     // Create entries for each level tier
                     foreach ($rolls as $sortOrder => $roll) {
-                        \App\Models\EntityDataTableEntry::create([
+                        EntityDataTableEntry::create([
                             'entity_data_table_id' => $dataTable->id,
                             'level' => $roll['level'],
                             'result_text' => $roll['formula'],
@@ -470,12 +475,12 @@ class RaceImporter extends BaseImporter
                 } else {
                     // Non-leveled roll(s): create individual table(s) as before
                     foreach ($rolls as $roll) {
-                        $dataTable = \App\Models\EntityDataTable::create([
-                            'reference_type' => \App\Models\CharacterTrait::class,
+                        $dataTable = EntityDataTable::create([
+                            'reference_type' => CharacterTrait::class,
                             'reference_id' => $trait->id,
                             'table_name' => $description,
                             'dice_type' => $roll['formula'],
-                            'table_type' => \App\Enums\DataTableType::RANDOM,
+                            'table_type' => DataTableType::RANDOM,
                             'description' => "From trait: {$traitData['name']}",
                         ]);
                     }
@@ -497,7 +502,7 @@ class RaceImporter extends BaseImporter
         $abilityScore = null;
         if (! empty($spellcastingData['ability'])) {
             $code = strtoupper(substr($spellcastingData['ability'], 0, 3));
-            $abilityScore = \App\Models\AbilityScore::where('code', $code)->first();
+            $abilityScore = AbilityScore::where('code', $code)->first();
         }
 
         // Transform parsed spells into format expected by ImportsEntitySpells trait

--- a/app/Services/Importers/Strategies/Monster/AbstractMonsterStrategy.php
+++ b/app/Services/Importers/Strategies/Monster/AbstractMonsterStrategy.php
@@ -4,6 +4,7 @@ namespace App\Services\Importers\Strategies\Monster;
 
 use App\Models\Monster;
 use App\Services\Importers\Strategies\AbstractImportStrategy;
+use Illuminate\Database\Eloquent\Model;
 
 abstract class AbstractMonsterStrategy extends AbstractImportStrategy
 {
@@ -53,7 +54,7 @@ abstract class AbstractMonsterStrategy extends AbstractImportStrategy
      *
      * @param  Monster  $entity
      */
-    public function afterCreate(\Illuminate\Database\Eloquent\Model $entity, array $data): void
+    public function afterCreate(Model $entity, array $data): void
     {
         // Override in strategies that need post-creation work
     }

--- a/app/Services/Importers/Strategies/Monster/SpellcasterStrategy.php
+++ b/app/Services/Importers/Strategies/Monster/SpellcasterStrategy.php
@@ -4,6 +4,7 @@ namespace App\Services\Importers\Strategies\Monster;
 
 use App\Models\Monster;
 use App\Services\Concerns\NormalizesSpellNames;
+use Illuminate\Database\Eloquent\Model;
 
 class SpellcasterStrategy extends AbstractMonsterStrategy
 {
@@ -17,7 +18,7 @@ class SpellcasterStrategy extends AbstractMonsterStrategy
     /**
      * @param  Monster  $entity
      */
-    public function afterCreate(\Illuminate\Database\Eloquent\Model $entity, array $data): void
+    public function afterCreate(Model $entity, array $data): void
     {
         if (empty($data['spells'])) {
             return;

--- a/app/Services/ItemSearchService.php
+++ b/app/Services/ItemSearchService.php
@@ -6,8 +6,11 @@ use App\DTOs\ItemSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Item;
 use App\Services\Search\MeilisearchFilterCompiler;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
+use MeiliSearch\Exceptions\ApiException;
 
 /**
  * Service for searching and filtering D&D items
@@ -50,7 +53,7 @@ final class ItemSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -104,7 +107,7 @@ final class ItemSearchService extends AbstractSearchService
         try {
             $indexName = (new Item)->searchableAs();
             $results = $client->index($indexName)->search($dto->searchQuery ?? '', $searchParams);
-        } catch (\MeiliSearch\Exceptions\ApiException $e) {
+        } catch (ApiException $e) {
             throw new InvalidFilterSyntaxException(
                 filter: $dto->meilisearchFilter ?? 'unknown',
                 meilisearchMessage: $e->getMessage(),
@@ -141,7 +144,7 @@ final class ItemSearchService extends AbstractSearchService
      *
      * @param  ItemSearchDTO|object  $dto
      */
-    public function buildScoutQuery(object $dto): \Laravel\Scout\Builder
+    public function buildScoutQuery(object $dto): Builder
     {
         return Item::search($dto->searchQuery ?? '');
     }

--- a/app/Services/MonsterSearchService.php
+++ b/app/Services/MonsterSearchService.php
@@ -5,8 +5,11 @@ namespace App\Services;
 use App\DTOs\MonsterSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Monster;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
+use MeiliSearch\Exceptions\ApiException;
 
 /**
  * Service for searching and filtering D&D monsters
@@ -48,7 +51,7 @@ final class MonsterSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -100,7 +103,7 @@ final class MonsterSearchService extends AbstractSearchService
         try {
             $indexName = (new Monster)->searchableAs();
             $results = $client->index($indexName)->search($dto->searchQuery ?? '', $searchParams);
-        } catch (\MeiliSearch\Exceptions\ApiException $e) {
+        } catch (ApiException $e) {
             throw new InvalidFilterSyntaxException(
                 filter: $dto->meilisearchFilter ?? 'unknown',
                 meilisearchMessage: $e->getMessage(),
@@ -137,7 +140,7 @@ final class MonsterSearchService extends AbstractSearchService
      *
      * @param  MonsterSearchDTO|object  $dto
      */
-    public function buildScoutQuery(object $dto): \Laravel\Scout\Builder
+    public function buildScoutQuery(object $dto): Builder
     {
         return Monster::search($dto->searchQuery ?? '');
     }

--- a/app/Services/MulticlassCharacterBuilder.php
+++ b/app/Services/MulticlassCharacterBuilder.php
@@ -9,6 +9,7 @@ use App\Models\CharacterClass;
 use App\Services\WizardFlowTesting\CharacterRandomizer;
 use App\Services\WizardFlowTesting\FlowExecutor;
 use App\Services\WizardFlowTesting\FlowGenerator;
+use Illuminate\Http\Request;
 use InvalidArgumentException;
 
 /**
@@ -412,7 +413,7 @@ class MulticlassCharacterBuilder
      */
     private function makeRequest(string $method, string $uri, array $data = []): array
     {
-        $request = \Illuminate\Http\Request::create(
+        $request = Request::create(
             $uri,
             $method,
             $method === 'GET' ? $data : [],

--- a/app/Services/OptionalFeatureSearchService.php
+++ b/app/Services/OptionalFeatureSearchService.php
@@ -4,6 +4,8 @@ namespace App\Services;
 
 use App\DTOs\OptionalFeatureSearchDTO;
 use App\Models\OptionalFeature;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Builder;
 
 /**
  * Service for searching and filtering D&D optional features
@@ -34,7 +36,7 @@ final class OptionalFeatureSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -68,7 +70,7 @@ final class OptionalFeatureSearchService extends AbstractSearchService
      *
      * @param  OptionalFeatureSearchDTO|object  $dto
      */
-    public function buildScoutQuery(object $dto): \Laravel\Scout\Builder
+    public function buildScoutQuery(object $dto): Builder
     {
         return OptionalFeature::search($dto->searchQuery ?? '');
     }

--- a/app/Services/Parsers/FeatXmlParser.php
+++ b/app/Services/Parsers/FeatXmlParser.php
@@ -2,6 +2,10 @@
 
 namespace App\Services\Parsers;
 
+use App\Models\AbilityScore;
+use App\Models\ProficiencyType;
+use App\Models\Race;
+use App\Models\Skill;
 use App\Services\Parsers\Concerns\ConvertsWordNumbers;
 use App\Services\Parsers\Concerns\MapsAbilityCodes;
 use App\Services\Parsers\Concerns\ParsesModifiers;
@@ -12,6 +16,7 @@ use App\Services\Parsers\Concerns\ParsesSourceCitations;
 use App\Services\Parsers\Concerns\ParsesUnarmoredAc;
 use App\Services\Parsers\Concerns\ParsesUsageLimits;
 use App\Services\Parsers\Concerns\StripsSourceCitations;
+use Illuminate\Database\Eloquent\Collection;
 use SimpleXMLElement;
 
 class FeatXmlParser
@@ -390,11 +395,11 @@ class FeatXmlParser
                 $abilityCode = $this->mapAbilityNameToCode($abilityName);
 
                 // Look up ability score ID
-                $abilityScore = \App\Models\AbilityScore::where('code', $abilityCode)->first();
+                $abilityScore = AbilityScore::where('code', $abilityCode)->first();
 
                 if ($abilityScore) {
                     $prerequisites[] = [
-                        'prerequisite_type' => \App\Models\AbilityScore::class,
+                        'prerequisite_type' => AbilityScore::class,
                         'prerequisite_id' => $abilityScore->id,
                         'minimum_value' => $minimumValue,
                         'description' => null,
@@ -438,7 +443,7 @@ class FeatXmlParser
 
                 if ($skill) {
                     $prerequisites[] = [
-                        'prerequisite_type' => \App\Models\Skill::class,
+                        'prerequisite_type' => Skill::class,
                         'prerequisite_id' => $skill->id,
                         'minimum_value' => null,
                         'description' => null,
@@ -455,7 +460,7 @@ class FeatXmlParser
             if ($profType) {
                 // Add the category proficiency
                 $prerequisites[] = [
-                    'prerequisite_type' => \App\Models\ProficiencyType::class,
+                    'prerequisite_type' => ProficiencyType::class,
                     'prerequisite_id' => $profType->id,
                     'minimum_value' => null,
                     'description' => null,
@@ -469,7 +474,7 @@ class FeatXmlParser
 
                     foreach ($individualWeapons as $weapon) {
                         $prerequisites[] = [
-                            'prerequisite_type' => \App\Models\ProficiencyType::class,
+                            'prerequisite_type' => ProficiencyType::class,
                             'prerequisite_id' => $weapon->id,
                             'minimum_value' => null,
                             'description' => null,
@@ -495,7 +500,7 @@ class FeatXmlParser
     /**
      * Check if a proficiency type is a weapon category that should be expanded.
      */
-    private function shouldExpandWeaponCategory(\App\Models\ProficiencyType $profType): bool
+    private function shouldExpandWeaponCategory(ProficiencyType $profType): bool
     {
         $weaponCategories = ['Martial Weapons', 'Simple Weapons'];
 
@@ -505,9 +510,9 @@ class FeatXmlParser
     /**
      * Get individual weapons for a weapon category based on subcategory.
      *
-     * @return \Illuminate\Database\Eloquent\Collection<int, \App\Models\ProficiencyType>
+     * @return Collection<int, ProficiencyType>
      */
-    private function getIndividualWeapons(\App\Models\ProficiencyType $categoryProfType): \Illuminate\Database\Eloquent\Collection
+    private function getIndividualWeapons(ProficiencyType $categoryProfType): Collection
     {
         // Map category names to subcategory prefixes
         $subcategoryPrefix = match ($categoryProfType->name) {
@@ -518,13 +523,13 @@ class FeatXmlParser
 
         if ($subcategoryPrefix === null) {
             // Fallback: get all individual weapons
-            return \App\Models\ProficiencyType::where('category', 'weapon')
+            return ProficiencyType::where('category', 'weapon')
                 ->whereNotIn('name', ['Simple Weapons', 'Martial Weapons'])
                 ->get();
         }
 
         // Get weapons with matching subcategory (e.g., 'martial_melee', 'martial_ranged')
-        return \App\Models\ProficiencyType::where('category', 'weapon')
+        return ProficiencyType::where('category', 'weapon')
             ->where('subcategory', 'LIKE', "{$subcategoryPrefix}%")
             ->whereNotIn('name', ['Simple Weapons', 'Martial Weapons'])
             ->get();
@@ -533,24 +538,24 @@ class FeatXmlParser
     /**
      * Find skill by name.
      */
-    private function findSkill(string $name): ?\App\Models\Skill
+    private function findSkill(string $name): ?Skill
     {
         $normalized = strtolower(trim($name));
 
         // Try exact match first
-        $skill = \App\Models\Skill::whereRaw('LOWER(name) = ?', [$normalized])->first();
+        $skill = Skill::whereRaw('LOWER(name) = ?', [$normalized])->first();
         if ($skill) {
             return $skill;
         }
 
         // Try LIKE match
-        return \App\Models\Skill::where('name', 'LIKE', "%{$name}%")->first();
+        return Skill::where('name', 'LIKE', "%{$name}%")->first();
     }
 
     /**
      * Find proficiency type by name (with fuzzy matching).
      */
-    private function findProficiencyType(string $name): ?\App\Models\ProficiencyType
+    private function findProficiencyType(string $name): ?ProficiencyType
     {
         $normalized = strtolower(trim($name));
 
@@ -558,35 +563,35 @@ class FeatXmlParser
         $normalized = preg_replace('/^(a|an)\s+/', '', $normalized);
 
         // Direct match
-        $profType = \App\Models\ProficiencyType::whereRaw('LOWER(name) = ?', [$normalized])->first();
+        $profType = ProficiencyType::whereRaw('LOWER(name) = ?', [$normalized])->first();
         if ($profType) {
             return $profType;
         }
 
         // Fuzzy match for armor types
         if (str_contains($normalized, 'light') && str_contains($normalized, 'armor')) {
-            return \App\Models\ProficiencyType::where('name', 'LIKE', '%Light%Armor%')->first();
+            return ProficiencyType::where('name', 'LIKE', '%Light%Armor%')->first();
         }
 
         if (str_contains($normalized, 'medium') && str_contains($normalized, 'armor')) {
-            return \App\Models\ProficiencyType::where('name', 'LIKE', '%Medium%Armor%')->first();
+            return ProficiencyType::where('name', 'LIKE', '%Medium%Armor%')->first();
         }
 
         if (str_contains($normalized, 'heavy') && str_contains($normalized, 'armor')) {
-            return \App\Models\ProficiencyType::where('name', 'LIKE', '%Heavy%Armor%')->first();
+            return ProficiencyType::where('name', 'LIKE', '%Heavy%Armor%')->first();
         }
 
         // Fuzzy match for weapon categories
         if (str_contains($normalized, 'martial') && str_contains($normalized, 'weapon')) {
-            return \App\Models\ProficiencyType::where('name', 'LIKE', '%Martial%Weapon%')->first();
+            return ProficiencyType::where('name', 'LIKE', '%Martial%Weapon%')->first();
         }
 
         if (str_contains($normalized, 'simple') && str_contains($normalized, 'weapon')) {
-            return \App\Models\ProficiencyType::where('name', 'LIKE', '%Simple%Weapon%')->first();
+            return ProficiencyType::where('name', 'LIKE', '%Simple%Weapon%')->first();
         }
 
         // Try LIKE match
-        return \App\Models\ProficiencyType::where('name', 'LIKE', "%{$name}%")->first();
+        return ProficiencyType::where('name', 'LIKE', "%{$name}%")->first();
     }
 
     /**
@@ -673,7 +678,7 @@ class FeatXmlParser
                 $race = $this->findRace($raceName);
                 if ($race) {
                     $prerequisites[] = [
-                        'prerequisite_type' => \App\Models\Race::class,
+                        'prerequisite_type' => Race::class,
                         'prerequisite_id' => $race->id,
                         'minimum_value' => null,
                         'description' => null,
@@ -702,7 +707,7 @@ class FeatXmlParser
                 $race = $this->findRace($raceName);
                 if ($race) {
                     $prerequisites[] = [
-                        'prerequisite_type' => \App\Models\Race::class,
+                        'prerequisite_type' => Race::class,
                         'prerequisite_id' => $race->id,
                         'minimum_value' => null,
                         'description' => null,
@@ -735,7 +740,7 @@ class FeatXmlParser
      * - Simple race: "Elf", "Dwarf"
      * - Parenthetical subrace: "Elf (High)", "Elf (Drow)", "Elf (Wood)"
      */
-    private function findRace(string $name): ?\App\Models\Race
+    private function findRace(string $name): ?Race
     {
         $name = trim($name);
 
@@ -750,13 +755,13 @@ class FeatXmlParser
         $normalized = strtolower($name);
 
         // Try exact match first
-        $race = \App\Models\Race::whereRaw('LOWER(name) = ?', [$normalized])->first();
+        $race = Race::whereRaw('LOWER(name) = ?', [$normalized])->first();
         if ($race) {
             return $race;
         }
 
         // Try LIKE match
-        return \App\Models\Race::where('name', 'LIKE', "%{$name}%")->first();
+        return Race::where('name', 'LIKE', "%{$name}%")->first();
     }
 
     /**
@@ -766,10 +771,10 @@ class FeatXmlParser
      * - findSubrace("Elf", "High") -> Race with name "High" and parent_race_id pointing to "Elf"
      * - findSubrace("Elf", "Drow") -> Race with name containing "Drow" (e.g., "Drow / Dark")
      */
-    private function findSubrace(string $parentRaceName, string $subraceName): ?\App\Models\Race
+    private function findSubrace(string $parentRaceName, string $subraceName): ?Race
     {
         // First find the parent race
-        $parentRace = \App\Models\Race::whereRaw('LOWER(name) = ?', [strtolower($parentRaceName)])
+        $parentRace = Race::whereRaw('LOWER(name) = ?', [strtolower($parentRaceName)])
             ->whereNull('parent_race_id')
             ->first();
 
@@ -780,7 +785,7 @@ class FeatXmlParser
         $normalizedSubrace = strtolower($subraceName);
 
         // Try exact match on subrace name
-        $subrace = \App\Models\Race::where('parent_race_id', $parentRace->id)
+        $subrace = Race::where('parent_race_id', $parentRace->id)
             ->whereRaw('LOWER(name) = ?', [$normalizedSubrace])
             ->first();
 
@@ -789,7 +794,7 @@ class FeatXmlParser
         }
 
         // Try LIKE match (for names like "Drow / Dark" matching "Drow")
-        return \App\Models\Race::where('parent_race_id', $parentRace->id)
+        return Race::where('parent_race_id', $parentRace->id)
             ->where('name', 'LIKE', "%{$subraceName}%")
             ->first();
     }

--- a/app/Services/Parsers/ItemXmlParser.php
+++ b/app/Services/Parsers/ItemXmlParser.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Parsers;
 
+use App\Models\AbilityScore;
+use App\Models\Skill;
 use App\Services\Parsers\Concerns\LookupsGameEntities;
 use App\Services\Parsers\Concerns\MapsAbilityCodes;
 use App\Services\Parsers\Concerns\MatchesProficiencyTypes;
@@ -457,7 +459,7 @@ class ItemXmlParser
         // Fall back to fuzzy matching (e.g., "Strength save" contains "strength")
         try {
             $text = strtolower($text);
-            $abilities = \App\Models\AbilityScore::all();
+            $abilities = AbilityScore::all();
 
             foreach ($abilities as $ability) {
                 if (str_contains($text, strtolower($ability->name)) ||
@@ -487,7 +489,7 @@ class ItemXmlParser
         // Fall back to fuzzy matching (e.g., "Acrobatics check" contains "acrobatics")
         try {
             $text = strtolower($text);
-            $skills = \App\Models\Skill::all();
+            $skills = Skill::all();
 
             foreach ($skills as $skill) {
                 if (str_contains($text, strtolower($skill->name))) {

--- a/app/Services/RaceSearchService.php
+++ b/app/Services/RaceSearchService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Models\Race;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Builder;
 
 final class RaceSearchService extends AbstractSearchService
 {
@@ -70,7 +72,7 @@ final class RaceSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -105,7 +107,7 @@ final class RaceSearchService extends AbstractSearchService
      * - ?filter=spell_slugs IN [misty-step, faerie-fire]
      * - ?filter=tag_slugs IN [darkvision, fey-ancestry]
      */
-    public function buildScoutQuery(object $dto): \Laravel\Scout\Builder
+    public function buildScoutQuery(object $dto): Builder
     {
         return parent::buildScoutQuery($dto);
     }

--- a/app/Services/SpellSearchService.php
+++ b/app/Services/SpellSearchService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Models\Spell;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Builder;
 
 /**
  * Service for searching and filtering D&D spells
@@ -38,7 +40,7 @@ final class SpellSearchService extends AbstractSearchService
     /**
      * Get the fully qualified model class name
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     protected function getModelClass(): string
     {
@@ -72,7 +74,7 @@ final class SpellSearchService extends AbstractSearchService
      * - ?filter=concentration = true
      * - ?filter=level <= 3 AND school = EV
      */
-    public function buildScoutQuery(object $dto): \Laravel\Scout\Builder
+    public function buildScoutQuery(object $dto): Builder
     {
         return parent::buildScoutQuery($dto);
     }

--- a/app/Services/WizardFlowTesting/CharacterRandomizer.php
+++ b/app/Services/WizardFlowTesting/CharacterRandomizer.php
@@ -7,6 +7,7 @@ namespace App\Services\WizardFlowTesting;
 use App\Models\Background;
 use App\Models\CharacterClass;
 use App\Models\Race;
+use Illuminate\Support\Str;
 
 /**
  * Picks random valid entities from the database for wizard flow testing.
@@ -175,7 +176,7 @@ class CharacterRandomizer
         // Use random_int() (non-seeded) for guaranteed uniqueness
         $adjective = $adjectives[random_int(0, count($adjectives) - 1)];
         $noun = $nouns[random_int(0, count($nouns) - 1)];
-        $suffix = \Illuminate\Support\Str::random(4);
+        $suffix = Str::random(4);
 
         return "{$adjective}-{$noun}-{$suffix}";
     }

--- a/app/Services/WizardFlowTesting/FlowGenerator.php
+++ b/app/Services/WizardFlowTesting/FlowGenerator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\WizardFlowTesting;
 
+use App\Models\Race;
+
 /**
  * Generates wizard flow step sequences for testing.
  * Supports linear flows, chaos mode (random switches), and parameterized patterns.
@@ -146,7 +148,7 @@ class FlowGenerator
      */
     public function allRacesWithChaos(CharacterRandomizer $randomizer): array
     {
-        $races = \App\Models\Race::whereNull('parent_race_id')->get();
+        $races = Race::whereNull('parent_race_id')->get();
         $flows = [];
 
         foreach ($races as $race) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Exceptions\ApiException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Validation\ValidationException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -13,12 +16,12 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->api(prepend: [
-            \Illuminate\Http\Middleware\HandleCors::class,
+            HandleCors::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         // Handle validation exceptions for API routes
-        $exceptions->renderable(function (\Illuminate\Validation\ValidationException $e, $request) {
+        $exceptions->renderable(function (ValidationException $e, $request) {
             if ($request->is('api/*')) {
                 return response()->json([
                     'message' => $e->getMessage(),
@@ -28,7 +31,7 @@ return Application::configure(basePath: dirname(__DIR__))
         });
 
         // Handle custom API exceptions
-        $exceptions->renderable(function (\App\Exceptions\ApiException $e, $request) {
+        $exceptions->renderable(function (ApiException $e, $request) {
             return $e->render($request);
         });
     })->create();

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
+    AppServiceProvider::class,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -62,7 +64,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         // 'users' => [

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -1,5 +1,31 @@
 <?php
 
+use Spatie\ImageOptimizer\Optimizers\Avifenc;
+use Spatie\ImageOptimizer\Optimizers\Cwebp;
+use Spatie\ImageOptimizer\Optimizers\Gifsicle;
+use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
+use Spatie\ImageOptimizer\Optimizers\Optipng;
+use Spatie\ImageOptimizer\Optimizers\Pngquant;
+use Spatie\ImageOptimizer\Optimizers\Svgo;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Avif;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Image;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Svg;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
+use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
+use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver;
+use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
+use Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred;
+use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
+use Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer;
+use Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover;
+use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
+use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
+use Spatie\MediaLibraryPro\Models\TemporaryUpload;
+
 return [
 
     /*
@@ -39,12 +65,12 @@ return [
     /*
      * The fully qualified class name of the media model.
      */
-    'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
+    'media_model' => Media::class,
 
     /*
      * The fully qualified class name of the media observer.
      */
-    'media_observer' => Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver::class,
+    'media_observer' => MediaObserver::class,
 
     /*
      * When enabled, media collections will be serialised using the default
@@ -59,7 +85,7 @@ return [
      *
      * This model is only used in Media Library Pro (https://medialibrary.pro)
      */
-    'temporary_upload_model' => Spatie\MediaLibraryPro\Models\TemporaryUpload::class,
+    'temporary_upload_model' => TemporaryUpload::class,
 
     /*
      * When enabled, Media Library Pro will only process temporary uploads that were uploaded
@@ -76,17 +102,17 @@ return [
     /*
      * This is the class that is responsible for naming generated files.
      */
-    'file_namer' => Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class,
+    'file_namer' => DefaultFileNamer::class,
 
     /*
      * The class that contains the strategy for determining a media file's path.
      */
-    'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
+    'path_generator' => DefaultPathGenerator::class,
 
     /*
      * The class that contains the strategy for determining how to remove files.
      */
-    'file_remover_class' => Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover::class,
+    'file_remover_class' => DefaultFileRemover::class,
 
     /*
      * Here you can specify which path generator should be used for the given class.
@@ -101,7 +127,7 @@ return [
      * When urls to files get generated, this class will be called. Use the default
      * if your files are stored locally above the site root or on s3.
      */
-    'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
+    'url_generator' => DefaultUrlGenerator::class,
 
     /*
      * Moves media on updating to keep path consistent. Enable it only with a custom
@@ -121,34 +147,34 @@ return [
      * the optimizers that will be used by default.
      */
     'image_optimizers' => [
-        Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
+        Jpegoptim::class => [
             '-m85', // set maximum quality to 85%
             '--force', // ensure that progressive generation is always done also if a little bigger
             '--strip-all', // this strips out all text information such as comments and EXIF data
             '--all-progressive', // this will make sure the resulting image is a progressive one
         ],
-        Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
+        Pngquant::class => [
             '--force', // required parameter for this package
         ],
-        Spatie\ImageOptimizer\Optimizers\Optipng::class => [
+        Optipng::class => [
             '-i0', // this will result in a non-interlaced, progressive scanned image
             '-o2', // this set the optimization level to two (multiple IDAT compression trials)
             '-quiet', // required parameter for this package
         ],
-        Spatie\ImageOptimizer\Optimizers\Svgo::class => [
+        Svgo::class => [
             '--disable=cleanupIDs', // disabling because it is known to cause troubles
         ],
-        Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
+        Gifsicle::class => [
             '-b', // required parameter for this package
             '-O3', // this produces the slowest but best results
         ],
-        Spatie\ImageOptimizer\Optimizers\Cwebp::class => [
+        Cwebp::class => [
             '-m 6', // for the slowest compression method in order to get the best compression.
             '-pass 10', // for maximizing the amount of analysis pass.
             '-mt', // multithreading for some speed improvements.
             '-q 90', // quality factor that brings the least noticeable changes.
         ],
-        Spatie\ImageOptimizer\Optimizers\Avifenc::class => [
+        Avifenc::class => [
             '-a cq-level=23', // constant quality level, lower values mean better quality and greater file size (0-63).
             '-j all', // number of jobs (worker threads, "all" uses all available cores).
             '--min 0', // min quantizer for color (0-63).
@@ -164,12 +190,12 @@ return [
      * These generators will be used to create an image of media files.
      */
     'image_generators' => [
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Avif::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
+        Image::class,
+        Webp::class,
+        Avif::class,
+        Pdf::class,
+        Svg::class,
+        Video::class,
     ],
 
     /*
@@ -209,8 +235,8 @@ return [
      * your custom jobs extend the ones provided by the package.
      */
     'jobs' => [
-        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
-        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+        'perform_conversions' => PerformConversionsJob::class,
+        'generate_responsive_images' => GenerateResponsiveImagesJob::class,
     ],
 
     /*
@@ -218,7 +244,7 @@ return [
      * This is particularly useful when the url of the image is behind a firewall and
      * need to add additional flags, possibly using curl.
      */
-    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+    'media_downloader' => DefaultDownloader::class,
 
     /*
      * When using the addMediaFromUrl method the SSL is verified by default.
@@ -255,7 +281,7 @@ return [
          *
          * https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/generating-responsive-images
          */
-        'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
+        'width_calculator' => FileSizeOptimizedWidthCalculator::class,
 
         /*
          * By default rendering media to a responsive image will add some javascript and a tiny placeholder.
@@ -268,7 +294,7 @@ return [
          * This class will generate the tiny placeholder used for progressive image loading. By default
          * the media library will use a tiny blurred jpg image.
          */
-        'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
+        'tiny_placeholder_generator' => Blurred::class,
     ],
 
     /*

--- a/config/media.php
+++ b/config/media.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Character;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -13,7 +15,7 @@ return [
     */
     'models' => [
         'characters' => [
-            'class' => \App\Models\Character::class,
+            'class' => Character::class,
             'collections' => ['portrait', 'token'],
         ],
     ],

--- a/database/factories/BackgroundFactory.php
+++ b/database/factories/BackgroundFactory.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Background>
+ * @extends Factory<Background>
  */
 class BackgroundFactory extends Factory
 {

--- a/database/factories/CharacterAbilityScoreFactory.php
+++ b/database/factories/CharacterAbilityScoreFactory.php
@@ -7,7 +7,7 @@ use App\Models\CharacterAbilityScore;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CharacterAbilityScore>
+ * @extends Factory<CharacterAbilityScore>
  */
 class CharacterAbilityScoreFactory extends Factory
 {

--- a/database/factories/CharacterClassFactory.php
+++ b/database/factories/CharacterClassFactory.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CharacterClass>
+ * @extends Factory<CharacterClass>
  */
 class CharacterClassFactory extends Factory
 {

--- a/database/factories/CharacterConditionFactory.php
+++ b/database/factories/CharacterConditionFactory.php
@@ -8,7 +8,7 @@ use App\Models\Condition;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CharacterCondition>
+ * @extends Factory<CharacterCondition>
  */
 class CharacterConditionFactory extends Factory
 {

--- a/database/factories/CharacterFactory.php
+++ b/database/factories/CharacterFactory.php
@@ -8,10 +8,11 @@ use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
 use App\Models\Race;
+use App\Services\CharacterFeatureService;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Character>
+ * @extends Factory<Character>
  */
 class CharacterFactory extends Factory
 {
@@ -302,7 +303,7 @@ class CharacterFactory extends Factory
     public function withFeatures(): static
     {
         return $this->afterCreating(function (Character $character) {
-            $service = app(\App\Services\CharacterFeatureService::class);
+            $service = app(CharacterFeatureService::class);
             $service->populateAll($character);
         });
     }

--- a/database/factories/CharacterLanguageFactory.php
+++ b/database/factories/CharacterLanguageFactory.php
@@ -8,7 +8,7 @@ use App\Models\Language;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CharacterLanguage>
+ * @extends Factory<CharacterLanguage>
  */
 class CharacterLanguageFactory extends Factory
 {

--- a/database/factories/CharacterNoteFactory.php
+++ b/database/factories/CharacterNoteFactory.php
@@ -8,7 +8,7 @@ use App\Support\NoteCategories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CharacterNote>
+ * @extends Factory<CharacterNote>
  */
 class CharacterNoteFactory extends Factory
 {

--- a/database/factories/CharacterProficiencyFactory.php
+++ b/database/factories/CharacterProficiencyFactory.php
@@ -7,7 +7,7 @@ use App\Models\CharacterProficiency;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CharacterProficiency>
+ * @extends Factory<CharacterProficiency>
  */
 class CharacterProficiencyFactory extends Factory
 {

--- a/database/factories/CharacterTraitFactory.php
+++ b/database/factories/CharacterTraitFactory.php
@@ -7,7 +7,7 @@ use App\Models\Race;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CharacterTrait>
+ * @extends Factory<CharacterTrait>
  */
 class CharacterTraitFactory extends Factory
 {

--- a/database/factories/ClassCounterFactory.php
+++ b/database/factories/ClassCounterFactory.php
@@ -6,11 +6,12 @@ use App\Models\CharacterClass;
 use App\Models\ClassCounter;
 use App\Models\Feat;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @deprecated Use EntityCounterFactory instead.
  *
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ClassCounter>
+ * @extends Factory<ClassCounter>
  */
 class ClassCounterFactory extends Factory
 {
@@ -77,7 +78,7 @@ class ClassCounterFactory extends Factory
      *
      * @param  array<string, mixed>|callable  $attributes
      */
-    public function create($attributes = [], ?\Illuminate\Database\Eloquent\Model $parent = null)
+    public function create($attributes = [], ?Model $parent = null)
     {
         // Transform legacy attributes if passed as array
         if (is_array($attributes)) {

--- a/database/factories/ClassFeatureFactory.php
+++ b/database/factories/ClassFeatureFactory.php
@@ -7,7 +7,7 @@ use App\Models\ClassFeature;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ClassFeature>
+ * @extends Factory<ClassFeature>
  */
 class ClassFeatureFactory extends Factory
 {

--- a/database/factories/ClassLevelProgressionFactory.php
+++ b/database/factories/ClassLevelProgressionFactory.php
@@ -7,7 +7,7 @@ use App\Models\ClassLevelProgression;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ClassLevelProgression>
+ * @extends Factory<ClassLevelProgression>
  */
 class ClassLevelProgressionFactory extends Factory
 {

--- a/database/factories/ConditionFactory.php
+++ b/database/factories/ConditionFactory.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Condition>
+ * @extends Factory<Condition>
  */
 class ConditionFactory extends Factory
 {

--- a/database/factories/CreatureTypeFactory.php
+++ b/database/factories/CreatureTypeFactory.php
@@ -6,7 +6,7 @@ use App\Models\CreatureType;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CreatureType>
+ * @extends Factory<CreatureType>
  */
 class CreatureTypeFactory extends Factory
 {

--- a/database/factories/EncounterPresetFactory.php
+++ b/database/factories/EncounterPresetFactory.php
@@ -7,7 +7,7 @@ use App\Models\Party;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\EncounterPreset>
+ * @extends Factory<EncounterPreset>
  */
 class EncounterPresetFactory extends Factory
 {

--- a/database/factories/EntityConditionFactory.php
+++ b/database/factories/EntityConditionFactory.php
@@ -6,7 +6,7 @@ use App\Models\EntityCondition;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\EntityCondition>
+ * @extends Factory<EntityCondition>
  */
 class EntityConditionFactory extends Factory
 {

--- a/database/factories/EntityCounterFactory.php
+++ b/database/factories/EntityCounterFactory.php
@@ -9,7 +9,7 @@ use App\Models\Feat;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\EntityCounter>
+ * @extends Factory<EntityCounter>
  */
 class EntityCounterFactory extends Factory
 {

--- a/database/factories/EntityDataTableEntryFactory.php
+++ b/database/factories/EntityDataTableEntryFactory.php
@@ -7,7 +7,7 @@ use App\Models\EntityDataTableEntry;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\EntityDataTableEntry>
+ * @extends Factory<EntityDataTableEntry>
  */
 class EntityDataTableEntryFactory extends Factory
 {

--- a/database/factories/EntityDataTableFactory.php
+++ b/database/factories/EntityDataTableFactory.php
@@ -8,7 +8,7 @@ use App\Models\EntityDataTable;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\EntityDataTable>
+ * @extends Factory<EntityDataTable>
  */
 class EntityDataTableFactory extends Factory
 {

--- a/database/factories/EntityLanguageFactory.php
+++ b/database/factories/EntityLanguageFactory.php
@@ -8,7 +8,7 @@ use App\Models\Race;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\EntityLanguage>
+ * @extends Factory<EntityLanguage>
  */
 class EntityLanguageFactory extends Factory
 {

--- a/database/factories/EntitySourceFactory.php
+++ b/database/factories/EntitySourceFactory.php
@@ -8,7 +8,7 @@ use App\Models\Spell;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\EntitySource>
+ * @extends Factory<EntitySource>
  */
 class EntitySourceFactory extends Factory
 {

--- a/database/factories/FeatFactory.php
+++ b/database/factories/FeatFactory.php
@@ -2,12 +2,16 @@
 
 namespace Database\Factories;
 
+use App\Models\EntityCondition;
+use App\Models\EntitySource;
 use App\Models\Feat;
+use App\Models\Modifier;
+use App\Models\Proficiency;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Feat>
+ * @extends Factory<Feat>
  */
 class FeatFactory extends Factory
 {
@@ -58,7 +62,7 @@ class FeatFactory extends Factory
     public function withSources(): static
     {
         return $this->afterCreating(function (Feat $feat) {
-            \App\Models\EntitySource::factory()
+            EntitySource::factory()
                 ->forEntity(Feat::class, $feat->id)
                 ->fromSource('PHB')
                 ->create();
@@ -71,7 +75,7 @@ class FeatFactory extends Factory
     public function withModifiers(): static
     {
         return $this->afterCreating(function (Feat $feat) {
-            \App\Models\Modifier::factory()
+            Modifier::factory()
                 ->forEntity(Feat::class, $feat->id)
                 ->create([
                     'modifier_category' => 'ability_score',
@@ -86,7 +90,7 @@ class FeatFactory extends Factory
     public function withProficiencies(): static
     {
         return $this->afterCreating(function (Feat $feat) {
-            \App\Models\Proficiency::factory()
+            Proficiency::factory()
                 ->forEntity(Feat::class, $feat->id)
                 ->create();
         });
@@ -98,7 +102,7 @@ class FeatFactory extends Factory
     public function withConditions(): static
     {
         return $this->afterCreating(function (Feat $feat) {
-            \App\Models\EntityCondition::factory()
+            EntityCondition::factory()
                 ->forEntity(Feat::class, $feat->id)
                 ->create([
                     'effect_type' => 'advantage',

--- a/database/factories/FeatureSelectionFactory.php
+++ b/database/factories/FeatureSelectionFactory.php
@@ -9,7 +9,7 @@ use App\Models\OptionalFeature;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\FeatureSelection>
+ * @extends Factory<FeatureSelection>
  */
 class FeatureSelectionFactory extends Factory
 {

--- a/database/factories/LanguageFactory.php
+++ b/database/factories/LanguageFactory.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Language>
+ * @extends Factory<Language>
  */
 class LanguageFactory extends Factory
 {

--- a/database/factories/ModifierFactory.php
+++ b/database/factories/ModifierFactory.php
@@ -8,7 +8,7 @@ use App\Models\Race;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Modifier>
+ * @extends Factory<Modifier>
  */
 class ModifierFactory extends Factory
 {

--- a/database/factories/OptionalFeatureFactory.php
+++ b/database/factories/OptionalFeatureFactory.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\OptionalFeature>
+ * @extends Factory<OptionalFeature>
  */
 class OptionalFeatureFactory extends Factory
 {

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Party>
+ * @extends Factory<Party>
  */
 class PartyFactory extends Factory
 {

--- a/database/factories/ProficiencyFactory.php
+++ b/database/factories/ProficiencyFactory.php
@@ -8,7 +8,7 @@ use App\Models\Skill;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Proficiency>
+ * @extends Factory<Proficiency>
  */
 class ProficiencyFactory extends Factory
 {

--- a/database/factories/ProficiencyTypeFactory.php
+++ b/database/factories/ProficiencyTypeFactory.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ProficiencyType>
+ * @extends Factory<ProficiencyType>
  */
 class ProficiencyTypeFactory extends Factory
 {

--- a/database/factories/RaceFactory.php
+++ b/database/factories/RaceFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\Race;
 use App\Models\Size;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Race>
+ * @extends Factory<Race>
  */
 class RaceFactory extends Factory
 {

--- a/database/factories/SenseFactory.php
+++ b/database/factories/SenseFactory.php
@@ -6,7 +6,7 @@ use App\Models\Sense;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Sense>
+ * @extends Factory<Sense>
  */
 class SenseFactory extends Factory
 {

--- a/database/factories/SizeFactory.php
+++ b/database/factories/SizeFactory.php
@@ -6,7 +6,7 @@ use App\Models\Size;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Size>
+ * @extends Factory<Size>
  */
 class SizeFactory extends Factory
 {

--- a/database/factories/SkillFactory.php
+++ b/database/factories/SkillFactory.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Skill>
+ * @extends Factory<Skill>
  */
 class SkillFactory extends Factory
 {

--- a/database/factories/SourceFactory.php
+++ b/database/factories/SourceFactory.php
@@ -6,7 +6,7 @@ use App\Models\Source;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Source>
+ * @extends Factory<Source>
  */
 class SourceFactory extends Factory
 {

--- a/database/factories/SpellEffectFactory.php
+++ b/database/factories/SpellEffectFactory.php
@@ -8,7 +8,7 @@ use App\Models\SpellEffect;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\SpellEffect>
+ * @extends Factory<SpellEffect>
  */
 class SpellEffectFactory extends Factory
 {

--- a/database/factories/SpellFactory.php
+++ b/database/factories/SpellFactory.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Spell>
+ * @extends Factory<Spell>
  */
 class SpellFactory extends Factory
 {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/database/migrations/2025_01_01_000021_drop_choice_columns_from_entity_tables.php
+++ b/database/migrations/2025_01_01_000021_drop_choice_columns_from_entity_tables.php
@@ -85,6 +85,6 @@ return new class extends Migration
     public function down(): void
     {
         // This migration is not reversible - requires re-import
-        throw new \RuntimeException('This migration cannot be reversed. Run migrate:fresh and re-import.');
+        throw new RuntimeException('This migration cannot be reversed. Run migrate:fresh and re-import.');
     }
 };

--- a/database/seeders/TestDatabaseSeeder.php
+++ b/database/seeders/TestDatabaseSeeder.php
@@ -2,6 +2,14 @@
 
 namespace Database\Seeders;
 
+use App\Models\Background;
+use App\Models\CharacterClass;
+use App\Models\Feat;
+use App\Models\Item;
+use App\Models\Monster;
+use App\Models\OptionalFeature;
+use App\Models\Race;
+use App\Models\Spell;
 use Illuminate\Database\Seeder;
 
 class TestDatabaseSeeder extends Seeder
@@ -66,14 +74,14 @@ class TestDatabaseSeeder extends Seeder
     protected function indexSearchableModels(): void
     {
         $models = [
-            \App\Models\Spell::class,
-            \App\Models\Monster::class,
-            \App\Models\CharacterClass::class,
-            \App\Models\Race::class,
-            \App\Models\Item::class,
-            \App\Models\Feat::class,
-            \App\Models\Background::class,
-            \App\Models\OptionalFeature::class,
+            Spell::class,
+            Monster::class,
+            CharacterClass::class,
+            Race::class,
+            Item::class,
+            Feat::class,
+            Background::class,
+            OptionalFeature::class,
         ];
 
         foreach ($models as $model) {

--- a/database/seeders/Testing/OptionalFeatureFixtureSeeder.php
+++ b/database/seeders/Testing/OptionalFeatureFixtureSeeder.php
@@ -2,11 +2,13 @@
 
 namespace Database\Seeders\Testing;
 
+use App\Models\AbilityScore;
 use App\Models\CharacterClass;
 use App\Models\EntityPrerequisite;
 use App\Models\EntitySource;
 use App\Models\OptionalFeature;
 use App\Models\Source;
+use App\Models\Spell;
 use App\Models\SpellSchool;
 
 class OptionalFeatureFixtureSeeder extends FixtureSeeder
@@ -107,14 +109,14 @@ class OptionalFeatureFixtureSeeder extends FixtureSeeder
                 break;
 
             case 'Spell':
-                $prerequisiteType = \App\Models\Spell::class;
-                $spell = \App\Models\Spell::where('slug', $prerequisite['value'])->first();
+                $prerequisiteType = Spell::class;
+                $spell = Spell::where('slug', $prerequisite['value'])->first();
                 $prerequisiteId = $spell?->id;
                 break;
 
             case 'AbilityScore':
-                $prerequisiteType = \App\Models\AbilityScore::class;
-                $abilityScore = \App\Models\AbilityScore::where('code', $prerequisite['value'])->first();
+                $prerequisiteType = AbilityScore::class;
+                $abilityScore = AbilityScore::where('code', $prerequisite['value'])->first();
                 $prerequisiteId = $abilityScore?->id;
                 break;
         }

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,21 +3,36 @@
 use App\Http\Controllers\Api\AbilityScoreController;
 use App\Http\Controllers\Api\AlignmentController;
 use App\Http\Controllers\Api\ArmorTypeController;
+use App\Http\Controllers\Api\AsiChoiceController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\BackgroundController;
 use App\Http\Controllers\Api\CharacterAvailableFeatsController;
 use App\Http\Controllers\Api\CharacterChoiceController;
+use App\Http\Controllers\Api\CharacterClassController;
+use App\Http\Controllers\Api\CharacterConditionController;
 use App\Http\Controllers\Api\CharacterController;
 use App\Http\Controllers\Api\CharacterCurrencyController;
+use App\Http\Controllers\Api\CharacterDeathSaveController;
+use App\Http\Controllers\Api\CharacterEquipmentController;
 use App\Http\Controllers\Api\CharacterExperienceController;
 use App\Http\Controllers\Api\CharacterExportController;
+use App\Http\Controllers\Api\CharacterFeatureController;
 use App\Http\Controllers\Api\CharacterHpController;
+use App\Http\Controllers\Api\CharacterLanguageController;
+use App\Http\Controllers\Api\CharacterNoteController;
+use App\Http\Controllers\Api\CharacterOptionalFeatureController;
+use App\Http\Controllers\Api\CharacterProficiencyController;
+use App\Http\Controllers\Api\CharacterReviveController;
+use App\Http\Controllers\Api\CharacterSpellController;
 use App\Http\Controllers\Api\CharacterValidationController;
 use App\Http\Controllers\Api\ClassController;
 use App\Http\Controllers\Api\ConditionController;
+use App\Http\Controllers\Api\CounterController;
 use App\Http\Controllers\Api\CreatureTypeController;
 use App\Http\Controllers\Api\DamageTypeController;
 use App\Http\Controllers\Api\FeatController;
+use App\Http\Controllers\Api\FeatureSelectionController;
+use App\Http\Controllers\Api\HitDiceController;
 use App\Http\Controllers\Api\ItemController;
 use App\Http\Controllers\Api\ItemPropertyController;
 use App\Http\Controllers\Api\ItemTypeController;
@@ -27,15 +42,20 @@ use App\Http\Controllers\Api\MonsterController;
 use App\Http\Controllers\Api\MonsterTypeController;
 use App\Http\Controllers\Api\OptionalFeatureController;
 use App\Http\Controllers\Api\OptionalFeatureTypeController;
+use App\Http\Controllers\Api\PartyController;
+use App\Http\Controllers\Api\PartyEncounterMonsterController;
+use App\Http\Controllers\Api\PartyEncounterPresetController;
 use App\Http\Controllers\Api\ProficiencyTypeController;
 use App\Http\Controllers\Api\RaceController;
 use App\Http\Controllers\Api\RarityController;
+use App\Http\Controllers\Api\RestController;
 use App\Http\Controllers\Api\SearchController;
 use App\Http\Controllers\Api\SizeController;
 use App\Http\Controllers\Api\SkillController;
 use App\Http\Controllers\Api\SourceController;
 use App\Http\Controllers\Api\SpellController;
 use App\Http\Controllers\Api\SpellSchoolController;
+use App\Http\Controllers\Api\SpellSlotController;
 use App\Http\Controllers\Api\TagController;
 use Illuminate\Support\Facades\Route;
 
@@ -283,39 +303,39 @@ Route::prefix('v1')->group(function () {
 
     // Character Spell Management
     Route::prefix('characters/{character}')->name('characters.')->group(function () {
-        Route::get('spells', [\App\Http\Controllers\Api\CharacterSpellController::class, 'index'])
+        Route::get('spells', [CharacterSpellController::class, 'index'])
             ->name('spells.index');
-        Route::get('available-spells', [\App\Http\Controllers\Api\CharacterSpellController::class, 'available'])
+        Route::get('available-spells', [CharacterSpellController::class, 'available'])
             ->name('spells.available');
         Route::get('available-feats', CharacterAvailableFeatsController::class)
             ->name('feats.available');
-        Route::post('spells', [\App\Http\Controllers\Api\CharacterSpellController::class, 'store'])
+        Route::post('spells', [CharacterSpellController::class, 'store'])
             ->name('spells.store');
-        Route::delete('spells/{spellIdOrSlug}', [\App\Http\Controllers\Api\CharacterSpellController::class, 'destroy'])
+        Route::delete('spells/{spellIdOrSlug}', [CharacterSpellController::class, 'destroy'])
             ->name('spells.destroy');
-        Route::patch('spells/{characterSpellId}', [\App\Http\Controllers\Api\CharacterSpellController::class, 'update'])
+        Route::patch('spells/{characterSpellId}', [CharacterSpellController::class, 'update'])
             ->where('characterSpellId', '[0-9]+')
             ->name('spells.update');
-        Route::patch('spells/{spellIdOrSlug}/prepare', [\App\Http\Controllers\Api\CharacterSpellController::class, 'prepare'])
+        Route::patch('spells/{spellIdOrSlug}/prepare', [CharacterSpellController::class, 'prepare'])
             ->name('spells.prepare');
-        Route::patch('spells/{spellIdOrSlug}/unprepare', [\App\Http\Controllers\Api\CharacterSpellController::class, 'unprepare'])
+        Route::patch('spells/{spellIdOrSlug}/unprepare', [CharacterSpellController::class, 'unprepare'])
             ->name('spells.unprepare');
-        Route::get('spell-slots', [\App\Http\Controllers\Api\CharacterSpellController::class, 'slots'])
+        Route::get('spell-slots', [CharacterSpellController::class, 'slots'])
             ->name('spell-slots');
-        Route::post('spell-slots/use', [\App\Http\Controllers\Api\SpellSlotController::class, 'use'])
+        Route::post('spell-slots/use', [SpellSlotController::class, 'use'])
             ->name('spell-slots.use');
-        Route::patch('spell-slots/{level}', [\App\Http\Controllers\Api\SpellSlotController::class, 'update'])
+        Route::patch('spell-slots/{level}', [SpellSlotController::class, 'update'])
             ->where('level', '[1-9]')
             ->name('spell-slots.update');
 
         // Character Equipment Management
-        Route::get('equipment', [\App\Http\Controllers\Api\CharacterEquipmentController::class, 'index'])
+        Route::get('equipment', [CharacterEquipmentController::class, 'index'])
             ->name('equipment.index');
-        Route::post('equipment', [\App\Http\Controllers\Api\CharacterEquipmentController::class, 'store'])
+        Route::post('equipment', [CharacterEquipmentController::class, 'store'])
             ->name('equipment.store');
-        Route::patch('equipment/{equipment}', [\App\Http\Controllers\Api\CharacterEquipmentController::class, 'update'])
+        Route::patch('equipment/{equipment}', [CharacterEquipmentController::class, 'update'])
             ->name('equipment.update');
-        Route::delete('equipment/{equipment}', [\App\Http\Controllers\Api\CharacterEquipmentController::class, 'destroy'])
+        Route::delete('equipment/{equipment}', [CharacterEquipmentController::class, 'destroy'])
             ->name('equipment.destroy');
 
         // Unified Choice System
@@ -329,57 +349,57 @@ Route::prefix('v1')->group(function () {
             ->name('choices.undo');
 
         // Character Proficiencies
-        Route::get('proficiencies', [\App\Http\Controllers\Api\CharacterProficiencyController::class, 'index'])
+        Route::get('proficiencies', [CharacterProficiencyController::class, 'index'])
             ->name('proficiencies.index');
-        Route::post('proficiencies/sync', [\App\Http\Controllers\Api\CharacterProficiencyController::class, 'sync'])
+        Route::post('proficiencies/sync', [CharacterProficiencyController::class, 'sync'])
             ->name('proficiencies.sync');
 
         // Character Languages
-        Route::get('languages', [\App\Http\Controllers\Api\CharacterLanguageController::class, 'index'])
+        Route::get('languages', [CharacterLanguageController::class, 'index'])
             ->name('languages.index');
-        Route::post('languages/sync', [\App\Http\Controllers\Api\CharacterLanguageController::class, 'sync'])
+        Route::post('languages/sync', [CharacterLanguageController::class, 'sync'])
             ->name('languages.sync');
 
         // Character Features
-        Route::get('features', [\App\Http\Controllers\Api\CharacterFeatureController::class, 'index'])
+        Route::get('features', [CharacterFeatureController::class, 'index'])
             ->name('features.index');
-        Route::post('features/sync', [\App\Http\Controllers\Api\CharacterFeatureController::class, 'sync'])
+        Route::post('features/sync', [CharacterFeatureController::class, 'sync'])
             ->name('features.sync');
-        Route::delete('features/{source}', [\App\Http\Controllers\Api\CharacterFeatureController::class, 'clear'])
+        Route::delete('features/{source}', [CharacterFeatureController::class, 'clear'])
             ->name('features.clear');
 
         // Character Optional Features (Invocations, Infusions, Metamagic with full details)
-        Route::get('optional-features', [\App\Http\Controllers\Api\CharacterOptionalFeatureController::class, 'index'])
+        Route::get('optional-features', [CharacterOptionalFeatureController::class, 'index'])
             ->name('optional-features.index');
 
         // ASI Choice (Feat or Ability Score Increase)
-        Route::post('asi-choice', \App\Http\Controllers\Api\AsiChoiceController::class)
+        Route::post('asi-choice', AsiChoiceController::class)
             ->name('asi-choice');
 
         // Character Classes (Multiclass Support)
-        Route::get('classes', [\App\Http\Controllers\Api\CharacterClassController::class, 'index'])
+        Route::get('classes', [CharacterClassController::class, 'index'])
             ->name('classes.index');
-        Route::post('classes', [\App\Http\Controllers\Api\CharacterClassController::class, 'store'])
+        Route::post('classes', [CharacterClassController::class, 'store'])
             ->name('classes.store');
-        Route::delete('classes/{classIdOrSlug}', [\App\Http\Controllers\Api\CharacterClassController::class, 'destroy'])
+        Route::delete('classes/{classIdOrSlug}', [CharacterClassController::class, 'destroy'])
             ->name('classes.destroy');
-        Route::put('classes/{classIdOrSlug}', [\App\Http\Controllers\Api\CharacterClassController::class, 'replace'])
+        Route::put('classes/{classIdOrSlug}', [CharacterClassController::class, 'replace'])
             ->name('classes.replace');
-        Route::post('classes/{classIdOrSlug}/level-up', [\App\Http\Controllers\Api\CharacterClassController::class, 'levelUp'])
+        Route::post('classes/{classIdOrSlug}/level-up', [CharacterClassController::class, 'levelUp'])
             ->name('classes.level-up');
-        Route::put('classes/{classIdOrSlug}/subclass', [\App\Http\Controllers\Api\CharacterClassController::class, 'setSubclass'])
+        Route::put('classes/{classIdOrSlug}/subclass', [CharacterClassController::class, 'setSubclass'])
             ->name('classes.set-subclass');
 
         // Character Notes (Personality traits, ideals, bonds, flaws, backstory, custom notes)
-        Route::get('notes', [\App\Http\Controllers\Api\CharacterNoteController::class, 'index'])
+        Route::get('notes', [CharacterNoteController::class, 'index'])
             ->name('notes.index');
-        Route::post('notes', [\App\Http\Controllers\Api\CharacterNoteController::class, 'store'])
+        Route::post('notes', [CharacterNoteController::class, 'store'])
             ->name('notes.store');
-        Route::get('notes/{note}', [\App\Http\Controllers\Api\CharacterNoteController::class, 'show'])
+        Route::get('notes/{note}', [CharacterNoteController::class, 'show'])
             ->name('notes.show');
-        Route::match(['put', 'patch'], 'notes/{note}', [\App\Http\Controllers\Api\CharacterNoteController::class, 'update'])
+        Route::match(['put', 'patch'], 'notes/{note}', [CharacterNoteController::class, 'update'])
             ->name('notes.update');
-        Route::delete('notes/{note}', [\App\Http\Controllers\Api\CharacterNoteController::class, 'destroy'])
+        Route::delete('notes/{note}', [CharacterNoteController::class, 'destroy'])
             ->name('notes.destroy');
 
         // HP Modification (D&D rules: damage, healing, temp HP)
@@ -391,54 +411,54 @@ Route::prefix('v1')->group(function () {
             ->name('currency.modify');
 
         // Death Saves
-        Route::post('death-saves', [\App\Http\Controllers\Api\CharacterDeathSaveController::class, 'store'])
+        Route::post('death-saves', [CharacterDeathSaveController::class, 'store'])
             ->name('death-saves.store');
-        Route::post('death-saves/stabilize', [\App\Http\Controllers\Api\CharacterDeathSaveController::class, 'stabilize'])
+        Route::post('death-saves/stabilize', [CharacterDeathSaveController::class, 'stabilize'])
             ->name('death-saves.stabilize');
-        Route::delete('death-saves', [\App\Http\Controllers\Api\CharacterDeathSaveController::class, 'reset'])
+        Route::delete('death-saves', [CharacterDeathSaveController::class, 'reset'])
             ->name('death-saves.reset');
 
         // Revival
-        Route::post('revive', \App\Http\Controllers\Api\CharacterReviveController::class)
+        Route::post('revive', CharacterReviveController::class)
             ->name('revive');
 
         // Hit Dice
-        Route::get('hit-dice', [\App\Http\Controllers\Api\HitDiceController::class, 'index'])
+        Route::get('hit-dice', [HitDiceController::class, 'index'])
             ->name('hit-dice.index');
-        Route::post('hit-dice/spend', [\App\Http\Controllers\Api\HitDiceController::class, 'spend'])
+        Route::post('hit-dice/spend', [HitDiceController::class, 'spend'])
             ->name('hit-dice.spend');
-        Route::post('hit-dice/recover', [\App\Http\Controllers\Api\HitDiceController::class, 'recover'])
+        Route::post('hit-dice/recover', [HitDiceController::class, 'recover'])
             ->name('hit-dice.recover');
 
         // Rest Mechanics
-        Route::post('short-rest', [\App\Http\Controllers\Api\RestController::class, 'shortRest'])
+        Route::post('short-rest', [RestController::class, 'shortRest'])
             ->name('short-rest');
-        Route::post('long-rest', [\App\Http\Controllers\Api\RestController::class, 'longRest'])
+        Route::post('long-rest', [RestController::class, 'longRest'])
             ->name('long-rest');
 
         // Counters (Class Resources: Rage, Ki, Action Surge, etc.)
-        Route::get('counters', [\App\Http\Controllers\Api\CounterController::class, 'index'])
+        Route::get('counters', [CounterController::class, 'index'])
             ->name('counters.index');
-        Route::patch('counters/{id}', [\App\Http\Controllers\Api\CounterController::class, 'update'])
+        Route::patch('counters/{id}', [CounterController::class, 'update'])
             ->name('counters.update')
             ->whereNumber('id');
 
         // Feature Selections (Invocations, Maneuvers, Metamagic, etc.)
-        Route::get('feature-selections', [\App\Http\Controllers\Api\FeatureSelectionController::class, 'index'])
+        Route::get('feature-selections', [FeatureSelectionController::class, 'index'])
             ->name('feature-selections.index');
-        Route::get('available-feature-selections', [\App\Http\Controllers\Api\FeatureSelectionController::class, 'available'])
+        Route::get('available-feature-selections', [FeatureSelectionController::class, 'available'])
             ->name('feature-selections.available');
-        Route::post('feature-selections', [\App\Http\Controllers\Api\FeatureSelectionController::class, 'store'])
+        Route::post('feature-selections', [FeatureSelectionController::class, 'store'])
             ->name('feature-selections.store');
-        Route::delete('feature-selections/{featureIdOrSlug}', [\App\Http\Controllers\Api\FeatureSelectionController::class, 'destroy'])
+        Route::delete('feature-selections/{featureIdOrSlug}', [FeatureSelectionController::class, 'destroy'])
             ->name('feature-selections.destroy');
 
         // Conditions
-        Route::get('conditions', [\App\Http\Controllers\Api\CharacterConditionController::class, 'index'])
+        Route::get('conditions', [CharacterConditionController::class, 'index'])
             ->name('conditions.index');
-        Route::post('conditions', [\App\Http\Controllers\Api\CharacterConditionController::class, 'store'])
+        Route::post('conditions', [CharacterConditionController::class, 'store'])
             ->name('conditions.store');
-        Route::delete('conditions/{conditionIdOrSlug}', [\App\Http\Controllers\Api\CharacterConditionController::class, 'destroy'])
+        Route::delete('conditions/{conditionIdOrSlug}', [CharacterConditionController::class, 'destroy'])
             ->name('conditions.destroy');
     });
 
@@ -451,36 +471,36 @@ Route::prefix('v1')->group(function () {
     | TODO: Re-add auth:sanctum middleware when auth is implemented.
     |
     */
-    Route::apiResource('parties', \App\Http\Controllers\Api\PartyController::class);
-    Route::post('parties/{party}/characters', [\App\Http\Controllers\Api\PartyController::class, 'addCharacter'])
+    Route::apiResource('parties', PartyController::class);
+    Route::post('parties/{party}/characters', [PartyController::class, 'addCharacter'])
         ->name('parties.characters.store');
-    Route::delete('parties/{party}/characters/{character}', [\App\Http\Controllers\Api\PartyController::class, 'removeCharacter'])
+    Route::delete('parties/{party}/characters/{character}', [PartyController::class, 'removeCharacter'])
         ->name('parties.characters.destroy');
-    Route::get('parties/{party}/stats', [\App\Http\Controllers\Api\PartyController::class, 'stats'])
+    Route::get('parties/{party}/stats', [PartyController::class, 'stats'])
         ->name('parties.stats');
 
     // Party Encounter Monsters (DM Screen initiative tracker)
-    Route::get('parties/{party}/monsters', [\App\Http\Controllers\Api\PartyEncounterMonsterController::class, 'index'])
+    Route::get('parties/{party}/monsters', [PartyEncounterMonsterController::class, 'index'])
         ->name('parties.monsters.index');
-    Route::post('parties/{party}/monsters', [\App\Http\Controllers\Api\PartyEncounterMonsterController::class, 'store'])
+    Route::post('parties/{party}/monsters', [PartyEncounterMonsterController::class, 'store'])
         ->name('parties.monsters.store');
-    Route::patch('parties/{party}/monsters/{encounterMonster}', [\App\Http\Controllers\Api\PartyEncounterMonsterController::class, 'update'])
+    Route::patch('parties/{party}/monsters/{encounterMonster}', [PartyEncounterMonsterController::class, 'update'])
         ->name('parties.monsters.update');
-    Route::delete('parties/{party}/monsters/{encounterMonster}', [\App\Http\Controllers\Api\PartyEncounterMonsterController::class, 'destroy'])
+    Route::delete('parties/{party}/monsters/{encounterMonster}', [PartyEncounterMonsterController::class, 'destroy'])
         ->name('parties.monsters.destroy');
-    Route::delete('parties/{party}/monsters', [\App\Http\Controllers\Api\PartyEncounterMonsterController::class, 'clear'])
+    Route::delete('parties/{party}/monsters', [PartyEncounterMonsterController::class, 'clear'])
         ->name('parties.monsters.clear');
 
     // Party Encounter Presets (save/load monster groups)
-    Route::get('parties/{party}/encounter-presets', [\App\Http\Controllers\Api\PartyEncounterPresetController::class, 'index'])
+    Route::get('parties/{party}/encounter-presets', [PartyEncounterPresetController::class, 'index'])
         ->name('parties.encounter-presets.index');
-    Route::post('parties/{party}/encounter-presets', [\App\Http\Controllers\Api\PartyEncounterPresetController::class, 'store'])
+    Route::post('parties/{party}/encounter-presets', [PartyEncounterPresetController::class, 'store'])
         ->name('parties.encounter-presets.store');
-    Route::patch('parties/{party}/encounter-presets/{encounterPreset}', [\App\Http\Controllers\Api\PartyEncounterPresetController::class, 'update'])
+    Route::patch('parties/{party}/encounter-presets/{encounterPreset}', [PartyEncounterPresetController::class, 'update'])
         ->name('parties.encounter-presets.update');
-    Route::delete('parties/{party}/encounter-presets/{encounterPreset}', [\App\Http\Controllers\Api\PartyEncounterPresetController::class, 'destroy'])
+    Route::delete('parties/{party}/encounter-presets/{encounterPreset}', [PartyEncounterPresetController::class, 'destroy'])
         ->name('parties.encounter-presets.destroy');
-    Route::post('parties/{party}/encounter-presets/{encounterPreset}/load', [\App\Http\Controllers\Api\PartyEncounterPresetController::class, 'load'])
+    Route::post('parties/{party}/encounter-presets/{encounterPreset}/load', [PartyEncounterPresetController::class, 'load'])
         ->name('parties.encounter-presets.load');
 
     /*

--- a/tests/Concerns/ClearsMeilisearchIndex.php
+++ b/tests/Concerns/ClearsMeilisearchIndex.php
@@ -4,6 +4,7 @@ namespace Tests\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Meilisearch\Client;
+use Meilisearch\Exceptions\ApiException;
 
 /**
  * Trait for clearing Meilisearch indexes in tests.
@@ -39,7 +40,7 @@ trait ClearsMeilisearchIndex
         try {
             $task = $client->index($indexName)->deleteAllDocuments();
             $client->waitForTask($task['taskUid'], $timeoutMs);
-        } catch (\Meilisearch\Exceptions\ApiException $e) {
+        } catch (ApiException $e) {
             // Index may not exist yet - that's fine
             if (! str_contains($e->getMessage(), 'not found')) {
                 throw $e;

--- a/tests/Concerns/WaitsForMeilisearch.php
+++ b/tests/Concerns/WaitsForMeilisearch.php
@@ -4,6 +4,8 @@ namespace Tests\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Meilisearch\Client;
+use Meilisearch\Contracts\TasksQuery;
+use Meilisearch\Exceptions\ApiException;
 
 /**
  * Trait for waiting on Meilisearch indexing operations in tests.
@@ -80,7 +82,7 @@ trait WaitsForMeilisearch
                     foreach ($expectedIds as $id) {
                         try {
                             $index->getDocument($id);
-                        } catch (\Meilisearch\Exceptions\ApiException $e) {
+                        } catch (ApiException $e) {
                             // Document not found yet
                             $allFound = false;
                             break;
@@ -126,7 +128,7 @@ trait WaitsForMeilisearch
 
             try {
                 // Get pending/processing tasks for this index using TasksQuery
-                $tasksQuery = new \Meilisearch\Contracts\TasksQuery;
+                $tasksQuery = new TasksQuery;
                 $tasksQuery->setIndexUids([$indexName]);
                 $tasksQuery->setStatuses(['enqueued', 'processing']);
 

--- a/tests/Feature/Api/AbilityScoreApiTest.php
+++ b/tests/Feature/Api/AbilityScoreApiTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\AbilityScore;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,12 +14,12 @@ use Tests\TestCase;
  *
  * These tests use LookupSeeder for stable ability score data.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class AbilityScoreApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function can_get_all_ability_scores()

--- a/tests/Feature/Api/AbilityScoreReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/AbilityScoreReverseRelationshipsApiTest.php
@@ -4,13 +4,15 @@ namespace Tests\Feature\Api;
 
 use App\Models\AbilityScore;
 use App\Models\Spell;
+use Database\Seeders\TestDatabaseSeeder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class AbilityScoreReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function it_returns_spells_for_ability_score()

--- a/tests/Feature/Api/AlignmentApiTest.php
+++ b/tests/Feature/Api/AlignmentApiTest.php
@@ -3,16 +3,18 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class AlignmentApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_can_list_all_alignments(): void

--- a/tests/Feature/Api/ArmorTypeApiTest.php
+++ b/tests/Feature/Api/ArmorTypeApiTest.php
@@ -3,16 +3,18 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ArmorTypeApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_can_list_all_armor_types(): void

--- a/tests/Feature/Api/BackgroundApiTest.php
+++ b/tests/Feature/Api/BackgroundApiTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Background;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,13 +14,13 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class BackgroundApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function can_get_all_backgrounds()

--- a/tests/Feature/Api/BackgroundFilterOperatorTest.php
+++ b/tests/Feature/Api/BackgroundFilterOperatorTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Background;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
@@ -12,20 +15,20 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class BackgroundFilterOperatorTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     // ============================================================
     // Integer Operators (id field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_equals(): void
     {
         // Arrange: Verify database has backgrounds
@@ -45,7 +48,7 @@ class BackgroundFilterOperatorTest extends TestCase
         $this->assertEquals('Acolyte', $response->json('data.0.name'), 'Should return Acolyte');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_not_equals(): void
     {
         // Arrange: Verify database has backgrounds
@@ -71,7 +74,7 @@ class BackgroundFilterOperatorTest extends TestCase
         $this->assertNotContains('Acolyte', $names, 'Acolyte should be excluded');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_greater_than(): void
     {
         // Arrange: Get backgrounds and find a mid-range ID
@@ -94,7 +97,7 @@ class BackgroundFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_greater_than_or_equal(): void
     {
         // Arrange: Get a specific background
@@ -121,7 +124,7 @@ class BackgroundFilterOperatorTest extends TestCase
         $this->assertContains($midBackground->id, $ids, 'Mid-range background should be included (>= is inclusive)');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_less_than(): void
     {
         // Arrange: Get backgrounds and find a mid-range ID
@@ -144,7 +147,7 @@ class BackgroundFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_less_than_or_equal(): void
     {
         // Arrange: Get a specific background
@@ -171,7 +174,7 @@ class BackgroundFilterOperatorTest extends TestCase
         $this->assertContains($midBackground->id, $ids, 'Mid-range background should be included (<= is inclusive)');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_to_range(): void
     {
         // Arrange: Get backgrounds and define a range
@@ -206,7 +209,7 @@ class BackgroundFilterOperatorTest extends TestCase
     // String Operators (slug field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_slug_with_equals(): void
     {
         // Arrange: Verify database has backgrounds
@@ -225,7 +228,7 @@ class BackgroundFilterOperatorTest extends TestCase
         $this->assertEquals('Acolyte', $response->json('data.0.name'), 'Should return Acolyte background');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_slug_with_not_equals(): void
     {
         // Arrange: Verify database has backgrounds
@@ -247,7 +250,7 @@ class BackgroundFilterOperatorTest extends TestCase
     // Array Operators (skill_proficiencies field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_skill_proficiencies_with_in(): void
     {
         // Acolyte has Insight and Religion proficiencies (from PHB import)
@@ -264,7 +267,7 @@ class BackgroundFilterOperatorTest extends TestCase
         $this->assertContains('Acolyte', $names, 'Acolyte grants insight and religion proficiency');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_skill_proficiencies_with_not_in(): void
     {
         // Skill slugs are stored with the "core:" prefix (see SkillSeeder).

--- a/tests/Feature/Api/BackgroundSearchTest.php
+++ b/tests/Feature/Api/BackgroundSearchTest.php
@@ -3,17 +3,20 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Background;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class BackgroundSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -21,7 +24,7 @@ class BackgroundSearchTest extends TestCase
         $this->artisan('search:configure-indexes');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_backgrounds_using_scout_when_available(): void
     {
         // Use fixture data - Acolyte and Soldier exist in TestDatabaseSeeder
@@ -35,7 +38,7 @@ class BackgroundSearchTest extends TestCase
             ->assertJsonPath('data.0.name', 'Acolyte');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_query_minimum_length(): void
     {
         $response = $this->getJson('/api/v1/backgrounds?q=a');
@@ -44,7 +47,7 @@ class BackgroundSearchTest extends TestCase
             ->assertJsonValidationErrors(['q']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_search_query_gracefully(): void
     {
         // Use fixture data - returns paginated results (default 15 per page)

--- a/tests/Feature/Api/CharacterAvailableFeatsTest.php
+++ b/tests/Feature/Api/CharacterAvailableFeatsTest.php
@@ -4,20 +4,23 @@ namespace Tests\Feature\Api;
 
 use App\Models\AbilityScore;
 use App\Models\Character;
+use App\Models\CharacterClass;
 use App\Models\Feat;
 use App\Models\ProficiencyType;
 use App\Models\Race;
 use App\Models\Skill;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class CharacterAvailableFeatsTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function character_with_no_prerequisites_gets_all_non_prerequisite_feats()
@@ -412,7 +415,7 @@ class CharacterAvailableFeatsTest extends TestCase
     {
         $character = Character::factory()->create();
 
-        $warlock = \App\Models\CharacterClass::factory()->create([
+        $warlock = CharacterClass::factory()->create([
             'name' => 'Warlock',
             'slug' => 'warlock',
         ]);
@@ -428,7 +431,7 @@ class CharacterAvailableFeatsTest extends TestCase
         // Create feat that requires Warlock class
         $feat = Feat::factory()->create(['name' => 'Eldritch Adept']);
         $feat->prerequisites()->create([
-            'prerequisite_type' => \App\Models\CharacterClass::class,
+            'prerequisite_type' => CharacterClass::class,
             'prerequisite_id' => $warlock->id,
         ]);
 
@@ -443,7 +446,7 @@ class CharacterAvailableFeatsTest extends TestCase
     {
         $character = Character::factory()->create();
 
-        $warlock = \App\Models\CharacterClass::factory()->create([
+        $warlock = CharacterClass::factory()->create([
             'name' => 'Warlock',
             'slug' => 'warlock',
         ]);
@@ -451,7 +454,7 @@ class CharacterAvailableFeatsTest extends TestCase
         // Create feat that requires Warlock class (character doesn't have it)
         $feat = Feat::factory()->create(['name' => 'Eldritch Adept']);
         $feat->prerequisites()->create([
-            'prerequisite_type' => \App\Models\CharacterClass::class,
+            'prerequisite_type' => CharacterClass::class,
             'prerequisite_id' => $warlock->id,
         ]);
 

--- a/tests/Feature/Api/CharacterEquipmentApiTest.php
+++ b/tests/Feature/Api/CharacterEquipmentApiTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature\Api;
 
 use App\Models\Character;
 use App\Models\CharacterEquipment;
+use App\Models\DamageType;
 use App\Models\Item;
+use App\Models\ItemProperty;
 use App\Models\ItemType;
 use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -619,7 +621,7 @@ class CharacterEquipmentApiTest extends TestCase
 
         // Create a melee weapon with damage type and versatile damage
         $meleeType = ItemType::where('code', 'M')->first();
-        $slashingType = \App\Models\DamageType::firstOrCreate(['name' => 'Slashing'], ['slug' => 'slashing']);
+        $slashingType = DamageType::firstOrCreate(['name' => 'Slashing'], ['slug' => 'slashing']);
 
         $longsword = Item::create([
             'name' => 'Test Longsword',
@@ -633,7 +635,7 @@ class CharacterEquipmentApiTest extends TestCase
         ]);
 
         // Attach properties (Versatile)
-        $versatileProperty = \App\Models\ItemProperty::firstOrCreate(
+        $versatileProperty = ItemProperty::firstOrCreate(
             ['code' => 'V'],
             ['name' => 'Versatile', 'description' => 'Can be used two-handed']
         );
@@ -663,7 +665,7 @@ class CharacterEquipmentApiTest extends TestCase
         $character = Character::factory()->create();
 
         $rangedType = ItemType::where('code', 'R')->first();
-        $piercingType = \App\Models\DamageType::firstOrCreate(['name' => 'Piercing'], ['slug' => 'piercing']);
+        $piercingType = DamageType::firstOrCreate(['name' => 'Piercing'], ['slug' => 'piercing']);
 
         $longbow = Item::create([
             'name' => 'Test Longbow',
@@ -784,7 +786,7 @@ class CharacterEquipmentApiTest extends TestCase
         $character = Character::factory()->create();
 
         $meleeType = ItemType::where('code', 'M')->first();
-        $slashingType = \App\Models\DamageType::firstOrCreate(['name' => 'Slashing'], ['slug' => 'slashing']);
+        $slashingType = DamageType::firstOrCreate(['name' => 'Slashing'], ['slug' => 'slashing']);
 
         $magicSword = Item::create([
             'name' => '+1 Longsword',

--- a/tests/Feature/Api/CharacterExportApiTest.php
+++ b/tests/Feature/Api/CharacterExportApiTest.php
@@ -6,10 +6,13 @@ use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
 use App\Models\CharacterCondition;
 use App\Models\CharacterEquipment;
+use App\Models\CharacterFeature;
 use App\Models\CharacterLanguage;
 use App\Models\CharacterNote;
 use App\Models\CharacterProficiency;
 use App\Models\CharacterSpell;
+use App\Models\CharacterTrait;
+use App\Models\ClassFeature;
 use App\Models\Condition;
 use App\Models\FeatureSelection;
 use App\Models\Item;
@@ -357,7 +360,7 @@ describe('Character Export', function () {
         $class = CharacterClass::factory()->create(['slug' => 'phb:barbarian', 'name' => 'Barbarian']);
 
         // Create a class feature with limited uses (like Rage)
-        $classFeature = \App\Models\ClassFeature::create([
+        $classFeature = ClassFeature::create([
             'class_id' => $class->id,
             'feature_name' => 'Rage',
             'level' => 1,
@@ -366,7 +369,7 @@ describe('Character Export', function () {
         ]);
 
         // Create the character feature link with uses tracking
-        \App\Models\CharacterFeature::create([
+        CharacterFeature::create([
             'character_id' => $character->id,
             'feature_type' => 'App\\Models\\ClassFeature',
             'feature_id' => $classFeature->id,
@@ -1124,7 +1127,7 @@ describe('Feature Export', function () {
         $race = Race::factory()->create(['slug' => 'test:dhampir', 'name' => 'Dhampir']);
 
         // Create a trait attached to the race
-        $trait = \App\Models\CharacterTrait::create([
+        $trait = CharacterTrait::create([
             'reference_type' => 'App\\Models\\Race',
             'reference_id' => $race->id,
             'name' => 'Vampiric Bite',
@@ -1137,7 +1140,7 @@ describe('Feature Export', function () {
         ]);
 
         // Link the trait to the character
-        \App\Models\CharacterFeature::create([
+        CharacterFeature::create([
             'character_id' => $character->id,
             'feature_type' => 'App\\Models\\CharacterTrait',
             'feature_id' => $trait->id,
@@ -1165,7 +1168,7 @@ describe('Feature Export', function () {
         $background = Background::factory()->create(['slug' => 'test:soldier', 'name' => 'Soldier']);
 
         // Create a trait attached to the background
-        $trait = \App\Models\CharacterTrait::create([
+        $trait = CharacterTrait::create([
             'reference_type' => 'App\\Models\\Background',
             'reference_id' => $background->id,
             'name' => 'Military Rank',
@@ -1178,7 +1181,7 @@ describe('Feature Export', function () {
         ]);
 
         // Link the trait to the character
-        \App\Models\CharacterFeature::create([
+        CharacterFeature::create([
             'character_id' => $character->id,
             'feature_type' => 'App\\Models\\CharacterTrait',
             'feature_id' => $trait->id,
@@ -1205,7 +1208,7 @@ describe('Feature Export', function () {
         $class = CharacterClass::factory()->create(['slug' => 'test:warlock', 'name' => 'Warlock']);
 
         // Create a trait attached to the race (simulating what would exist in DB)
-        $trait = \App\Models\CharacterTrait::create([
+        $trait = CharacterTrait::create([
             'reference_type' => 'App\\Models\\Race',
             'reference_id' => $race->id,
             'name' => 'Hellish Resistance',
@@ -1275,7 +1278,7 @@ describe('Feature Export', function () {
         $class = CharacterClass::factory()->create(['slug' => 'test:paladin', 'name' => 'Paladin']);
 
         // Create a trait attached to the race
-        $trait = \App\Models\CharacterTrait::create([
+        $trait = CharacterTrait::create([
             'reference_type' => 'App\\Models\\Race',
             'reference_id' => $race->id,
             'name' => 'Breath Weapon',
@@ -1297,7 +1300,7 @@ describe('Feature Export', function () {
             'is_primary' => true,
         ]);
 
-        \App\Models\CharacterFeature::create([
+        CharacterFeature::create([
             'character_id' => $character->id,
             'feature_type' => 'App\\Models\\CharacterTrait',
             'feature_id' => $trait->id,

--- a/tests/Feature/Api/CharacterMulticlassApiTest.php
+++ b/tests/Feature/Api/CharacterMulticlassApiTest.php
@@ -6,6 +6,7 @@ use App\Models\AbilityScore;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
+use App\Models\ClassFeature;
 use App\Models\Proficiency;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -380,7 +381,7 @@ class CharacterMulticlassApiTest extends TestCase
         ]);
 
         // Create subclass feature at level 3 to set the subclass_level
-        \App\Models\ClassFeature::factory()->create([
+        ClassFeature::factory()->create([
             'class_id' => $champion->id,
             'level' => 3,
             'feature_name' => 'Improved Critical',
@@ -416,7 +417,7 @@ class CharacterMulticlassApiTest extends TestCase
         ]);
 
         // Create subclass feature at level 1
-        \App\Models\ClassFeature::factory()->create([
+        ClassFeature::factory()->create([
             'class_id' => $lifeDomain->id,
             'level' => 1,
             'feature_name' => 'Disciple of Life',

--- a/tests/Feature/Api/CharacterSlugIdParameterTest.php
+++ b/tests/Feature/Api/CharacterSlugIdParameterTest.php
@@ -4,10 +4,12 @@ namespace Tests\Feature\Api;
 
 use App\Models\Character;
 use App\Models\CharacterClass;
+use App\Models\CharacterSpell;
 use App\Models\OptionalFeature;
 use App\Models\Race;
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class CharacterSlugIdParameterTest extends TestCase
@@ -50,11 +52,11 @@ class CharacterSlugIdParameterTest extends TestCase
     // CharacterSpellController Tests
     // ========================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_spell_by_id()
     {
         // Add spell to character
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $this->character->id,
             'spell_id' => $this->spell->id,
             'preparation_status' => 'known',
@@ -70,11 +72,11 @@ class CharacterSlugIdParameterTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_spell_by_slug()
     {
         // Add spell to character
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $this->character->id,
             'spell_id' => $this->spell->id,
             'preparation_status' => 'known',
@@ -90,7 +92,7 @@ class CharacterSlugIdParameterTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_for_invalid_spell_slug()
     {
         $response = $this->deleteJson("/api/v1/characters/{$this->character->id}/spells/invalid-slug");
@@ -98,7 +100,7 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertNotFound();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_for_invalid_spell_id()
     {
         $response = $this->deleteJson("/api/v1/characters/{$this->character->id}/spells/99999");
@@ -106,11 +108,11 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertNotFound();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prepares_spell_by_id()
     {
         // Add spell to character (not prepared)
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $this->character->id,
             'spell_id' => $this->spell->id,
             'preparation_status' => 'known',
@@ -123,11 +125,11 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertJsonPath('data.preparation_status', 'prepared');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prepares_spell_by_slug()
     {
         // Add spell to character (not prepared)
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $this->character->id,
             'spell_id' => $this->spell->id,
             'preparation_status' => 'known',
@@ -140,11 +142,11 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertJsonPath('data.preparation_status', 'prepared');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_unprepares_spell_by_id()
     {
         // Add spell to character (prepared)
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $this->character->id,
             'spell_id' => $this->spell->id,
             'preparation_status' => 'prepared',
@@ -157,11 +159,11 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertJsonPath('data.preparation_status', 'known');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_unprepares_spell_by_slug()
     {
         // Add spell to character (prepared)
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $this->character->id,
             'spell_id' => $this->spell->id,
             'preparation_status' => 'prepared',
@@ -178,7 +180,7 @@ class CharacterSlugIdParameterTest extends TestCase
     // CharacterClassController Tests
     // ========================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_character_class_by_id()
     {
         // Add two classes to character (need at least 2 to delete one)
@@ -201,7 +203,7 @@ class CharacterSlugIdParameterTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_character_class_by_slug()
     {
         // Add two classes to character (need at least 2 to delete one)
@@ -224,7 +226,7 @@ class CharacterSlugIdParameterTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_for_invalid_class_slug()
     {
         $response = $this->deleteJson("/api/v1/characters/{$this->character->id}/classes/invalid-slug");
@@ -232,7 +234,7 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertNotFound();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_for_invalid_class_id()
     {
         $response = $this->deleteJson("/api/v1/characters/{$this->character->id}/classes/99999");
@@ -240,7 +242,7 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertNotFound();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_levels_up_class_by_slug()
     {
         $race = Race::factory()->create();
@@ -262,7 +264,7 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertJsonPath('data.previous_level', 3);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_levels_up_class_by_slug()
     {
         $race = Race::factory()->create();
@@ -284,7 +286,7 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertJsonPath('data.previous_level', 3);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_subclass_by_id()
     {
         // Create a subclass for this class
@@ -309,7 +311,7 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertJsonPath('data.subclass.id', $subclass->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_subclass_by_slug()
     {
         // Create a subclass for this class
@@ -338,7 +340,7 @@ class CharacterSlugIdParameterTest extends TestCase
     // FeatureSelectionController Tests
     // ========================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_feature_selection_by_id()
     {
         // Add feature selection to character
@@ -356,7 +358,7 @@ class CharacterSlugIdParameterTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_feature_selection_by_slug()
     {
         // Add feature selection to character
@@ -374,7 +376,7 @@ class CharacterSlugIdParameterTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_for_invalid_feature_selection_slug()
     {
         $response = $this->deleteJson("/api/v1/characters/{$this->character->id}/feature-selections/invalid-slug");
@@ -382,7 +384,7 @@ class CharacterSlugIdParameterTest extends TestCase
         $response->assertNotFound();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_for_invalid_feature_selection_id()
     {
         $response = $this->deleteJson("/api/v1/characters/{$this->character->id}/feature-selections/99999");

--- a/tests/Feature/Api/CharacterSpellSlotConsolidationTest.php
+++ b/tests/Feature/Api/CharacterSpellSlotConsolidationTest.php
@@ -5,7 +5,9 @@ namespace Tests\Feature\Api;
 use App\Enums\SpellSlotType;
 use App\Models\Character;
 use App\Models\CharacterClass;
+use App\Models\CharacterSpell;
 use App\Models\CharacterSpellSlot;
+use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -127,9 +129,9 @@ class CharacterSpellSlotConsolidationTest extends TestCase
             ->create();
 
         // Prepare some spells
-        $spells = \App\Models\Spell::factory()->count(3)->create(['level' => 1]);
+        $spells = Spell::factory()->count(3)->create(['level' => 1]);
         foreach ($spells as $spell) {
-            \App\Models\CharacterSpell::create([
+            CharacterSpell::create([
                 'character_id' => $character->id,
                 'spell_id' => $spell->id,
                 'preparation_status' => 'prepared',

--- a/tests/Feature/Api/CharacterSpellTest.php
+++ b/tests/Feature/Api/CharacterSpellTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature\Api;
 
+use App\Enums\SpellSlotType;
+use App\Models\AbilityScore;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterSpell;
 use App\Models\CharacterSpellSlot;
+use App\Models\DamageType;
 use App\Models\Spell;
 use App\Models\SpellEffect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -212,7 +215,7 @@ class CharacterSpellTest extends TestCase
         ]);
 
         // Attach DEX saving throw
-        $dex = \App\Models\AbilityScore::where('code', 'DEX')->first();
+        $dex = AbilityScore::where('code', 'DEX')->first();
         $spell->savingThrows()->attach($dex->id, [
             'save_effect' => 'half damage',
             'is_initial_save' => true,
@@ -799,7 +802,7 @@ class CharacterSpellTest extends TestCase
             'spell_level' => 1,
             'max_slots' => 4,
             'used_slots' => 2,
-            'slot_type' => \App\Enums\SpellSlotType::STANDARD,
+            'slot_type' => SpellSlotType::STANDARD,
         ]);
 
         CharacterSpellSlot::create([
@@ -807,7 +810,7 @@ class CharacterSpellTest extends TestCase
             'spell_level' => 2,
             'max_slots' => 2,
             'used_slots' => 1,
-            'slot_type' => \App\Enums\SpellSlotType::STANDARD,
+            'slot_type' => SpellSlotType::STANDARD,
         ]);
 
         $response = $this->getJson("/api/v1/characters/{$character->id}/spell-slots");
@@ -849,7 +852,7 @@ class CharacterSpellTest extends TestCase
             'spell_level' => 3,
             'max_slots' => 2,
             'used_slots' => 1,
-            'slot_type' => \App\Enums\SpellSlotType::PACT_MAGIC,
+            'slot_type' => SpellSlotType::PACT_MAGIC,
         ]);
 
         $response = $this->getJson("/api/v1/characters/{$character->id}/spell-slots");
@@ -1295,7 +1298,7 @@ class CharacterSpellTest extends TestCase
      */
     private function createCantripScalingEffects(Spell $spell, string $damageTypeName): void
     {
-        $damageType = \App\Models\DamageType::where('name', $damageTypeName)->first();
+        $damageType = DamageType::where('name', $damageTypeName)->first();
 
         $tiers = [
             ['level' => 0, 'dice' => '1d10'],

--- a/tests/Feature/Api/CharacterStatsSpellSlotsTest.php
+++ b/tests/Feature/Api/CharacterStatsSpellSlotsTest.php
@@ -5,7 +5,9 @@ namespace Tests\Feature\Api;
 use App\Enums\SpellSlotType;
 use App\Models\Character;
 use App\Models\CharacterClass;
+use App\Models\CharacterSpell;
 use App\Models\CharacterSpellSlot;
+use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use PHPUnit\Framework\Attributes\Test;
@@ -153,9 +155,9 @@ class CharacterStatsSpellSlotsTest extends TestCase
             ->create();
 
         // Prepare some spells
-        $spells = \App\Models\Spell::factory()->count(2)->create(['level' => 1]);
+        $spells = Spell::factory()->count(2)->create(['level' => 1]);
         foreach ($spells as $spell) {
-            \App\Models\CharacterSpell::create([
+            CharacterSpell::create([
                 'character_id' => $character->id,
                 'spell_slug' => $spell->slug,
                 'preparation_status' => 'prepared',

--- a/tests/Feature/Api/CharacterSummaryTest.php
+++ b/tests/Feature/Api/CharacterSummaryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use App\Enums\SpellSlotType;
+use App\Models\AbilityScore;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
@@ -10,20 +11,24 @@ use App\Models\CharacterCondition;
 use App\Models\CharacterLanguage;
 use App\Models\CharacterSpellSlot;
 use App\Models\ClassCounter;
+use App\Models\ClassFeature;
 use App\Models\Condition;
 use App\Models\EntityChoice;
 use App\Models\Language;
 use App\Models\Modifier;
 use App\Models\Race;
 use App\Models\Size;
+use App\Models\Skill;
+use App\Services\CharacterProficiencyService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class CharacterSummaryTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_character_summary_structure()
     {
         $character = Character::factory()
@@ -69,7 +74,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_basic_character_info()
     {
         $character = Character::factory()
@@ -96,7 +101,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_calculates_pending_proficiency_choices()
     {
         $race = Race::factory()->create();
@@ -113,7 +118,7 @@ class CharacterSummaryTest extends TestCase
         $this->assertIsInt($data['pending_choices']['proficiencies']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_calculates_pending_language_choices()
     {
         $race = Race::factory()->create();
@@ -162,7 +167,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_zero_for_spell_choices_placeholder()
     {
         $character = Character::factory()->withStandardArray()->create();
@@ -179,7 +184,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_asi_choices_remaining()
     {
         $character = Character::factory()
@@ -198,7 +203,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_hit_points_state()
     {
         $character = Character::factory()
@@ -225,7 +230,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_hit_dice_state()
     {
         $character = Character::factory()->withStandardArray()->create();
@@ -253,7 +258,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_spell_slots_state()
     {
         $character = Character::factory()->withStandardArray()->create();
@@ -313,7 +318,7 @@ class CharacterSummaryTest extends TestCase
         $this->assertEquals(2, $slot2['available']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_empty_counters_for_character_without_counters()
     {
         $character = Character::factory()->withStandardArray()->create();
@@ -330,7 +335,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_active_conditions()
     {
         $character = Character::factory()->withStandardArray()->create();
@@ -357,7 +362,7 @@ class CharacterSummaryTest extends TestCase
         $this->assertContains($blinded->slug, $data['combat_state']['conditions']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_death_saves_state()
     {
         $character = Character::factory()
@@ -384,7 +389,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_determines_consciousness_based_on_hp()
     {
         $conscious = Character::factory()
@@ -405,7 +410,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJson(['data' => ['combat_state' => ['is_conscious' => false]]]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_incomplete_character_creation()
     {
         // Character missing race and ability scores
@@ -422,7 +427,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_complete_character_creation()
     {
         $race = Race::factory()->create();
@@ -444,7 +449,7 @@ class CharacterSummaryTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_shows_pending_choices_in_missing_required_when_incomplete()
     {
         $race = Race::factory()->create();
@@ -480,7 +485,7 @@ class CharacterSummaryTest extends TestCase
         $this->assertContains('language_choices', $data['missing_required']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_size_choices_for_race_with_has_size_choice()
     {
         $race = Race::factory()->create(['has_size_choice' => true]);
@@ -502,7 +507,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJsonPath('data.pending_choices.size', 1);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_zero_size_choices_when_race_has_no_size_choice()
     {
         $race = Race::factory()->create(['has_size_choice' => false]);
@@ -520,7 +525,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJsonPath('data.pending_choices.size', 0);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_zero_size_choices_when_size_already_selected()
     {
         $race = Race::factory()->create(['has_size_choice' => true]);
@@ -546,7 +551,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJsonPath('data.pending_choices.size', 0);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_size_choice_in_missing_required_when_pending()
     {
         $race = Race::factory()->create(['has_size_choice' => true]);
@@ -571,7 +576,7 @@ class CharacterSummaryTest extends TestCase
         $this->assertContains('size_choice', $data['missing_required']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_feats_choices_for_race_with_bonus_feat()
     {
         $race = Race::factory()->create();
@@ -598,7 +603,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJsonPath('data.pending_choices.feats', 1);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_zero_feats_choices_when_race_has_no_bonus_feat()
     {
         $race = Race::factory()->create();
@@ -616,7 +621,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJsonPath('data.pending_choices.feats', 0);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_feat_choices_in_missing_required_when_pending()
     {
         $race = Race::factory()->create();
@@ -646,7 +651,7 @@ class CharacterSummaryTest extends TestCase
         $this->assertContains('feat_choices', $data['missing_required']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_size_in_pending_choices_structure()
     {
         $character = Character::factory()->withStandardArray()->create();
@@ -672,9 +677,9 @@ class CharacterSummaryTest extends TestCase
     /**
      * Helper to create a skill with required ability score.
      */
-    private function createSkill(string $baseName): \App\Models\Skill
+    private function createSkill(string $baseName): Skill
     {
-        $abilityScore = \App\Models\AbilityScore::firstOrCreate(
+        $abilityScore = AbilityScore::firstOrCreate(
             ['code' => 'WIS'],
             ['name' => 'Wisdom', 'slug' => 'wisdom']
         );
@@ -682,7 +687,7 @@ class CharacterSummaryTest extends TestCase
         $uniqueId = uniqid();
         $slug = strtolower(str_replace(' ', '-', $baseName)).'-'.$uniqueId;
 
-        return \App\Models\Skill::create([
+        return Skill::create([
             'name' => $baseName.' '.$uniqueId,
             'slug' => $slug,
             'slug' => 'test:'.$slug,
@@ -693,7 +698,7 @@ class CharacterSummaryTest extends TestCase
     /**
      * Issue #480 fix: Verify subclass_feature proficiencies are counted in summary
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_counts_subclass_feature_proficiencies_in_summary()
     {
         // Create skill for choices
@@ -722,7 +727,7 @@ class CharacterSummaryTest extends TestCase
 
         // Add skill choice to the feature via EntityChoice (proficiency choices moved from entity_proficiencies)
         EntityChoice::create([
-            'reference_type' => \App\Models\ClassFeature::class,
+            'reference_type' => ClassFeature::class,
             'reference_id' => $acolyteFeature->id,
             'choice_type' => 'proficiency',
             'choice_group' => 'feature_skill_choice_1',
@@ -764,7 +769,7 @@ class CharacterSummaryTest extends TestCase
      * This test uses the CharacterProficiencyService directly instead of the HTTP API
      * to avoid URL encoding issues with the choice ID (which contains colons and pipes).
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_shows_zero_proficiencies_after_subclass_feature_choice_is_resolved()
     {
         // Create skill for choices
@@ -793,7 +798,7 @@ class CharacterSummaryTest extends TestCase
 
         // Add skill choice to the feature via EntityChoice (proficiency choices moved from entity_proficiencies)
         EntityChoice::create([
-            'reference_type' => \App\Models\ClassFeature::class,
+            'reference_type' => ClassFeature::class,
             'reference_id' => $acolyteFeature->id,
             'choice_type' => 'proficiency',
             'choice_group' => 'feature_skill_choice_1',
@@ -822,7 +827,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJson(['data' => ['pending_choices' => ['proficiencies' => 1]]]);
 
         // Resolve the choice using the service directly (avoid URL encoding issues)
-        $proficiencyService = app(\App\Services\CharacterProficiencyService::class);
+        $proficiencyService = app(CharacterProficiencyService::class);
         $fullChoiceGroup = 'Acolyte of Nature:feature_skill_choice_1';
         $proficiencyService->makeSkillChoice($character, 'subclass_feature', $fullChoiceGroup, [$nature->slug]);
 
@@ -843,7 +848,7 @@ class CharacterSummaryTest extends TestCase
     // Fighting Style & Expertise in Summary (Issue #490)
     // =====================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_fighting_style_in_pending_choices()
     {
         // Create Fighter class with "Fighting Styles Known" counter
@@ -883,7 +888,7 @@ class CharacterSummaryTest extends TestCase
             ->assertJsonPath('data.pending_choices.fighting_style', 1);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_expertise_in_pending_choices_structure()
     {
         $character = Character::factory()->withStandardArray()->create();

--- a/tests/Feature/Api/CharacterValidationApiTest.php
+++ b/tests/Feature/Api/CharacterValidationApiTest.php
@@ -10,6 +10,7 @@ use App\Models\CharacterLanguage;
 use App\Models\CharacterSpell;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 uses(TestCase::class, RefreshDatabase::class);
@@ -331,11 +332,11 @@ describe('Bulk Character Validation', function () {
         ]);
 
         // Enable query logging
-        \Illuminate\Support\Facades\DB::enableQueryLog();
+        DB::enableQueryLog();
 
         $response = $this->getJson('/api/v1/characters/validate-all');
 
-        $queryCount = count(\Illuminate\Support\Facades\DB::getQueryLog());
+        $queryCount = count(DB::getQueryLog());
 
         $response->assertOk()
             ->assertJsonPath('data.total', 50)

--- a/tests/Feature/Api/ClassApiTest.php
+++ b/tests/Feature/Api/ClassApiTest.php
@@ -3,18 +3,21 @@
 namespace Tests\Feature\Api;
 
 use App\Models\CharacterClass;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
  * These tests use fixture-based test data from TestDatabaseSeeder.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class ClassApiTest extends TestCase
 {
-    use \Illuminate\Foundation\Testing\RefreshDatabase;
+    use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function it_returns_paginated_list_of_classes()

--- a/tests/Feature/Api/ClassDetailOptimizationTest.php
+++ b/tests/Feature/Api/ClassDetailOptimizationTest.php
@@ -5,16 +5,18 @@ namespace Tests\Feature\Api;
 use App\Models\CharacterClass;
 use App\Models\ClassCounter;
 use App\Models\ClassFeature;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ClassDetailOptimizationTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function show_endpoint_returns_computed_hit_points_for_base_class(): void

--- a/tests/Feature/Api/ClassEntitySpecificFiltersApiTest.php
+++ b/tests/Feature/Api/ClassEntitySpecificFiltersApiTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\Api;
 
 use App\Models\CharacterClass;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -11,20 +14,20 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class ClassEntitySpecificFiltersApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
         parent::setUp();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_is_spellcaster_true(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=is_spellcaster = true');
@@ -38,7 +41,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_is_spellcaster_false(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=is_spellcaster = false');
@@ -52,7 +55,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_hit_die_12(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=hit_die = 12');
@@ -67,7 +70,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_hit_die_10(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=hit_die = 10');
@@ -82,7 +85,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_combined_hit_die_and_is_spellcaster(): void
     {
         // d10 spellcasters: Ranger, Paladin
@@ -99,7 +102,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_combined_hit_die_and_is_spellcaster_false(): void
     {
         // d12 non-spellcasters: Barbarian (and subclasses)
@@ -116,7 +119,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_max_spell_level(): void
     {
         // Note: Class-spell relationships are created during spell imports, not class imports.
@@ -144,7 +147,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_rejects_invalid_filter_syntax(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=invalid_field INVALID_OPERATOR value');
@@ -152,7 +155,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         $this->assertContains($response->status(), [400, 422, 500]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_valid_filter_with_multiple_conditions(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=hit_die = 6 AND is_spellcaster = true');
@@ -161,7 +164,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         $response->assertJsonStructure(['data', 'links', 'meta']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_is_base_class_true(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=is_base_class = true');
@@ -175,7 +178,7 @@ class ClassEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_classes_by_is_base_class_false(): void
     {
         $response = $this->getJson('/api/v1/classes?filter=is_base_class = false');

--- a/tests/Feature/Api/ClassEquipmentChoicesApiTest.php
+++ b/tests/Feature/Api/ClassEquipmentChoicesApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api;
 use App\Models\CharacterClass;
 use App\Models\EntityChoice;
 use App\Models\Item;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -23,7 +24,7 @@ class ClassEquipmentChoicesApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function class_show_endpoint_returns_equipment_choices(): void

--- a/tests/Feature/Api/ClassFeatureSpellsApiTest.php
+++ b/tests/Feature/Api/ClassFeatureSpellsApiTest.php
@@ -6,6 +6,7 @@ use App\Models\CharacterClass;
 use App\Models\ClassFeature;
 use App\Models\EntitySpell;
 use App\Models\Spell;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -16,7 +17,7 @@ class ClassFeatureSpellsApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function class_api_includes_feature_spells(): void

--- a/tests/Feature/Api/ClassFilterOperatorTest.php
+++ b/tests/Feature/Api/ClassFilterOperatorTest.php
@@ -3,19 +3,22 @@
 namespace Tests\Feature\Api;
 
 use App\Models\CharacterClass;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\Feature\Api\Concerns\TestsFilterOperators;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class ClassFilterOperatorTest extends TestCase
 {
     use RefreshDatabase;
     use TestsFilterOperators;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -98,43 +101,43 @@ class ClassFilterOperatorTest extends TestCase
     // Integer Operators (hit_die field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_hit_die_with_equals(): void
     {
         $this->assertIntegerEquals();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_hit_die_with_not_equals(): void
     {
         $this->assertIntegerNotEquals();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_hit_die_with_greater_than(): void
     {
         $this->assertIntegerGreaterThan();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_hit_die_with_greater_than_or_equal(): void
     {
         $this->assertIntegerGreaterThanOrEqual();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_hit_die_with_less_than(): void
     {
         $this->assertIntegerLessThan();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_hit_die_with_less_than_or_equal(): void
     {
         $this->assertIntegerLessThanOrEqual();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_hit_die_with_to_range(): void
     {
         $this->assertIntegerToRange();
@@ -144,7 +147,7 @@ class ClassFilterOperatorTest extends TestCase
     // String Operators (spellcasting_ability field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_spellcasting_ability_with_equals(): void
     {
         // Assert: Database should have imported classes
@@ -168,7 +171,7 @@ class ClassFilterOperatorTest extends TestCase
         $this->assertContains('Wizard', $classNames, 'Wizard is an Intelligence caster');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_spellcasting_ability_with_not_equals(): void
     {
         // Assert: Database should have imported classes
@@ -202,7 +205,7 @@ class ClassFilterOperatorTest extends TestCase
     // Boolean Operators (is_base_class field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_base_class_with_equals_true(): void
     {
         $this->assertBooleanEqualsTrue();
@@ -214,7 +217,7 @@ class ClassFilterOperatorTest extends TestCase
         $this->assertContains('Fighter', $classNames, 'Fighter is a base class');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_base_class_with_equals_false(): void
     {
         $this->assertBooleanEqualsFalse();
@@ -228,7 +231,7 @@ class ClassFilterOperatorTest extends TestCase
         $this->assertGreaterThan(0, count($parentClasses), 'Should have subclasses with parent classes');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_base_class_with_not_equals_true(): void
     {
         $this->assertBooleanNotEqualsTrue();
@@ -240,7 +243,7 @@ class ClassFilterOperatorTest extends TestCase
         $this->assertNotContains('Fighter', $classNames, 'Fighter is a base class (should be excluded)');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_base_class_with_not_equals_false(): void
     {
         $this->assertBooleanNotEqualsFalse();
@@ -252,7 +255,7 @@ class ClassFilterOperatorTest extends TestCase
         $this->assertContains('Fighter', $classNames, 'Fighter is a base class');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_base_class_with_is_null(): void
     {
         $this->assertBooleanIsNull();
@@ -262,7 +265,7 @@ class ClassFilterOperatorTest extends TestCase
         $this->assertEquals(0, $response->json('meta.total'), 'IS NULL should return 0 results for properly imported data');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_base_class_with_is_not_null(): void
     {
         $this->assertBooleanIsNotNull();
@@ -272,7 +275,7 @@ class ClassFilterOperatorTest extends TestCase
         $this->assertGreaterThanOrEqual(CharacterClass::count(), $response->json('meta.total'), 'Should return all classes or more if index has stale data');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_base_class_with_not_equals(): void
     {
         // Assert: Database should have imported classes
@@ -295,19 +298,19 @@ class ClassFilterOperatorTest extends TestCase
     // Array Operators (source_codes field) - 3 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_source_codes_with_in(): void
     {
         $this->assertArrayIn();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_source_codes_with_not_in(): void
     {
         $this->assertArrayNotIn();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_source_codes_with_is_empty(): void
     {
         $this->assertArrayIsEmpty();

--- a/tests/Feature/Api/ClassResourceCompleteTest.php
+++ b/tests/Feature/Api/ClassResourceCompleteTest.php
@@ -9,16 +9,18 @@ use App\Models\ClassCounter;
 use App\Models\ClassFeature;
 use App\Models\ClassLevelProgression;
 use App\Models\Proficiency;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ClassResourceCompleteTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function class_resource_includes_all_new_relationships()

--- a/tests/Feature/Api/ClassSearchTest.php
+++ b/tests/Feature/Api/ClassSearchTest.php
@@ -3,17 +3,20 @@
 namespace Tests\Feature\Api;
 
 use App\Models\CharacterClass;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class ClassSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -21,7 +24,7 @@ class ClassSearchTest extends TestCase
         $this->artisan('search:configure-indexes');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_classes_using_scout_when_available(): void
     {
         // Use fixture data - Fighter and Wizard exist in TestDatabaseSeeder
@@ -35,7 +38,7 @@ class ClassSearchTest extends TestCase
             ->assertJsonPath('data.0.name', 'Fighter');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_query_minimum_length(): void
     {
         $response = $this->getJson('/api/v1/classes?q=a');
@@ -44,7 +47,7 @@ class ClassSearchTest extends TestCase
             ->assertJsonValidationErrors(['q']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_search_query_gracefully(): void
     {
         // Use fixture data - returns paginated results (default 15 per page)

--- a/tests/Feature/Api/ClassSpellListTest.php
+++ b/tests/Feature/Api/ClassSpellListTest.php
@@ -5,16 +5,18 @@ namespace Tests\Feature\Api;
 use App\Models\CharacterClass;
 use App\Models\Spell;
 use App\Models\SpellSchool;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ClassSpellListTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_returns_spells_for_a_class()

--- a/tests/Feature/Api/Concerns/ReverseRelationshipTestCase.php
+++ b/tests/Feature/Api/Concerns/ReverseRelationshipTestCase.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api\Concerns;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
 use Tests\TestCase;
 
 /**
@@ -31,7 +32,7 @@ abstract class ReverseRelationshipTestCase extends TestCase
      * @param  int  $expectedCount  Expected number of entities in response
      * @param  array  $expectedNames  Expected names in order
      */
-    protected function assertReturnsRelatedEntities(string $route, int $expectedCount, array $expectedNames = []): \Illuminate\Testing\TestResponse
+    protected function assertReturnsRelatedEntities(string $route, int $expectedCount, array $expectedNames = []): TestResponse
     {
         $response = $this->getJson($route);
 
@@ -50,7 +51,7 @@ abstract class ReverseRelationshipTestCase extends TestCase
      *
      * @param  string  $route  Full API route
      */
-    protected function assertReturnsEmpty(string $route): \Illuminate\Testing\TestResponse
+    protected function assertReturnsEmpty(string $route): TestResponse
     {
         $response = $this->getJson($route);
 
@@ -73,7 +74,7 @@ abstract class ReverseRelationshipTestCase extends TestCase
         int $expectedDataCount,
         int $expectedTotal,
         int $expectedPerPage
-    ): \Illuminate\Testing\TestResponse {
+    ): TestResponse {
         $response = $this->getJson($route);
 
         $response->assertOk()
@@ -90,7 +91,7 @@ abstract class ReverseRelationshipTestCase extends TestCase
      * @param  string  $route  Full API route using slug/code/name
      * @param  int  $expectedMinCount  Minimum expected count (use 1 for "has results")
      */
-    protected function assertAcceptsAlternativeIdentifier(string $route, int $expectedMinCount = 1): \Illuminate\Testing\TestResponse
+    protected function assertAcceptsAlternativeIdentifier(string $route, int $expectedMinCount = 1): TestResponse
     {
         $response = $this->getJson($route);
 

--- a/tests/Feature/Api/ConditionApiTest.php
+++ b/tests/Feature/Api/ConditionApiTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Api;
 
+use Database\Seeders\ConditionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ConditionApiTest extends TestCase
 {
     use RefreshDatabase;
@@ -14,7 +16,7 @@ class ConditionApiTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(\Database\Seeders\ConditionSeeder::class);
+        $this->seed(ConditionSeeder::class);
     }
 
     #[Test]

--- a/tests/Feature/Api/ConditionReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/ConditionReverseRelationshipsApiTest.php
@@ -5,10 +5,11 @@ namespace Tests\Feature\Api;
 use App\Models\Condition;
 use App\Models\Monster;
 use App\Models\Spell;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ConditionReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
     // ========================================

--- a/tests/Feature/Api/CreatureTypeApiTest.php
+++ b/tests/Feature/Api/CreatureTypeApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api;
 
+use App\Http\Controllers\Api\CreatureTypeController;
 use App\Models\CreatureType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
@@ -13,7 +14,7 @@ use Tests\TestCase;
 /**
  * Tests for CreatureTypeController.
  *
- * @see \App\Http\Controllers\Api\CreatureTypeController
+ * @see CreatureTypeController
  */
 #[Group('feature-db')]
 class CreatureTypeApiTest extends TestCase

--- a/tests/Feature/Api/DamageTypeApiTest.php
+++ b/tests/Feature/Api/DamageTypeApiTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Feature\Api;
 
+use App\Models\DamageType;
+use Database\Seeders\DamageTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class DamageTypeApiTest extends TestCase
 {
     use RefreshDatabase;
@@ -16,8 +19,8 @@ class DamageTypeApiTest extends TestCase
         parent::setUp();
 
         // Only seed if not already seeded (prevents duplicate key errors)
-        if (\App\Models\DamageType::count() === 0) {
-            $this->seed(\Database\Seeders\DamageTypeSeeder::class);
+        if (DamageType::count() === 0) {
+            $this->seed(DamageTypeSeeder::class);
         }
     }
 

--- a/tests/Feature/Api/DamageTypeReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/DamageTypeReverseRelationshipsApiTest.php
@@ -6,13 +6,15 @@ use App\Models\DamageType;
 use App\Models\Item;
 use App\Models\Spell;
 use App\Models\SpellEffect;
+use Database\Seeders\LookupSeeder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class DamageTypeReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     protected function getDamageType(string $name): DamageType
     {

--- a/tests/Feature/Api/FeatApiTest.php
+++ b/tests/Feature/Api/FeatApiTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Feat;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,13 +14,13 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class FeatApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function can_get_all_feats()

--- a/tests/Feature/Api/FeatFilterOperatorTest.php
+++ b/tests/Feature/Api/FeatFilterOperatorTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Feat;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -11,19 +14,19 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class FeatFilterOperatorTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     // ============================================================
     // Integer Operators (id field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_equals(): void
     {
         $feat = Feat::where('name', 'Alert')->first();
@@ -36,7 +39,7 @@ class FeatFilterOperatorTest extends TestCase
         $response->assertJsonPath('data.0.name', 'Alert');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_not_equals(): void
     {
         $feat = Feat::where('name', 'Alert')->first();
@@ -50,7 +53,7 @@ class FeatFilterOperatorTest extends TestCase
         $this->assertNotContains($feat->id, $returnedIds, 'Alert should not be in results');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_greater_than(): void
     {
         // Get a feat ID in the middle range
@@ -66,7 +69,7 @@ class FeatFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_greater_than_or_equal(): void
     {
         $feats = Feat::orderBy('id')->get();
@@ -81,7 +84,7 @@ class FeatFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_less_than(): void
     {
         $feats = Feat::orderBy('id')->get();
@@ -96,7 +99,7 @@ class FeatFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_less_than_or_equal(): void
     {
         $feats = Feat::orderBy('id')->get();
@@ -111,7 +114,7 @@ class FeatFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_id_with_to_range(): void
     {
         $feats = Feat::orderBy('id')->get();
@@ -132,7 +135,7 @@ class FeatFilterOperatorTest extends TestCase
     // String Operators (slug field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_slug_with_equals(): void
     {
         $response = $this->getJson('/api/v1/feats?filter=slug = "phb:alert"');
@@ -142,7 +145,7 @@ class FeatFilterOperatorTest extends TestCase
         $response->assertJsonPath('data.0.name', 'Alert');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_slug_with_not_equals(): void
     {
         $response = $this->getJson('/api/v1/feats?filter=slug != "phb:alert"');
@@ -157,7 +160,7 @@ class FeatFilterOperatorTest extends TestCase
     // Boolean Operators (has_prerequisites field) - 4 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_prerequisites_with_equals_true(): void
     {
         $response = $this->getJson('/api/v1/feats?filter=has_prerequisites = true');
@@ -171,7 +174,7 @@ class FeatFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_prerequisites_with_equals_false(): void
     {
         $response = $this->getJson('/api/v1/feats?filter=has_prerequisites = false');
@@ -184,7 +187,7 @@ class FeatFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_prerequisites_with_not_equals_true(): void
     {
         // != true should return feats without prerequisites
@@ -198,7 +201,7 @@ class FeatFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_prerequisites_with_not_equals_false(): void
     {
         // != false should return feats with prerequisites
@@ -217,7 +220,7 @@ class FeatFilterOperatorTest extends TestCase
     // Skipped: No imported feats have tags in the test data
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_tag_slugs_with_in(): void
     {
         // PHB feats don't have tags, so we verify the filter returns empty
@@ -227,7 +230,7 @@ class FeatFilterOperatorTest extends TestCase
         $this->assertEquals(0, $response->json('meta.total'), 'No imported feats have tags');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_tag_slugs_with_not_in(): void
     {
         // All feats have no tags, so NOT IN [combat] returns all feats

--- a/tests/Feature/Api/FeatFilterTest.php
+++ b/tests/Feature/Api/FeatFilterTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Feat;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,13 +14,13 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class FeatFilterTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function it_filters_feats_by_has_prerequisites()

--- a/tests/Feature/Api/FeatPrerequisitesApiTest.php
+++ b/tests/Feature/Api/FeatPrerequisitesApiTest.php
@@ -7,16 +7,18 @@ use App\Models\CharacterClass;
 use App\Models\Feat;
 use App\Models\Race;
 use App\Models\Skill;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class FeatPrerequisitesApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function feat_includes_ability_score_prerequisite_in_response()

--- a/tests/Feature/Api/FeatSearchTest.php
+++ b/tests/Feature/Api/FeatSearchTest.php
@@ -3,17 +3,20 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Feat;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class FeatSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -21,7 +24,7 @@ class FeatSearchTest extends TestCase
         $this->artisan('search:configure-indexes');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_feats_using_scout_when_available(): void
     {
         // Use fixture data - Alert exists in TestDatabaseSeeder
@@ -35,7 +38,7 @@ class FeatSearchTest extends TestCase
             ->assertJsonPath('data.0.name', 'Alert');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_query_minimum_length(): void
     {
         $response = $this->getJson('/api/v1/feats?q=a');
@@ -44,7 +47,7 @@ class FeatSearchTest extends TestCase
             ->assertJsonValidationErrors(['q']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_search_query_gracefully(): void
     {
         // Use fixture data - returns paginated results (default 15 per page)

--- a/tests/Feature/Api/GlobalSearchTest.php
+++ b/tests/Feature/Api/GlobalSearchTest.php
@@ -4,17 +4,20 @@ namespace Tests\Feature\Api;
 
 use App\Models\Item;
 use App\Models\Spell;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class GlobalSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -22,7 +25,7 @@ class GlobalSearchTest extends TestCase
         $this->artisan('search:configure-indexes');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_across_all_entity_types(): void
     {
         Spell::factory()->create(['name' => 'Fireball']);
@@ -45,7 +48,7 @@ class GlobalSearchTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_entity_types(): void
     {
         Spell::factory()->create(['name' => 'Fireball']);
@@ -63,7 +66,7 @@ class GlobalSearchTest extends TestCase
             ->assertJsonPath('data.items', []);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_query_required(): void
     {
         $response = $this->getJson('/api/v1/search');
@@ -72,7 +75,7 @@ class GlobalSearchTest extends TestCase
             ->assertJsonValidationErrors(['q']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_supports_debug_mode(): void
     {
         $spell = Spell::factory()->create(['name' => 'Fireball']);
@@ -89,7 +92,7 @@ class GlobalSearchTest extends TestCase
             ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_query_minimum_length(): void
     {
         $response = $this->getJson('/api/v1/search?q=a');

--- a/tests/Feature/Api/ItemFilterOperatorTest.php
+++ b/tests/Feature/Api/ItemFilterOperatorTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Item;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\ClearsMeilisearchIndex;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
@@ -15,15 +18,15 @@ use Tests\TestCase;
  *
  * Run: docker compose exec php php artisan test --testsuite=Feature-Search-Isolated
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class ItemFilterOperatorTest extends TestCase
 {
     use ClearsMeilisearchIndex;
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private static bool $indexed = false;
 
@@ -49,11 +52,11 @@ class ItemFilterOperatorTest extends TestCase
     // Integer Operators (charges_max field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_charges_max_with_equals(): void
     {
         // Find an item with charges_max from the database
-        $itemWithCharges = \App\Models\Item::whereNotNull('charges_max')->first();
+        $itemWithCharges = Item::whereNotNull('charges_max')->first();
 
         if (! $itemWithCharges) {
             $this->markTestSkipped('No items with charges_max in fixtures');
@@ -70,7 +73,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_charges_max_with_not_equals(): void
     {
         $response = $this->getJson('/api/v1/items?filter=charges_max != "7"');
@@ -82,7 +85,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_charges_max_with_greater_than(): void
     {
         $response = $this->getJson('/api/v1/items?filter=charges_max > "5"&per_page=100');
@@ -97,7 +100,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_charges_max_with_greater_than_or_equal(): void
     {
         $response = $this->getJson('/api/v1/items?filter=charges_max >= "7"&per_page=100');
@@ -112,7 +115,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_charges_max_with_less_than(): void
     {
         $response = $this->getJson('/api/v1/items?filter=charges_max < "5"&per_page=100');
@@ -127,7 +130,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_charges_max_with_less_than_or_equal(): void
     {
         $response = $this->getJson('/api/v1/items?filter=charges_max <= "3"&per_page=100');
@@ -142,7 +145,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_charges_max_with_to_range(): void
     {
         $response = $this->getJson('/api/v1/items?filter=charges_max "3" TO "7"&per_page=100');
@@ -163,7 +166,7 @@ class ItemFilterOperatorTest extends TestCase
     // String Operators (rarity field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_rarity_with_equals(): void
     {
         $response = $this->getJson('/api/v1/items?filter=rarity = rare&per_page=100');
@@ -176,7 +179,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_rarity_with_not_equals(): void
     {
         $response = $this->getJson('/api/v1/items?filter=rarity != rare');
@@ -196,7 +199,7 @@ class ItemFilterOperatorTest extends TestCase
     // Boolean Operators (is_magic field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_magic_with_equals_true(): void
     {
         $response = $this->getJson('/api/v1/items?filter=is_magic = true&per_page=100');
@@ -209,7 +212,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_magic_with_equals_false(): void
     {
         $response = $this->getJson('/api/v1/items?filter=is_magic = false&per_page=100');
@@ -221,7 +224,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_magic_with_not_equals_true(): void
     {
         $response = $this->getJson('/api/v1/items?filter=is_magic != true');
@@ -233,7 +236,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_magic_with_not_equals_false(): void
     {
         $response = $this->getJson('/api/v1/items?filter=is_magic != false');
@@ -246,7 +249,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_magic_with_is_null(): void
     {
         $response = $this->getJson('/api/v1/items?filter=is_magic IS NULL');
@@ -260,7 +263,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_magic_with_is_not_null(): void
     {
         $response = $this->getJson('/api/v1/items?filter=is_magic IS NOT NULL');
@@ -274,7 +277,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_is_magic_with_not_equals(): void
     {
         $response = $this->getJson('/api/v1/items?filter=is_magic != true');
@@ -290,7 +293,7 @@ class ItemFilterOperatorTest extends TestCase
     // Array Operators (property_codes field) - 3 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_property_codes_with_in(): void
     {
         $response = $this->getJson('/api/v1/items?filter=property_codes IN [V, L]&per_page=100');
@@ -308,7 +311,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_property_codes_with_not_in(): void
     {
         $response = $this->getJson('/api/v1/items?filter=property_codes NOT IN [H]&per_page=100');
@@ -324,7 +327,7 @@ class ItemFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_property_codes_with_is_empty(): void
     {
         $response = $this->getJson('/api/v1/items?filter=property_codes IS EMPTY&per_page=100');

--- a/tests/Feature/Api/ItemFilterTest.php
+++ b/tests/Feature/Api/ItemFilterTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Item;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,13 +14,13 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class ItemFilterTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function it_filters_items_by_minimum_strength_requirement()

--- a/tests/Feature/Api/ItemPrerequisitesApiTest.php
+++ b/tests/Feature/Api/ItemPrerequisitesApiTest.php
@@ -6,17 +6,20 @@ use App\Models\AbilityScore;
 use App\Models\EntityPrerequisite;
 use App\Models\Item;
 use App\Models\ItemType;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ItemPrerequisitesApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_prerequisites_in_item_show_response()
     {
         // Arrange: Create item with strength requirement prerequisite
@@ -76,7 +79,7 @@ class ItemPrerequisitesApiTest extends TestCase
             ->assertJsonPath('data.prerequisites.0.group_id', 1);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_prerequisites_in_item_index_response()
     {
         // Arrange: Create items with and without prerequisites
@@ -141,7 +144,7 @@ class ItemPrerequisitesApiTest extends TestCase
         $this->assertCount(0, $leatherData['prerequisites']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_empty_prerequisites_array_for_items_without_requirements()
     {
         // Arrange: Create item without prerequisites
@@ -167,7 +170,7 @@ class ItemPrerequisitesApiTest extends TestCase
             ->assertJsonCount(0, 'data.prerequisites');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_eager_loads_prerequisites_to_avoid_n_plus_1_queries()
     {
         // Arrange: Create multiple items with prerequisites

--- a/tests/Feature/Api/ItemPropertyApiTest.php
+++ b/tests/Feature/Api/ItemPropertyApiTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Api;
 
+use Database\Seeders\ItemPropertySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ItemPropertyApiTest extends TestCase
 {
     use RefreshDatabase;
@@ -14,7 +16,7 @@ class ItemPropertyApiTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(\Database\Seeders\ItemPropertySeeder::class);
+        $this->seed(ItemPropertySeeder::class);
     }
 
     #[Test]

--- a/tests/Feature/Api/ItemSearchTest.php
+++ b/tests/Feature/Api/ItemSearchTest.php
@@ -4,17 +4,20 @@ namespace Tests\Feature\Api;
 
 use App\Models\Item;
 use App\Models\ItemType;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class ItemSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -22,7 +25,7 @@ class ItemSearchTest extends TestCase
         $this->artisan('search:configure-indexes');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_items_using_scout(): void
     {
         $type = ItemType::factory()->create(['name' => 'Weapon']);
@@ -40,7 +43,7 @@ class ItemSearchTest extends TestCase
             ->assertJsonPath('data.0.name', 'Longsword');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_query_minimum_length(): void
     {
         $response = $this->getJson('/api/v1/items?q=a');
@@ -49,7 +52,7 @@ class ItemSearchTest extends TestCase
             ->assertJsonValidationErrors(['q']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_search_gracefully(): void
     {
         Item::factory()->count(3)->create();

--- a/tests/Feature/Api/ItemSpellsApiTest.php
+++ b/tests/Feature/Api/ItemSpellsApiTest.php
@@ -2,18 +2,21 @@
 
 namespace Tests\Feature\Api;
 
+use App\Http\Resources\ItemResource;
 use App\Models\Item;
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ItemSpellsApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_serializes_spells_with_charge_costs_correctly()
     {
         // Create item and spell
@@ -42,7 +45,7 @@ class ItemSpellsApiTest extends TestCase
 
         // Load spells relationship and serialize
         $staff->load('spells');
-        $resource = new \App\Http\Resources\ItemResource($staff);
+        $resource = new ItemResource($staff);
         $response = $resource->toArray(request());
 
         $this->assertEquals('Staff of Testing', $response['name']);
@@ -58,7 +61,7 @@ class ItemSpellsApiTest extends TestCase
         $this->assertEquals('1 per spell level', $spells[0]['charges_cost_formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_empty_spells_array_for_items_without_spells()
     {
         $wand = Item::factory()->create([
@@ -68,7 +71,7 @@ class ItemSpellsApiTest extends TestCase
         ]);
 
         $wand->load('spells');
-        $resource = new \App\Http\Resources\ItemResource($wand);
+        $resource = new ItemResource($wand);
         $response = $resource->toArray(request());
 
         $this->assertEquals('Wand of Testing', $response['name']);

--- a/tests/Feature/Api/ItemTypeApiTest.php
+++ b/tests/Feature/Api/ItemTypeApiTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Api;
 
+use Database\Seeders\ItemTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ItemTypeApiTest extends TestCase
 {
     use RefreshDatabase;
@@ -14,7 +16,7 @@ class ItemTypeApiTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(\Database\Seeders\ItemTypeSeeder::class);
+        $this->seed(ItemTypeSeeder::class);
     }
 
     #[Test]

--- a/tests/Feature/Api/LanguageApiTest.php
+++ b/tests/Feature/Api/LanguageApiTest.php
@@ -3,11 +3,13 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Language;
+use Database\Seeders\LanguageSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class LanguageApiTest extends TestCase
 {
     use RefreshDatabase;
@@ -15,7 +17,7 @@ class LanguageApiTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(\Database\Seeders\LanguageSeeder::class);
+        $this->seed(LanguageSeeder::class);
     }
 
     #[Test]

--- a/tests/Feature/Api/LanguageReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/LanguageReverseRelationshipsApiTest.php
@@ -5,13 +5,15 @@ namespace Tests\Feature\Api;
 use App\Models\Background;
 use App\Models\Language;
 use App\Models\Race;
+use Database\Seeders\LookupSeeder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class LanguageReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_returns_races_for_language()

--- a/tests/Feature/Api/MonsterApiTest.php
+++ b/tests/Feature/Api/MonsterApiTest.php
@@ -3,18 +3,21 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
  * These tests use fixture-based test data from TestDatabaseSeeder.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class MonsterApiTest extends TestCase
 {
-    use \Illuminate\Foundation\Testing\RefreshDatabase;
+    use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function can_get_all_monsters()

--- a/tests/Feature/Api/MonsterEnhancedFilteringApiTest.php
+++ b/tests/Feature/Api/MonsterEnhancedFilteringApiTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -31,13 +33,13 @@ use Tests\TestCase;
  *
  * See MonsterController PHPDoc for comprehensive filter examples.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class MonsterEnhancedFilteringApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {

--- a/tests/Feature/Api/MonsterFilterOperatorTest.php
+++ b/tests/Feature/Api/MonsterFilterOperatorTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\TestsFilterOperators;
 use Tests\TestCase;
 
@@ -12,14 +15,14 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class MonsterFilterOperatorTest extends TestCase
 {
     use RefreshDatabase;
     use TestsFilterOperators;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     // ============================================================
     // Entity-Specific Configuration
@@ -97,43 +100,43 @@ class MonsterFilterOperatorTest extends TestCase
     // Integer Operators (challenge_rating field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_challenge_rating_with_equals(): void
     {
         $this->assertIntegerEquals();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_challenge_rating_with_not_equals(): void
     {
         $this->assertIntegerNotEquals();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_challenge_rating_with_greater_than(): void
     {
         $this->assertIntegerGreaterThan();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_challenge_rating_with_greater_than_or_equal(): void
     {
         $this->assertIntegerGreaterThanOrEqual();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_challenge_rating_with_less_than(): void
     {
         $this->assertIntegerLessThan();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_challenge_rating_with_less_than_or_equal(): void
     {
         $this->assertIntegerLessThanOrEqual();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_challenge_rating_with_to_range(): void
     {
         // Override to use better range for monsters (5-10 instead of trait defaults)
@@ -153,7 +156,7 @@ class MonsterFilterOperatorTest extends TestCase
     // String Operators (slug field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_slug_with_equals(): void
     {
         $config = $this->getStringFieldConfig();
@@ -168,7 +171,7 @@ class MonsterFilterOperatorTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $response->json('meta.total'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_slug_with_not_equals(): void
     {
         $config = $this->getStringFieldConfig();
@@ -188,25 +191,25 @@ class MonsterFilterOperatorTest extends TestCase
     // Boolean Operators (has_legendary_actions field) - 4 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_legendary_actions_with_equals_true(): void
     {
         $this->assertBooleanEqualsTrue();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_legendary_actions_with_equals_false(): void
     {
         $this->assertBooleanEqualsFalse();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_legendary_actions_with_not_equals_true(): void
     {
         $this->assertBooleanNotEqualsTrue();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_legendary_actions_with_not_equals_false(): void
     {
         $this->assertBooleanNotEqualsFalse();
@@ -216,7 +219,7 @@ class MonsterFilterOperatorTest extends TestCase
     // Array Operators (source_codes field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_source_codes_with_in(): void
     {
         $config = $this->getArrayFieldConfig();
@@ -227,7 +230,7 @@ class MonsterFilterOperatorTest extends TestCase
         $this->assertArrayIn();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_source_codes_with_not_in(): void
     {
         $config = $this->getArrayFieldConfig();

--- a/tests/Feature/Api/MonsterLanguagesTest.php
+++ b/tests/Feature/Api/MonsterLanguagesTest.php
@@ -3,16 +3,18 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class MonsterLanguagesTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function monster_includes_languages_in_response(): void

--- a/tests/Feature/Api/MonsterSearchTest.php
+++ b/tests/Feature/Api/MonsterSearchTest.php
@@ -3,18 +3,20 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class MonsterSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {

--- a/tests/Feature/Api/MonsterTypeApiTest.php
+++ b/tests/Feature/Api/MonsterTypeApiTest.php
@@ -3,16 +3,18 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Monster;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class MonsterTypeApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_can_list_all_monster_types(): void

--- a/tests/Feature/Api/OptionalFeatureApiTest.php
+++ b/tests/Feature/Api/OptionalFeatureApiTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature\Api;
 
 use App\Models\CharacterClass;
 use App\Models\OptionalFeature;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -13,13 +15,13 @@ use Tests\TestCase;
  *
  * These tests use fixture data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class OptionalFeatureApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function can_get_all_optional_features(): void

--- a/tests/Feature/Api/OptionalFeatureFilterOperatorTest.php
+++ b/tests/Feature/Api/OptionalFeatureFilterOperatorTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\OptionalFeature;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,13 +14,13 @@ use Tests\TestCase;
  *
  * These tests use fixture data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class OptionalFeatureFilterOperatorTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     // ============================================================
     // Integer Operators (id field) - 7 tests

--- a/tests/Feature/Api/OptionalFeatureSearchTest.php
+++ b/tests/Feature/Api/OptionalFeatureSearchTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\OptionalFeature;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
@@ -13,13 +15,13 @@ use Tests\TestCase;
  *
  * These tests use fixture data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class OptionalFeatureSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {

--- a/tests/Feature/Api/OptionalFeatureTypeApiTest.php
+++ b/tests/Feature/Api/OptionalFeatureTypeApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Api;
 
 use App\Enums\OptionalFeatureType;
+use App\Http\Controllers\Api\OptionalFeatureTypeController;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -13,7 +14,7 @@ use Tests\TestCase;
 /**
  * Tests for OptionalFeatureTypeController.
  *
- * @see \App\Http\Controllers\Api\OptionalFeatureTypeController
+ * @see OptionalFeatureTypeController
  */
 #[Group('feature-db')]
 class OptionalFeatureTypeApiTest extends TestCase

--- a/tests/Feature/Api/ParentRelationshipTest.php
+++ b/tests/Feature/Api/ParentRelationshipTest.php
@@ -4,7 +4,10 @@ namespace Tests\Feature\Api;
 
 use App\Models\CharacterClass;
 use App\Models\Race;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -12,17 +15,17 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class ParentRelationshipTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     // ==================== RACE TESTS ====================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function race_index_returns_parent_race_with_minimal_data(): void
     {
         // Find a subrace from imported data (e.g., High Elf)
@@ -51,7 +54,7 @@ class ParentRelationshipTest extends TestCase
         $this->assertArrayNotHasKey('subraces', $subraceData['parent_race']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function race_show_returns_parent_race_with_full_relationships(): void
     {
         // Find a subrace from imported data that has a parent with traits
@@ -84,7 +87,7 @@ class ParentRelationshipTest extends TestCase
         $this->assertIsArray($data['parent_race']['traits']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function race_search_returns_parent_race(): void
     {
         // Find a subrace from imported data
@@ -108,7 +111,7 @@ class ParentRelationshipTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function race_index_with_base_race_has_null_parent(): void
     {
         // Find a base race from imported data (has no parent_race_id)
@@ -132,7 +135,7 @@ class ParentRelationshipTest extends TestCase
 
     // ==================== CLASS TESTS ====================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function class_index_returns_parent_class_with_minimal_data(): void
     {
         // Find a subclass from imported data
@@ -161,7 +164,7 @@ class ParentRelationshipTest extends TestCase
         $this->assertArrayNotHasKey('subclasses', $subclassData['parent_class']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function class_show_returns_parent_class_with_full_relationships(): void
     {
         // Find a subclass from imported data that has a parent with features
@@ -194,7 +197,7 @@ class ParentRelationshipTest extends TestCase
         $this->assertIsArray($data['parent_class']['features']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function class_search_returns_parent_class(): void
     {
         // Find a subclass from imported data
@@ -219,7 +222,7 @@ class ParentRelationshipTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function class_index_with_base_class_has_null_parent(): void
     {
         // Find a base class from imported data (has no parent_class_id)

--- a/tests/Feature/Api/PartyApiTest.php
+++ b/tests/Feature/Api/PartyApiTest.php
@@ -3,7 +3,24 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Character;
+use App\Models\CharacterClass;
+use App\Models\CharacterClassPivot;
+use App\Models\CharacterCondition;
+use App\Models\CharacterCounter;
+use App\Models\CharacterEquipment;
+use App\Models\CharacterLanguage;
+use App\Models\CharacterProficiency;
+use App\Models\CharacterSpell;
+use App\Models\EntitySense;
+use App\Models\Item;
+use App\Models\ItemType;
+use App\Models\Language;
 use App\Models\Party;
+use App\Models\ProficiencyType;
+use App\Models\Race;
+use App\Models\Sense;
+use App\Models\Size;
+use App\Models\Spell;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
@@ -471,7 +488,7 @@ class PartyApiTest extends TestCase
         $character = Character::factory()->create();
 
         // Add a condition to the character
-        \App\Models\CharacterCondition::factory()->create([
+        CharacterCondition::factory()->create([
             'character_id' => $character->id,
             'condition_slug' => 'poisoned',
             'level' => null,
@@ -564,7 +581,7 @@ class PartyApiTest extends TestCase
         $party = Party::factory()->create(['user_id' => $user->id]);
 
         // Create a race with multiple speeds
-        $race = \App\Models\Race::factory()->create([
+        $race = Race::factory()->create([
             'speed' => 30,
             'fly_speed' => 50,
             'swim_speed' => null,
@@ -637,13 +654,13 @@ class PartyApiTest extends TestCase
         $party = Party::factory()->create(['user_id' => $user->id]);
 
         // Create a race with darkvision
-        $race = \App\Models\Race::factory()->create();
-        $sense = \App\Models\Sense::firstOrCreate(
+        $race = Race::factory()->create();
+        $sense = Sense::firstOrCreate(
             ['slug' => 'core:darkvision'],
             ['name' => 'Darkvision']
         );
-        \App\Models\EntitySense::create([
-            'reference_type' => \App\Models\Race::class,
+        EntitySense::create([
+            'reference_type' => Race::class,
             'reference_id' => $race->id,
             'sense_id' => $sense->id,
             'range_feet' => 60,
@@ -682,21 +699,21 @@ class PartyApiTest extends TestCase
 
         // Add languages with unique names for test isolation
         $uniqueId = uniqid();
-        $common = \App\Models\Language::create([
+        $common = Language::create([
             'slug' => 'test:common-'.$uniqueId,
             'name' => 'Common '.$uniqueId,
         ]);
-        $elvish = \App\Models\Language::create([
+        $elvish = Language::create([
             'slug' => 'test:elvish-'.$uniqueId,
             'name' => 'Elvish '.$uniqueId,
         ]);
 
-        \App\Models\CharacterLanguage::create([
+        CharacterLanguage::create([
             'character_id' => $character->id,
             'language_slug' => $common->slug,
             'source' => 'race',
         ]);
-        \App\Models\CharacterLanguage::create([
+        CharacterLanguage::create([
             'character_id' => $character->id,
             'language_slug' => $elvish->slug,
             'source' => 'race',
@@ -720,11 +737,11 @@ class PartyApiTest extends TestCase
         $user = User::factory()->create();
         $party = Party::factory()->create(['user_id' => $user->id]);
 
-        $size = \App\Models\Size::firstOrCreate(
+        $size = Size::firstOrCreate(
             ['code' => 'M'],
             ['name' => 'Medium']
         );
-        $race = \App\Models\Race::factory()->create(['size_id' => $size->id]);
+        $race = Race::factory()->create(['size_id' => $size->id]);
 
         $character = Character::factory()->create(['race_slug' => $race->slug]);
         $party->characters()->attach($character);
@@ -744,21 +761,21 @@ class PartyApiTest extends TestCase
         $character = Character::factory()->create();
 
         // Create tool proficiencies
-        $smithsTools = \App\Models\ProficiencyType::firstOrCreate(
+        $smithsTools = ProficiencyType::firstOrCreate(
             ['slug' => 'core:smiths-tools'],
             ['name' => "Smith's Tools", 'category' => 'tool']
         );
-        $thievesTools = \App\Models\ProficiencyType::firstOrCreate(
+        $thievesTools = ProficiencyType::firstOrCreate(
             ['slug' => 'core:thieves-tools'],
             ['name' => "Thieves' Tools", 'category' => 'tool']
         );
 
-        \App\Models\CharacterProficiency::create([
+        CharacterProficiency::create([
             'character_id' => $character->id,
             'proficiency_type_slug' => $smithsTools->slug,
             'source' => 'background',
         ]);
-        \App\Models\CharacterProficiency::create([
+        CharacterProficiency::create([
             'character_id' => $character->id,
             'proficiency_type_slug' => $thievesTools->slug,
             'source' => 'class',
@@ -790,17 +807,17 @@ class PartyApiTest extends TestCase
         $char2 = Character::factory()->create();
 
         $uniqueId = uniqid();
-        $common = \App\Models\Language::create(['slug' => 'test:common-agg-'.$uniqueId, 'name' => 'Common '.$uniqueId]);
-        $elvish = \App\Models\Language::create(['slug' => 'test:elvish-agg-'.$uniqueId, 'name' => 'Elvish '.$uniqueId]);
-        $dwarvish = \App\Models\Language::create(['slug' => 'test:dwarvish-agg-'.$uniqueId, 'name' => 'Dwarvish '.$uniqueId]);
+        $common = Language::create(['slug' => 'test:common-agg-'.$uniqueId, 'name' => 'Common '.$uniqueId]);
+        $elvish = Language::create(['slug' => 'test:elvish-agg-'.$uniqueId, 'name' => 'Elvish '.$uniqueId]);
+        $dwarvish = Language::create(['slug' => 'test:dwarvish-agg-'.$uniqueId, 'name' => 'Dwarvish '.$uniqueId]);
 
         // Char1 knows Common and Elvish
-        \App\Models\CharacterLanguage::create(['character_id' => $char1->id, 'language_slug' => $common->slug, 'source' => 'race']);
-        \App\Models\CharacterLanguage::create(['character_id' => $char1->id, 'language_slug' => $elvish->slug, 'source' => 'race']);
+        CharacterLanguage::create(['character_id' => $char1->id, 'language_slug' => $common->slug, 'source' => 'race']);
+        CharacterLanguage::create(['character_id' => $char1->id, 'language_slug' => $elvish->slug, 'source' => 'race']);
 
         // Char2 knows Common and Dwarvish
-        \App\Models\CharacterLanguage::create(['character_id' => $char2->id, 'language_slug' => $common->slug, 'source' => 'race']);
-        \App\Models\CharacterLanguage::create(['character_id' => $char2->id, 'language_slug' => $dwarvish->slug, 'source' => 'race']);
+        CharacterLanguage::create(['character_id' => $char2->id, 'language_slug' => $common->slug, 'source' => 'race']);
+        CharacterLanguage::create(['character_id' => $char2->id, 'language_slug' => $dwarvish->slug, 'source' => 'race']);
 
         $party->characters()->attach([$char1->id, $char2->id]);
 
@@ -823,17 +840,17 @@ class PartyApiTest extends TestCase
         $party = Party::factory()->create(['user_id' => $user->id]);
 
         // Create race with darkvision
-        $raceWithDarkvision = \App\Models\Race::factory()->create();
-        $sense = \App\Models\Sense::firstOrCreate(['slug' => 'core:darkvision'], ['name' => 'Darkvision']);
-        \App\Models\EntitySense::create([
-            'reference_type' => \App\Models\Race::class,
+        $raceWithDarkvision = Race::factory()->create();
+        $sense = Sense::firstOrCreate(['slug' => 'core:darkvision'], ['name' => 'Darkvision']);
+        EntitySense::create([
+            'reference_type' => Race::class,
             'reference_id' => $raceWithDarkvision->id,
             'sense_id' => $sense->id,
             'range_feet' => 60,
         ]);
 
         // Create race without darkvision
-        $raceWithoutDarkvision = \App\Models\Race::factory()->create();
+        $raceWithoutDarkvision = Race::factory()->create();
 
         $char1 = Character::factory()->create(['name' => 'Elf', 'race_slug' => $raceWithDarkvision->slug]);
         $char2 = Character::factory()->create(['name' => 'Human', 'race_slug' => $raceWithoutDarkvision->slug]);
@@ -858,19 +875,19 @@ class PartyApiTest extends TestCase
         $party = Party::factory()->create(['user_id' => $user->id]);
 
         // Create a cleric class using factory
-        $clericClass = \App\Models\CharacterClass::factory()->create([
+        $clericClass = CharacterClass::factory()->create([
             'slug' => 'test:cleric-healer-'.uniqid(),
             'name' => 'Cleric',
         ]);
 
         // Create a fighter class using factory
-        $fighterClass = \App\Models\CharacterClass::factory()->create([
+        $fighterClass = CharacterClass::factory()->create([
             'slug' => 'test:fighter-healer-'.uniqid(),
             'name' => 'Fighter',
         ]);
 
         $healer = Character::factory()->create(['name' => 'Mira']);
-        \App\Models\CharacterClassPivot::create([
+        CharacterClassPivot::create([
             'character_id' => $healer->id,
             'class_slug' => $clericClass->slug,
             'level' => 5,
@@ -879,7 +896,7 @@ class PartyApiTest extends TestCase
         ]);
 
         $fighter = Character::factory()->create(['name' => 'Aldric']);
-        \App\Models\CharacterClassPivot::create([
+        CharacterClassPivot::create([
             'character_id' => $fighter->id,
             'class_slug' => $fighterClass->slug,
             'level' => 5,
@@ -907,24 +924,24 @@ class PartyApiTest extends TestCase
         $character = Character::factory()->create();
 
         // Create spells using factory
-        $detectMagic = \App\Models\Spell::factory()->create([
+        $detectMagic = Spell::factory()->create([
             'slug' => 'test:detect-magic',
             'name' => 'Detect Magic',
             'level' => 1,
         ]);
-        $counterspell = \App\Models\Spell::factory()->create([
+        $counterspell = Spell::factory()->create([
             'slug' => 'test:counterspell',
             'name' => 'Counterspell',
             'level' => 3,
         ]);
 
         // Add spells to character
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $character->id,
             'spell_slug' => $detectMagic->slug,
             'source' => 'class',
         ]);
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $character->id,
             'spell_slug' => $counterspell->slug,
             'source' => 'class',
@@ -955,17 +972,17 @@ class PartyApiTest extends TestCase
         $character = Character::factory()->create();
 
         // Create heavy armor type and item using factory
-        $heavyArmorType = \App\Models\ItemType::firstOrCreate(
+        $heavyArmorType = ItemType::firstOrCreate(
             ['code' => 'HA'],
             ['name' => 'Heavy Armor']
         );
-        $plateArmor = \App\Models\Item::factory()->create([
+        $plateArmor = Item::factory()->create([
             'slug' => 'test:plate-'.uniqid(),
             'name' => 'Plate',
             'item_type_id' => $heavyArmorType->id,
         ]);
 
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => $plateArmor->slug,
             'quantity' => 1,
@@ -993,29 +1010,29 @@ class PartyApiTest extends TestCase
         $character = Character::factory()->create();
 
         // Create weapon type and items using factory
-        $meleeType = \App\Models\ItemType::firstOrCreate(
+        $meleeType = ItemType::firstOrCreate(
             ['code' => 'M'],
             ['name' => 'Melee Weapon']
         );
         $uniqueId = uniqid();
-        $longsword = \App\Models\Item::factory()->create([
+        $longsword = Item::factory()->create([
             'slug' => 'test:longsword-'.$uniqueId,
             'name' => 'Longsword',
             'item_type_id' => $meleeType->id,
         ]);
-        $longbow = \App\Models\Item::factory()->create([
+        $longbow = Item::factory()->create([
             'slug' => 'test:longbow-'.$uniqueId,
             'name' => 'Longbow',
             'item_type_id' => $meleeType->id,
         ]);
 
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => $longsword->slug,
             'quantity' => 1,
             'equipped' => true,
         ]);
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => $longbow->slug,
             'quantity' => 1,
@@ -1045,17 +1062,17 @@ class PartyApiTest extends TestCase
         $character = Character::factory()->create();
 
         // Create shield using factory
-        $shieldType = \App\Models\ItemType::firstOrCreate(
+        $shieldType = ItemType::firstOrCreate(
             ['code' => 'S'],
             ['name' => 'Shield']
         );
-        $shield = \App\Models\Item::factory()->create([
+        $shield = Item::factory()->create([
             'slug' => 'test:shield-'.uniqid(),
             'name' => 'Shield',
             'item_type_id' => $shieldType->id,
         ]);
 
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => $shield->slug,
             'quantity' => 1,
@@ -1084,7 +1101,7 @@ class PartyApiTest extends TestCase
 
         // Add counter directly to the character_counters table (new approach)
         // current_uses = actual remaining (null = full capacity)
-        \App\Models\CharacterCounter::create([
+        CharacterCounter::create([
             'character_id' => $character->id,
             'source_type' => 'class',
             'source_slug' => 'phb:barbarian',

--- a/tests/Feature/Api/ProficiencyTypeApiTest.php
+++ b/tests/Feature/Api/ProficiencyTypeApiTest.php
@@ -3,11 +3,13 @@
 namespace Tests\Feature\Api;
 
 use App\Models\ProficiencyType;
+use Database\Seeders\ProficiencyTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ProficiencyTypeApiTest extends TestCase
 {
     use RefreshDatabase;
@@ -15,7 +17,7 @@ class ProficiencyTypeApiTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(\Database\Seeders\ProficiencyTypeSeeder::class);
+        $this->seed(ProficiencyTypeSeeder::class);
     }
 
     #[Test]

--- a/tests/Feature/Api/ProficiencyTypeReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/ProficiencyTypeReverseRelationshipsApiTest.php
@@ -7,13 +7,15 @@ use App\Models\CharacterClass;
 use App\Models\Proficiency;
 use App\Models\ProficiencyType;
 use App\Models\Race;
+use Database\Seeders\LookupSeeder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ProficiencyTypeReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     // ========================================
     // Classes Endpoint Tests

--- a/tests/Feature/Api/RaceApiTest.php
+++ b/tests/Feature/Api/RaceApiTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Race;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,13 +14,13 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class RaceApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function can_get_all_races()

--- a/tests/Feature/Api/RaceEntitySpecificFiltersApiTest.php
+++ b/tests/Feature/Api/RaceEntitySpecificFiltersApiTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Race;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -11,20 +14,20 @@ use Tests\TestCase;
  *
  * These tests use factory-based data and are self-contained.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-isolated')]
+#[Group('feature-search')]
+#[Group('search-isolated')]
 class RaceEntitySpecificFiltersApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
         parent::setUp();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_ability_bonus_int(): void
     {
         // Get count of races with INT bonuses from pre-imported data
@@ -59,7 +62,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_ability_bonus_str(): void
     {
         // Get count of races with STR bonuses from pre-imported data
@@ -94,7 +97,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_size_small(): void
     {
         // Get count of small races from pre-imported data
@@ -117,7 +120,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_size_medium(): void
     {
         // Act: Filter by size_code = M using Meilisearch
@@ -133,7 +136,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_min_speed_35(): void
     {
         // Get count of races with speed >= 35 from pre-imported data
@@ -154,7 +157,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_has_darkvision_true(): void
     {
         // Get count of races with darkvision tag from pre-imported data
@@ -179,7 +182,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_combined_ability_bonus_and_has_darkvision(): void
     {
         // Get count of races with both INT bonus and darkvision from pre-imported data
@@ -223,7 +226,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_filter_parameter_with_invalid_syntax(): void
     {
         // Act: Send invalid filter syntax (this will be caught by Meilisearch, not validation)
@@ -234,7 +237,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         $response->assertStatus(422);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_valid_size_filter(): void
     {
         // Act: Send valid size filter (uses pre-imported data)
@@ -244,7 +247,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         $response->assertOk();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_valid_speed_filter(): void
     {
         // Act: Send valid speed filter (uses pre-imported data)
@@ -254,7 +257,7 @@ class RaceEntitySpecificFiltersApiTest extends TestCase
         $response->assertOk();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_valid_darkvision_filter(): void
     {
         // Act: Send valid darkvision filter (uses pre-imported data)

--- a/tests/Feature/Api/RaceFilterOperatorTest.php
+++ b/tests/Feature/Api/RaceFilterOperatorTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Race;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\ClearsMeilisearchIndex;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
@@ -14,14 +17,14 @@ use Tests\TestCase;
  * Uses real imported race data from PHB for realistic testing.
  * All tests share the same indexed data for efficiency.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class RaceFilterOperatorTest extends TestCase
 {
     use ClearsMeilisearchIndex;
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -59,7 +62,7 @@ class RaceFilterOperatorTest extends TestCase
     // Integer Operators (ability_str_bonus field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ability_str_bonus_with_equals(): void
     {
         // Act: Filter by ability_str_bonus = 2 (PHB has races with +2 STR)
@@ -76,7 +79,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ability_str_bonus_with_not_equals(): void
     {
         // Act: Filter by ability_str_bonus != 2 (should return all races except those with +2 STR)
@@ -100,7 +103,7 @@ class RaceFilterOperatorTest extends TestCase
         $this->assertNotContains(2, $strBonuses, 'STR bonus of 2 should be excluded');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ability_str_bonus_with_greater_than(): void
     {
         // Act: Filter by ability_str_bonus > 0 (should return races with positive STR bonuses)
@@ -127,7 +130,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ability_str_bonus_with_greater_than_or_equal(): void
     {
         // Act: Filter by ability_str_bonus >= 2 (should return races with STR bonus 2 or higher)
@@ -154,7 +157,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ability_str_bonus_with_less_than(): void
     {
         // Act: Filter by ability_str_bonus < 2 (should return races with STR bonus 0 or 1)
@@ -182,7 +185,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ability_str_bonus_with_less_than_or_equal(): void
     {
         // Act: Filter by ability_str_bonus <= 1 (should return races with STR bonus 1 or lower)
@@ -210,7 +213,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ability_str_bonus_with_to_range(): void
     {
         // Act: Filter by ability_str_bonus 1 TO 2 (inclusive range - should return bonuses 1, 2)
@@ -247,7 +250,7 @@ class RaceFilterOperatorTest extends TestCase
     // String Operators (size_code field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_size_code_with_equals(): void
     {
         // Act: Filter by size_code = M (Medium races) - use per_page to get more results
@@ -270,7 +273,7 @@ class RaceFilterOperatorTest extends TestCase
         $this->assertContains('Human', $raceNames, 'Human is a well-known Medium race');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_size_code_with_not_equals(): void
     {
         // Act: Filter by size_code != M (all races except Medium)
@@ -299,7 +302,7 @@ class RaceFilterOperatorTest extends TestCase
     // Using has_innate_spells instead as it's an actual boolean field.
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_darkvision_with_equals_true(): void
     {
         // Act: Filter by has_innate_spells = true (races with innate spellcasting)
@@ -318,7 +321,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_darkvision_with_equals_false(): void
     {
         // Act: Filter by has_innate_spells = false (races without innate spellcasting)
@@ -336,7 +339,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_darkvision_with_not_equals_true(): void
     {
         // Act: Filter by has_innate_spells != true (races that are false or null)
@@ -354,7 +357,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_darkvision_with_not_equals_false(): void
     {
         // Act: Filter by has_innate_spells != false (races that are true or null)
@@ -372,7 +375,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_darkvision_with_is_null(): void
     {
         // Act: Filter by has_innate_spells IS NULL (races with no innate spell data)
@@ -392,7 +395,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_darkvision_with_is_not_null(): void
     {
         // Act: Filter by has_innate_spells IS NOT NULL (races with innate spell data defined)
@@ -408,7 +411,7 @@ class RaceFilterOperatorTest extends TestCase
         $this->assertGreaterThan(0, $response->json('meta.total'), 'IS NOT NULL should return races');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_has_darkvision_with_not_equals(): void
     {
         // Act: Filter using generic != operator for boolean
@@ -430,7 +433,7 @@ class RaceFilterOperatorTest extends TestCase
     // Array Operators (spell_slugs field) - 3 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_spell_slugs_with_in(): void
     {
         // Act: Filter by spell_slugs IN [light, dancing-lights] (races with these innate spells)
@@ -451,7 +454,7 @@ class RaceFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_spell_slugs_with_not_in(): void
     {
         // Act: Filter by spell_slugs NOT IN [light] (exclude all races with light spell)
@@ -474,7 +477,7 @@ class RaceFilterOperatorTest extends TestCase
         $this->assertGreaterThan(0, $response->json('meta.total'), 'Should have races without light spell');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_spell_slugs_with_is_empty(): void
     {
         // Act: Filter by spell_slugs IS EMPTY (races with no innate spells)

--- a/tests/Feature/Api/RaceResourceTest.php
+++ b/tests/Feature/Api/RaceResourceTest.php
@@ -6,14 +6,16 @@ use App\Http\Resources\RaceResource;
 use App\Models\Race;
 use App\Models\Size;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class RaceResourceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_speed_fields_in_resource(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -35,7 +37,7 @@ class RaceResourceTest extends TestCase
         $this->assertEquals(20, $resource['climb_speed']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_missing_speeds(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -57,7 +59,7 @@ class RaceResourceTest extends TestCase
         $this->assertNull($resource['climb_speed']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_subrace_required_in_resource(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -73,7 +75,7 @@ class RaceResourceTest extends TestCase
         $this->assertTrue($resource['subrace_required']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_false_for_subrace_required_when_set(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);

--- a/tests/Feature/Api/RaceSearchTest.php
+++ b/tests/Feature/Api/RaceSearchTest.php
@@ -3,17 +3,20 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Race;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class RaceSearchTest extends TestCase
 {
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -21,7 +24,7 @@ class RaceSearchTest extends TestCase
         $this->artisan('search:configure-indexes');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_races_using_scout_when_available(): void
     {
         // Use fixture data - Dwarf and Elf exist in TestDatabaseSeeder
@@ -35,7 +38,7 @@ class RaceSearchTest extends TestCase
             ->assertJsonPath('data.0.name', 'Dwarf');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_query_minimum_length(): void
     {
         $response = $this->getJson('/api/v1/races?q=a');
@@ -44,7 +47,7 @@ class RaceSearchTest extends TestCase
             ->assertJsonValidationErrors(['q']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_search_query_gracefully(): void
     {
         // Use fixture data - returns paginated results (default 15 per page)
@@ -55,7 +58,7 @@ class RaceSearchTest extends TestCase
             ->assertJsonPath('meta.total', Race::count());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_subrace_required_false(): void
     {
         // Filter for races where subrace selection is optional (base race is complete)
@@ -77,7 +80,7 @@ class RaceSearchTest extends TestCase
         $this->assertNotContains('Dwarf', $names);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_races_by_subrace_required_true(): void
     {
         // Filter for races where subrace selection is required

--- a/tests/Feature/Api/RarityApiTest.php
+++ b/tests/Feature/Api/RarityApiTest.php
@@ -3,21 +3,24 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Item;
+use Database\Seeders\ItemTypeSeeder;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class RarityApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(\Database\Seeders\ItemTypeSeeder::class);
+        $this->seed(ItemTypeSeeder::class);
     }
 
     #[Test]

--- a/tests/Feature/Api/RouteBindingTest.php
+++ b/tests/Feature/Api/RouteBindingTest.php
@@ -11,13 +11,14 @@ use App\Models\Race;
 use App\Models\Spell;
 use App\Models\SpellSchool;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
  * Tests for route model binding supporting id and slug formats.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class RouteBindingTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Api/SizeApiTest.php
+++ b/tests/Feature/Api/SizeApiTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Size;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,12 +14,12 @@ use Tests\TestCase;
  *
  * These tests use LookupSeeder for stable size data.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SizeApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function can_get_all_sizes()

--- a/tests/Feature/Api/SizeReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/SizeReverseRelationshipsApiTest.php
@@ -5,13 +5,15 @@ namespace Tests\Feature\Api;
 use App\Models\Monster;
 use App\Models\Race;
 use App\Models\Size;
+use Database\Seeders\LookupSeeder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SizeReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_returns_races_for_size(): void

--- a/tests/Feature/Api/SkillApiTest.php
+++ b/tests/Feature/Api/SkillApiTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Api;
 
 use App\Models\Skill;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SkillApiTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Api/SourceApiTest.php
+++ b/tests/Feature/Api/SourceApiTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Api;
 
 use App\Models\Source;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SourceApiTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Api/SpellApiTest.php
+++ b/tests/Feature/Api/SpellApiTest.php
@@ -3,18 +3,21 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Spell;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
  * These tests use fixture-based test data from TestDatabaseSeeder.
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class SpellApiTest extends TestCase
 {
-    use \Illuminate\Foundation\Testing\RefreshDatabase;
+    use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function can_get_all_spells()

--- a/tests/Feature/Api/SpellEnhancedFilteringTest.php
+++ b/tests/Feature/Api/SpellEnhancedFilteringTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Api;
 
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 /**
  * Tests for enhanced Meilisearch filtering features:
  * 1. Damage Type Filtering (damage_types array field)
@@ -24,7 +26,7 @@ class SpellEnhancedFilteringTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {

--- a/tests/Feature/Api/SpellFilterOperatorTest.php
+++ b/tests/Feature/Api/SpellFilterOperatorTest.php
@@ -2,15 +2,18 @@
 
 namespace Tests\Feature\Api;
 
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 class SpellFilterOperatorTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -24,7 +27,7 @@ class SpellFilterOperatorTest extends TestCase
     // Integer Operators (level field) - 7 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_level_with_equals(): void
     {
         // Act: Filter by level = 3 (PHB has many level 3 spells)
@@ -44,7 +47,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertContains('Animate Dead', $spellNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_level_with_not_equals(): void
     {
         // Act: Filter by level != 3 (should return all spells except level 3)
@@ -64,7 +67,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertNotContains(3, $levels, 'Level 3 should be excluded');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_level_with_greater_than(): void
     {
         // Act: Filter by level > 5 (should return levels 6, 7, 8, 9)
@@ -86,7 +89,7 @@ class SpellFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_level_with_greater_than_or_equal(): void
     {
         // Act: Filter by level >= 7 (should return levels 7, 8, 9)
@@ -109,7 +112,7 @@ class SpellFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_level_with_less_than(): void
     {
         // Act: Filter by level < 2 (should return levels 0, 1 only)
@@ -131,7 +134,7 @@ class SpellFilterOperatorTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_level_with_less_than_or_equal(): void
     {
         // Act: Filter by level <= 1 (should return levels 0, 1)
@@ -151,7 +154,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertEquals([0, 1], $levels, 'Should only have levels 0 and 1');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_level_with_to_range(): void
     {
         // Act: Filter by level 3 TO 5 (inclusive range - should return levels 3, 4, 5)
@@ -182,7 +185,7 @@ class SpellFilterOperatorTest extends TestCase
     // String Operators (school_code field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_school_code_with_equals(): void
     {
         // Act: Filter by school_code = EV (Evocation spells) - use per_page to get more results
@@ -205,7 +208,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertContains('Bigby\'s Hand', $spellNames, 'Bigby\'s Hand is an Evocation spell in fixtures');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_school_code_with_not_equals(): void
     {
         // Act: Filter by school_code != EV (all spells except Evocation)
@@ -232,7 +235,7 @@ class SpellFilterOperatorTest extends TestCase
     // Boolean Operators (concentration field) - 5 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_concentration_with_equals_true(): void
     {
         // Act: Filter by concentration = true (spells requiring concentration) - use per_page to get more results
@@ -254,7 +257,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertContains('Alter Self', $spellNames, 'Alter Self requires concentration and exists in fixtures');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_concentration_with_equals_false(): void
     {
         // Act: Filter by concentration = false (spells not requiring concentration)
@@ -277,7 +280,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertContains('Acid Splash', $spellNames, 'Acid Splash does not require concentration');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_concentration_with_not_equals_true(): void
     {
         // Act: Filter by concentration != true (spells that are false or null)
@@ -299,7 +302,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertNotContains('Alter Self', $spellNames, 'Alter Self requires concentration (should be excluded)');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_concentration_with_not_equals_false(): void
     {
         // Act: Filter by concentration != false (spells that are true or null)
@@ -321,7 +324,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertNotContains('Acid Splash', $spellNames, 'Acid Splash does not require concentration (should be excluded)');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_concentration_with_is_null(): void
     {
         // Act: Filter by concentration IS NULL (spells with no concentration data)
@@ -344,7 +347,7 @@ class SpellFilterOperatorTest extends TestCase
     // Array Operators (class_slugs field) - 3 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_class_slugs_with_in(): void
     {
         // Act: Filter by class_slugs IN [wizard, bard] (spells available to wizard OR bard)
@@ -367,7 +370,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertGreaterThan(50, $response->json('meta.total'), 'Should find many wizard/bard spells in PHB');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_class_slugs_with_not_in(): void
     {
         // Act: Filter by class_slugs NOT IN [wizard] (exclude all wizard spells)
@@ -390,7 +393,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertLessThan(400, $response->json('meta.total'), 'Should have excluded wizard spells');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_class_slugs_with_is_empty(): void
     {
         // Act: Filter by class_slugs IS EMPTY (spells with no class associations)
@@ -415,7 +418,7 @@ class SpellFilterOperatorTest extends TestCase
     // Boolean Operators (ritual field) - 2 tests
     // ============================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ritual_with_equals_true(): void
     {
         // Act: Filter by ritual = true (spells that can be cast as rituals)
@@ -437,7 +440,7 @@ class SpellFilterOperatorTest extends TestCase
         $this->assertContains('Alarm', $spellNames, 'Alarm can be cast as a ritual and exists in fixtures');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_ritual_with_not_equals_false(): void
     {
         // Act: Filter by ritual != false (spells that are true or null)

--- a/tests/Feature/Api/SpellReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/SpellReverseRelationshipsApiTest.php
@@ -3,14 +3,16 @@
 namespace Tests\Feature\Api;
 
 use App\Models\CharacterClass;
+use App\Models\EntitySpell;
 use App\Models\Item;
 use App\Models\Monster;
 use App\Models\Race;
 use App\Models\Spell;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SpellReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
     // ========================================
@@ -133,8 +135,8 @@ class SpellReverseRelationshipsApiTest extends ReverseRelationshipTestCase
         $highElf = Race::factory()->create(['name' => 'High Elf', 'slug' => 'high-elf-'.uniqid()]);
         $human = Race::factory()->create(['name' => 'Human', 'slug' => 'human-'.uniqid()]);
 
-        \App\Models\EntitySpell::create(['reference_type' => Race::class, 'reference_id' => $drow->id, 'spell_id' => $spell->id, 'level_requirement' => 1]);
-        \App\Models\EntitySpell::create(['reference_type' => Race::class, 'reference_id' => $highElf->id, 'spell_id' => $spell->id, 'is_cantrip' => true]);
+        EntitySpell::create(['reference_type' => Race::class, 'reference_id' => $drow->id, 'spell_id' => $spell->id, 'level_requirement' => 1]);
+        EntitySpell::create(['reference_type' => Race::class, 'reference_id' => $highElf->id, 'spell_id' => $spell->id, 'is_cantrip' => true]);
 
         $this->assertReturnsRelatedEntities("/api/v1/spells/{$spell->slug}/races", 2, ['Drow', 'High Elf']);
     }
@@ -153,7 +155,7 @@ class SpellReverseRelationshipsApiTest extends ReverseRelationshipTestCase
         $spell = Spell::factory()->create(['name' => 'Test Spell']);
         $drow = Race::factory()->create(['name' => 'Drow']);
 
-        \App\Models\EntitySpell::create(['reference_type' => Race::class, 'reference_id' => $drow->id, 'spell_id' => $spell->id]);
+        EntitySpell::create(['reference_type' => Race::class, 'reference_id' => $drow->id, 'spell_id' => $spell->id]);
 
         $this->assertAcceptsAlternativeIdentifier("/api/v1/spells/{$spell->id}/races");
     }

--- a/tests/Feature/Api/SpellSchoolApiTest.php
+++ b/tests/Feature/Api/SpellSchoolApiTest.php
@@ -3,11 +3,13 @@
 namespace Tests\Feature\Api;
 
 use App\Models\SpellSchool;
+use Database\Seeders\SpellSchoolSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SpellSchoolApiTest extends TestCase
 {
     use RefreshDatabase;
@@ -17,8 +19,8 @@ class SpellSchoolApiTest extends TestCase
         parent::setUp();
 
         // Only seed if not already seeded (prevents duplicate key errors)
-        if (\App\Models\SpellSchool::count() === 0) {
-            $this->seed(\Database\Seeders\SpellSchoolSeeder::class);
+        if (SpellSchool::count() === 0) {
+            $this->seed(SpellSchoolSeeder::class);
         }
     }
 

--- a/tests/Feature/Api/SpellSchoolReverseRelationshipsApiTest.php
+++ b/tests/Feature/Api/SpellSchoolReverseRelationshipsApiTest.php
@@ -4,13 +4,15 @@ namespace Tests\Feature\Api;
 
 use App\Models\Spell;
 use App\Models\SpellSchool;
+use Database\Seeders\LookupSeeder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\Concerns\ReverseRelationshipTestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SpellSchoolReverseRelationshipsApiTest extends ReverseRelationshipTestCase
 {
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_returns_spells_for_spell_school()

--- a/tests/Feature/Api/SpellSearchAndFilterTest.php
+++ b/tests/Feature/Api/SpellSearchAndFilterTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Spell;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Concerns\WaitsForMeilisearch;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
+#[Group('feature-search')]
 /**
  * Tests for spell search functionality and filter integration.
  *
@@ -25,7 +28,7 @@ class SpellSearchAndFilterTest extends TestCase
     use RefreshDatabase;
     use WaitsForMeilisearch;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     protected function setUp(): void
     {
@@ -40,7 +43,7 @@ class SpellSearchAndFilterTest extends TestCase
     // SEARCH FUNCTIONALITY TESTS
     // ===================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_spells_using_scout_when_available(): void
     {
         // Use fixture data - "Acid Splash" exists in TestDatabaseSeeder
@@ -57,7 +60,7 @@ class SpellSearchAndFilterTest extends TestCase
         $this->assertContains('Acid Splash', $names, 'Acid Splash should be in search results');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_search_query_gracefully(): void
     {
         // Use fixture data - returns paginated results (default 15 per page)
@@ -68,7 +71,7 @@ class SpellSearchAndFilterTest extends TestCase
             ->assertJsonPath('meta.total', Spell::count());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_special_characters_in_search(): void
     {
         // Use fixture data - Bigby's Hand exists in fixtures
@@ -78,7 +81,7 @@ class SpellSearchAndFilterTest extends TestCase
         $this->assertGreaterThanOrEqual(1, count($response->json('data')));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_query_minimum_length(): void
     {
         $response = $this->getJson('/api/v1/spells?q=a');
@@ -91,7 +94,7 @@ class SpellSearchAndFilterTest extends TestCase
     // COMBINED SEARCH + FILTER TESTS
     // ===================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_combines_search_query_with_filter()
     {
         // Search for "fire" and filter to level <= 3
@@ -107,7 +110,7 @@ class SpellSearchAndFilterTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_meilisearch_results_by_level_with_search(): void
     {
         // Use fixture data - search for "animate" with level 3 filter
@@ -130,7 +133,7 @@ class SpellSearchAndFilterTest extends TestCase
     // BOOLEAN LOGIC (AND/OR) TESTS
     // ===================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_combines_multiple_filters_with_and()
     {
         $response = $this->getJson('/api/v1/spells?filter=level <= 2 AND concentration = false');
@@ -143,7 +146,7 @@ class SpellSearchAndFilterTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_combines_multiple_filters_with_or()
     {
         $response = $this->getJson('/api/v1/spells?filter=school_code = EV OR school_code = C');
@@ -160,7 +163,7 @@ class SpellSearchAndFilterTest extends TestCase
     // FILTER VALIDATION AND ERROR HANDLING TESTS
     // ===================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_filter_max_length()
     {
         $longFilter = str_repeat('level = 1 AND ', 100);
@@ -171,7 +174,7 @@ class SpellSearchAndFilterTest extends TestCase
         $response->assertJsonValidationErrors('filter');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_422_for_invalid_meilisearch_filter(): void
     {
         // This test assumes Meilisearch is running and will reject invalid filters
@@ -190,7 +193,7 @@ class SpellSearchAndFilterTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_provides_documentation_link_in_error_response(): void
     {
         $response = $this->getJson('/api/v1/spells?filter=invalid_syntax');
@@ -201,7 +204,7 @@ class SpellSearchAndFilterTest extends TestCase
         $this->assertStringContainsString('docs/meilisearch-filters', $data['documentation']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_meilisearch_error_message(): void
     {
         $response = $this->getJson('/api/v1/spells?filter=nonexistent_field = value');
@@ -216,7 +219,7 @@ class SpellSearchAndFilterTest extends TestCase
     // PAGINATION TESTS
     // ===================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_paginates_filtered_results()
     {
         $response = $this->getJson('/api/v1/spells?filter=level <= 5&per_page=5&page=1');
@@ -233,7 +236,7 @@ class SpellSearchAndFilterTest extends TestCase
     // SORTING TESTS
     // ===================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sorts_filtered_results()
     {
         $response = $this->getJson('/api/v1/spells?filter=level <= 3&sort_by=level&sort_direction=desc');
@@ -251,7 +254,7 @@ class SpellSearchAndFilterTest extends TestCase
     // EMPTY RESULTS TESTS
     // ===================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_empty_results_for_impossible_filter()
     {
         $response = $this->getJson('/api/v1/spells?filter=level = 99');

--- a/tests/Feature/Api/TagApiTest.php
+++ b/tests/Feature/Api/TagApiTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Feature\Api;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Spatie\Tags\Tag;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class TagApiTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Api/TagIntegrationTest.php
+++ b/tests/Feature/Api/TagIntegrationTest.php
@@ -10,14 +10,16 @@ use App\Models\Monster;
 use App\Models\Race;
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class TagIntegrationTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function spell_api_includes_tags_by_default()
     {
         $spell = Spell::factory()->create(['name' => 'Test Spell']);
@@ -43,7 +45,7 @@ class TagIntegrationTest extends TestCase
         $this->assertEquals(['Ritual Caster', 'Touch Spells'], $tagNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function race_api_includes_tags_by_default()
     {
         $race = Race::factory()->create(['name' => 'Test Race']);
@@ -69,7 +71,7 @@ class TagIntegrationTest extends TestCase
         $this->assertEquals(['Elven', 'Fey Ancestry'], $tagNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function item_api_includes_tags_by_default()
     {
         $item = Item::factory()->create(['name' => 'Test Item']);
@@ -95,7 +97,7 @@ class TagIntegrationTest extends TestCase
         $this->assertEquals(['Artifact', 'Legendary'], $tagNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function background_api_includes_tags_by_default()
     {
         $background = Background::factory()->create(['name' => 'Test Background']);
@@ -121,7 +123,7 @@ class TagIntegrationTest extends TestCase
         $this->assertEquals(['Guild Member', 'Urban'], $tagNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function class_api_includes_tags_by_default()
     {
         $class = CharacterClass::factory()->create(['name' => 'Test Class']);
@@ -147,7 +149,7 @@ class TagIntegrationTest extends TestCase
         $this->assertEquals(['Full Caster', 'Spellcaster'], $tagNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function feat_api_includes_tags_by_default()
     {
         $feat = Feat::factory()->create(['name' => 'Test Feat']);
@@ -173,7 +175,7 @@ class TagIntegrationTest extends TestCase
         $this->assertEquals(['Combat', 'Martial'], $tagNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function monster_api_includes_tags_by_default()
     {
         $monster = Monster::factory()->create(['name' => 'Test Monster']);
@@ -199,7 +201,7 @@ class TagIntegrationTest extends TestCase
         $this->assertEquals(['Fiend', 'Fire Immune'], $tagNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function entities_without_tags_return_empty_array()
     {
         $spell = Spell::factory()->create(['name' => 'Untagged Spell']);
@@ -214,7 +216,7 @@ class TagIntegrationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function tag_resource_includes_type_field()
     {
         $spell = Spell::factory()->create(['name' => 'Test Spell']);

--- a/tests/Feature/Console/ExtractFixturesCommandTest.php
+++ b/tests/Feature/Console/ExtractFixturesCommandTest.php
@@ -2,8 +2,29 @@
 
 namespace Tests\Feature\Console;
 
+use App\Models\AbilityScore;
+use App\Models\Background;
+use App\Models\CharacterClass;
+use App\Models\CharacterTrait;
+use App\Models\EntityPrerequisite;
+use App\Models\EntitySource;
+use App\Models\Feat;
+use App\Models\Item;
+use App\Models\ItemType;
+use App\Models\Modifier;
+use App\Models\Monster;
+use App\Models\OptionalFeature;
+use App\Models\Proficiency;
+use App\Models\Race;
+use App\Models\Size;
+use App\Models\Skill;
+use App\Models\Source;
+use App\Models\Spell;
+use App\Models\SpellSchool;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Tests\TestCase;
 
 class ExtractFixturesCommandTest extends TestCase
@@ -21,42 +42,42 @@ class ExtractFixturesCommandTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_the_command_registered(): void
     {
         $this->artisan('fixtures:extract', ['--help' => true])
             ->assertSuccessful();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_requires_entity_type_argument(): void
     {
         try {
             $this->artisan('fixtures:extract');
             $this->fail('Expected RuntimeException was not thrown');
-        } catch (\Symfony\Component\Console\Exception\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString('Not enough arguments', $e->getMessage());
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_spells_with_coverage_based_selection(): void
     {
         // Create test spells covering edge cases
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST', 'name' => 'Test Source']);
-        $school = \App\Models\SpellSchool::first();
-        $class = \App\Models\CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
+        $source = Source::factory()->create(['code' => 'TEST', 'name' => 'Test Source']);
+        $school = SpellSchool::first();
+        $class = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
 
         // Create spells at different levels
         foreach (range(0, 3) as $level) {
-            $spell = \App\Models\Spell::factory()->create([
+            $spell = Spell::factory()->create([
                 'level' => $level,
                 'spell_school_id' => $school->id,
             ]);
             $spell->classes()->attach($class->id);
 
             // Create entity source relationship
-            \App\Models\EntitySource::create([
+            EntitySource::create([
                 'reference_type' => 'App\Models\Spell',
                 'reference_id' => $spell->id,
                 'source_id' => $source->id,
@@ -93,19 +114,19 @@ class ExtractFixturesCommandTest extends TestCase
         $this->assertIsArray($spell['sources']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_monsters_with_cr_coverage(): void
     {
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST-MM']);
+        $source = Source::factory()->create(['code' => 'TEST-MM']);
 
         // Create monsters at different CRs
         foreach ([0, 0.125, 0.25, 0.5, 1, 5, 10, 20] as $cr) {
-            $monster = \App\Models\Monster::factory()->create([
+            $monster = Monster::factory()->create([
                 'challenge_rating' => $cr,
             ]);
 
             // Create entity source relationship
-            \App\Models\EntitySource::create([
+            EntitySource::create([
                 'reference_type' => 'App\Models\Monster',
                 'reference_id' => $monster->id,
                 'source_id' => $source->id,
@@ -134,17 +155,17 @@ class ExtractFixturesCommandTest extends TestCase
         $this->assertArrayHasKey('source', $monster);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_classes_with_all_base_classes(): void
     {
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST-PHB']);
+        $source = Source::factory()->create(['code' => 'TEST-PHB']);
 
         // Create test classes covering different hit dice and spellcasting
-        $wizInt = \App\Models\AbilityScore::where('code', 'INT')->first();
-        $wisWis = \App\Models\AbilityScore::where('code', 'WIS')->first();
+        $wizInt = AbilityScore::where('code', 'INT')->first();
+        $wisWis = AbilityScore::where('code', 'WIS')->first();
 
         // Base class with spellcasting
-        $wizard = \App\Models\CharacterClass::factory()->create([
+        $wizard = CharacterClass::factory()->create([
             'name' => 'Wizard',
             'slug' => 'wizard',
             'hit_die' => 6,
@@ -154,7 +175,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Base class without spellcasting
-        $fighter = \App\Models\CharacterClass::factory()->create([
+        $fighter = CharacterClass::factory()->create([
             'name' => 'Fighter',
             'slug' => 'fighter',
             'hit_die' => 10,
@@ -164,7 +185,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Base class with different spellcasting
-        $cleric = \App\Models\CharacterClass::factory()->create([
+        $cleric = CharacterClass::factory()->create([
             'name' => 'Cleric',
             'slug' => 'cleric',
             'hit_die' => 8,
@@ -175,7 +196,7 @@ class ExtractFixturesCommandTest extends TestCase
 
         // Create entity source relationships
         foreach ([$wizard, $fighter, $cleric] as $class) {
-            \App\Models\EntitySource::create([
+            EntitySource::create([
                 'reference_type' => 'App\Models\CharacterClass',
                 'reference_id' => $class->id,
                 'source_id' => $source->id,
@@ -211,23 +232,23 @@ class ExtractFixturesCommandTest extends TestCase
         $this->assertIsString($class['slug']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_races_with_size_coverage(): void
     {
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST-PHB']);
+        $source = Source::factory()->create(['code' => 'TEST-PHB']);
 
         // Get different sizes
-        $sizeMedium = \App\Models\Size::where('code', 'M')->first();
-        $sizeSmall = \App\Models\Size::where('code', 'S')->first();
-        $sizeTiny = \App\Models\Size::where('code', 'T')->first();
+        $sizeMedium = Size::where('code', 'M')->first();
+        $sizeSmall = Size::where('code', 'S')->first();
+        $sizeTiny = Size::where('code', 'T')->first();
 
         // Get ability scores for modifiers
-        $strAbility = \App\Models\AbilityScore::where('code', 'STR')->first();
-        $dexAbility = \App\Models\AbilityScore::where('code', 'DEX')->first();
-        $conAbility = \App\Models\AbilityScore::where('code', 'CON')->first();
+        $strAbility = AbilityScore::where('code', 'STR')->first();
+        $dexAbility = AbilityScore::where('code', 'DEX')->first();
+        $conAbility = AbilityScore::where('code', 'CON')->first();
 
         // Create base race with traits and modifiers
-        $human = \App\Models\Race::factory()->create([
+        $human = Race::factory()->create([
             'name' => 'Human',
             'slug' => 'human',
             'size_id' => $sizeMedium->id,
@@ -236,7 +257,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add ability score modifiers
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Race',
             'reference_id' => $human->id,
             'modifier_category' => 'ability_score',
@@ -244,7 +265,7 @@ class ExtractFixturesCommandTest extends TestCase
             'value' => 1,
         ]);
 
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Race',
             'reference_id' => $human->id,
             'modifier_category' => 'ability_score',
@@ -253,7 +274,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add a trait
-        \App\Models\CharacterTrait::create([
+        CharacterTrait::create([
             'reference_type' => 'App\Models\Race',
             'reference_id' => $human->id,
             'name' => 'Extra Language',
@@ -262,7 +283,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create race with subraces
-        $elf = \App\Models\Race::factory()->create([
+        $elf = Race::factory()->create([
             'name' => 'Elf',
             'slug' => 'elf',
             'size_id' => $sizeMedium->id,
@@ -270,7 +291,7 @@ class ExtractFixturesCommandTest extends TestCase
             'parent_race_id' => null,
         ]);
 
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Race',
             'reference_id' => $elf->id,
             'modifier_category' => 'ability_score',
@@ -279,7 +300,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create subrace
-        $highElf = \App\Models\Race::factory()->create([
+        $highElf = Race::factory()->create([
             'name' => 'High Elf',
             'slug' => 'high-elf',
             'size_id' => $sizeMedium->id,
@@ -287,7 +308,7 @@ class ExtractFixturesCommandTest extends TestCase
             'parent_race_id' => $elf->id,
         ]);
 
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Race',
             'reference_id' => $highElf->id,
             'modifier_category' => 'ability_score',
@@ -296,7 +317,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create small race
-        $halfling = \App\Models\Race::factory()->create([
+        $halfling = Race::factory()->create([
             'name' => 'Halfling',
             'slug' => 'halfling',
             'size_id' => $sizeSmall->id,
@@ -304,7 +325,7 @@ class ExtractFixturesCommandTest extends TestCase
             'parent_race_id' => null,
         ]);
 
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Race',
             'reference_id' => $halfling->id,
             'modifier_category' => 'ability_score',
@@ -313,7 +334,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create tiny race
-        $fairy = \App\Models\Race::factory()->create([
+        $fairy = Race::factory()->create([
             'name' => 'Fairy',
             'slug' => 'fairy',
             'size_id' => $sizeTiny->id,
@@ -321,7 +342,7 @@ class ExtractFixturesCommandTest extends TestCase
             'parent_race_id' => null,
         ]);
 
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Race',
             'reference_id' => $fairy->id,
             'modifier_category' => 'ability_score',
@@ -331,7 +352,7 @@ class ExtractFixturesCommandTest extends TestCase
 
         // Create entity source relationships
         foreach ([$human, $elf, $highElf, $halfling, $fairy] as $race) {
-            \App\Models\EntitySource::create([
+            EntitySource::create([
                 'reference_type' => 'App\Models\Race',
                 'reference_id' => $race->id,
                 'source_id' => $source->id,
@@ -378,20 +399,20 @@ class ExtractFixturesCommandTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $subraces->count(), 'Should have at least one subrace');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_items_with_rarity_and_type_coverage(): void
     {
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST-DMG']);
+        $source = Source::factory()->create(['code' => 'TEST-DMG']);
 
         // Get different item types
-        $typeGeneral = \App\Models\ItemType::where('code', 'G')->first();
-        $typeMelee = \App\Models\ItemType::where('code', 'M')->first();
-        $typeRanged = \App\Models\ItemType::where('code', 'R')->first();
-        $typeLightArmor = \App\Models\ItemType::where('code', 'LA')->first();
-        $typePotion = \App\Models\ItemType::where('code', 'P')->first();
+        $typeGeneral = ItemType::where('code', 'G')->first();
+        $typeMelee = ItemType::where('code', 'M')->first();
+        $typeRanged = ItemType::where('code', 'R')->first();
+        $typeLightArmor = ItemType::where('code', 'LA')->first();
+        $typePotion = ItemType::where('code', 'P')->first();
 
         // Create mundane items with different types
-        $rope = \App\Models\Item::factory()->create([
+        $rope = Item::factory()->create([
             'name' => 'Rope, Hempen',
             'slug' => 'rope-hempen',
             'item_type_id' => $typeGeneral->id,
@@ -401,7 +422,7 @@ class ExtractFixturesCommandTest extends TestCase
             'weight' => 10.00,
         ]);
 
-        $longsword = \App\Models\Item::factory()->create([
+        $longsword = Item::factory()->create([
             'name' => 'Longsword',
             'slug' => 'longsword',
             'item_type_id' => $typeMelee->id,
@@ -413,7 +434,7 @@ class ExtractFixturesCommandTest extends TestCase
             'weight' => 3.00,
         ]);
 
-        $longbow = \App\Models\Item::factory()->create([
+        $longbow = Item::factory()->create([
             'name' => 'Longbow',
             'slug' => 'longbow',
             'item_type_id' => $typeRanged->id,
@@ -426,7 +447,7 @@ class ExtractFixturesCommandTest extends TestCase
             'weight' => 2.00,
         ]);
 
-        $leatherArmor = \App\Models\Item::factory()->create([
+        $leatherArmor = Item::factory()->create([
             'name' => 'Leather Armor',
             'slug' => 'leather-armor',
             'item_type_id' => $typeLightArmor->id,
@@ -438,7 +459,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create magical items with different rarities
-        $potionHealing = \App\Models\Item::factory()->create([
+        $potionHealing = Item::factory()->create([
             'name' => 'Potion of Healing',
             'slug' => 'potion-of-healing',
             'item_type_id' => $typePotion->id,
@@ -448,7 +469,7 @@ class ExtractFixturesCommandTest extends TestCase
             'weight' => 0.50,
         ]);
 
-        $bagOfHolding = \App\Models\Item::factory()->create([
+        $bagOfHolding = Item::factory()->create([
             'name' => 'Bag of Holding',
             'slug' => 'bag-of-holding',
             'item_type_id' => $typeGeneral->id,
@@ -459,7 +480,7 @@ class ExtractFixturesCommandTest extends TestCase
             'weight' => 15.00,
         ]);
 
-        $flametongueSword = \App\Models\Item::factory()->create([
+        $flametongueSword = Item::factory()->create([
             'name' => 'Flametongue Sword',
             'slug' => 'flametongue-sword',
             'item_type_id' => $typeMelee->id,
@@ -471,7 +492,7 @@ class ExtractFixturesCommandTest extends TestCase
             'weight' => 3.00,
         ]);
 
-        $veryRareItem = \App\Models\Item::factory()->create([
+        $veryRareItem = Item::factory()->create([
             'name' => 'Cloak of Invisibility',
             'slug' => 'cloak-of-invisibility',
             'item_type_id' => $typeGeneral->id,
@@ -482,7 +503,7 @@ class ExtractFixturesCommandTest extends TestCase
             'weight' => 1.00,
         ]);
 
-        $legendaryItem = \App\Models\Item::factory()->create([
+        $legendaryItem = Item::factory()->create([
             'name' => 'Vorpal Sword',
             'slug' => 'vorpal-sword',
             'item_type_id' => $typeMelee->id,
@@ -496,7 +517,7 @@ class ExtractFixturesCommandTest extends TestCase
 
         // Create entity source relationships
         foreach ([$rope, $longsword, $longbow, $leatherArmor, $potionHealing, $bagOfHolding, $flametongueSword, $veryRareItem, $legendaryItem] as $item) {
-            \App\Models\EntitySource::create([
+            EntitySource::create([
                 'reference_type' => 'App\Models\Item',
                 'reference_id' => $item->id,
                 'source_id' => $source->id,
@@ -550,18 +571,18 @@ class ExtractFixturesCommandTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $mundaneItems->count(), 'Should have at least one mundane item');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_feats_with_prerequisite_coverage(): void
     {
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST-PHB']);
+        $source = Source::factory()->create(['code' => 'TEST-PHB']);
 
         // Get ability scores for prerequisites and modifiers
-        $strAbility = \App\Models\AbilityScore::where('code', 'STR')->first();
-        $dexAbility = \App\Models\AbilityScore::where('code', 'DEX')->first();
-        $intAbility = \App\Models\AbilityScore::where('code', 'INT')->first();
+        $strAbility = AbilityScore::where('code', 'STR')->first();
+        $dexAbility = AbilityScore::where('code', 'DEX')->first();
+        $intAbility = AbilityScore::where('code', 'INT')->first();
 
         // Create feat without prerequisites
-        $grappler = \App\Models\Feat::factory()->create([
+        $grappler = Feat::factory()->create([
             'name' => 'Grappler',
             'slug' => 'grappler',
             'prerequisites_text' => null,
@@ -569,7 +590,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create entity source relationship
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $grappler->id,
             'source_id' => $source->id,
@@ -577,7 +598,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create feat with prerequisites
-        $heavyArmorMaster = \App\Models\Feat::factory()->create([
+        $heavyArmorMaster = Feat::factory()->create([
             'name' => 'Heavy Armor Master',
             'slug' => 'heavy-armor-master',
             'prerequisites_text' => 'Proficiency with heavy armor',
@@ -585,7 +606,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add ability score modifier to this feat
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $heavyArmorMaster->id,
             'modifier_category' => 'ability_score',
@@ -594,7 +615,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create entity source relationship
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $heavyArmorMaster->id,
             'source_id' => $source->id,
@@ -602,7 +623,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create feat with prerequisite entity
-        $athlete = \App\Models\Feat::factory()->create([
+        $athlete = Feat::factory()->create([
             'name' => 'Athlete',
             'slug' => 'athlete',
             'prerequisites_text' => null,
@@ -610,7 +631,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add ability score prerequisite
-        \App\Models\EntityPrerequisite::create([
+        EntityPrerequisite::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $athlete->id,
             'prerequisite_type' => 'App\Models\AbilityScore',
@@ -619,7 +640,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add multiple ability score modifiers (choice options)
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $athlete->id,
             'modifier_category' => 'ability_score',
@@ -628,7 +649,7 @@ class ExtractFixturesCommandTest extends TestCase
             'choice_count' => 1,
         ]);
 
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $athlete->id,
             'modifier_category' => 'ability_score',
@@ -638,7 +659,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create entity source relationship
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $athlete->id,
             'source_id' => $source->id,
@@ -646,7 +667,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create feat with ability score improvement only
-        $keenMind = \App\Models\Feat::factory()->create([
+        $keenMind = Feat::factory()->create([
             'name' => 'Keen Mind',
             'slug' => 'keen-mind',
             'prerequisites_text' => null,
@@ -654,7 +675,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add ability score modifier
-        \App\Models\Modifier::create([
+        Modifier::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $keenMind->id,
             'modifier_category' => 'ability_score',
@@ -663,7 +684,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create entity source relationship
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\Feat',
             'reference_id' => $keenMind->id,
             'source_id' => $source->id,
@@ -711,30 +732,30 @@ class ExtractFixturesCommandTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $featsWithASI->count(), 'Should have at least one feat with ability score improvements');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_backgrounds(): void
     {
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST-PHB']);
+        $source = Source::factory()->create(['code' => 'TEST-PHB']);
 
         // Create ability score for skills
-        $chaAbility = \App\Models\AbilityScore::firstOrCreate(['code' => 'CHA'], ['name' => 'Charisma']);
-        $wisAbility = \App\Models\AbilityScore::firstOrCreate(['code' => 'WIS'], ['name' => 'Wisdom']);
-        $dexAbility = \App\Models\AbilityScore::firstOrCreate(['code' => 'DEX'], ['name' => 'Dexterity']);
+        $chaAbility = AbilityScore::firstOrCreate(['code' => 'CHA'], ['name' => 'Charisma']);
+        $wisAbility = AbilityScore::firstOrCreate(['code' => 'WIS'], ['name' => 'Wisdom']);
+        $dexAbility = AbilityScore::firstOrCreate(['code' => 'DEX'], ['name' => 'Dexterity']);
 
         // Create skills for proficiencies (look up by name to avoid unique constraint issues)
-        $deception = \App\Models\Skill::firstOrCreate(['name' => 'Deception'], ['slug' => 'deception', 'ability_score_id' => $chaAbility->id]);
-        $stealth = \App\Models\Skill::firstOrCreate(['name' => 'Stealth'], ['slug' => 'stealth', 'ability_score_id' => $dexAbility->id]);
-        $insight = \App\Models\Skill::firstOrCreate(['name' => 'Insight'], ['slug' => 'insight', 'ability_score_id' => $wisAbility->id]);
-        $persuasion = \App\Models\Skill::firstOrCreate(['name' => 'Persuasion'], ['slug' => 'persuasion', 'ability_score_id' => $chaAbility->id]);
+        $deception = Skill::firstOrCreate(['name' => 'Deception'], ['slug' => 'deception', 'ability_score_id' => $chaAbility->id]);
+        $stealth = Skill::firstOrCreate(['name' => 'Stealth'], ['slug' => 'stealth', 'ability_score_id' => $dexAbility->id]);
+        $insight = Skill::firstOrCreate(['name' => 'Insight'], ['slug' => 'insight', 'ability_score_id' => $wisAbility->id]);
+        $persuasion = Skill::firstOrCreate(['name' => 'Persuasion'], ['slug' => 'persuasion', 'ability_score_id' => $chaAbility->id]);
 
         // Create background with skill proficiencies
-        $criminal = \App\Models\Background::factory()->create([
+        $criminal = Background::factory()->create([
             'name' => 'Criminal',
             'slug' => 'criminal',
         ]);
 
         // Add skill proficiencies
-        \App\Models\Proficiency::create([
+        Proficiency::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $criminal->id,
             'proficiency_type' => 'skill',
@@ -742,7 +763,7 @@ class ExtractFixturesCommandTest extends TestCase
             'proficiency_name' => null,
         ]);
 
-        \App\Models\Proficiency::create([
+        Proficiency::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $criminal->id,
             'proficiency_type' => 'skill',
@@ -751,7 +772,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add tool proficiency
-        \App\Models\Proficiency::create([
+        Proficiency::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $criminal->id,
             'proficiency_type' => 'tool',
@@ -761,7 +782,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add language proficiency
-        \App\Models\Proficiency::create([
+        Proficiency::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $criminal->id,
             'proficiency_type' => 'language',
@@ -770,7 +791,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add background feature
-        \App\Models\CharacterTrait::create([
+        CharacterTrait::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $criminal->id,
             'name' => 'Criminal Contact',
@@ -779,7 +800,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create entity source relationship
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $criminal->id,
             'source_id' => $source->id,
@@ -787,20 +808,20 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create second background with different proficiencies
-        $acolyte = \App\Models\Background::factory()->create([
+        $acolyte = Background::factory()->create([
             'name' => 'Acolyte',
             'slug' => 'acolyte',
         ]);
 
         // Add different skill proficiencies
-        \App\Models\Proficiency::create([
+        Proficiency::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $acolyte->id,
             'proficiency_type' => 'skill',
             'skill_id' => $insight->id,
         ]);
 
-        \App\Models\Proficiency::create([
+        Proficiency::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $acolyte->id,
             'proficiency_type' => 'skill',
@@ -808,7 +829,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add language proficiency
-        \App\Models\Proficiency::create([
+        Proficiency::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $acolyte->id,
             'proficiency_type' => 'language',
@@ -817,7 +838,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Add background feature
-        \App\Models\CharacterTrait::create([
+        CharacterTrait::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $acolyte->id,
             'name' => 'Shelter of the Faithful',
@@ -826,7 +847,7 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // Create entity source relationship
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\Background',
             'reference_id' => $acolyte->id,
             'source_id' => $source->id,
@@ -887,31 +908,31 @@ class ExtractFixturesCommandTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_optional_features_by_type(): void
     {
-        $source = \App\Models\Source::factory()->create(['code' => 'TEST-XGE']);
+        $source = Source::factory()->create(['code' => 'TEST-XGE']);
 
         // Get classes for associations
-        $warlock = \App\Models\CharacterClass::factory()->create([
+        $warlock = CharacterClass::factory()->create([
             'name' => 'Warlock',
             'slug' => 'warlock',
             'parent_class_id' => null,
         ]);
 
-        $monk = \App\Models\CharacterClass::factory()->create([
+        $monk = CharacterClass::factory()->create([
             'name' => 'Monk',
             'slug' => 'monk',
             'parent_class_id' => null,
         ]);
 
-        $fighter = \App\Models\CharacterClass::factory()->create([
+        $fighter = CharacterClass::factory()->create([
             'name' => 'Fighter',
             'slug' => 'fighter',
             'parent_class_id' => null,
         ]);
 
-        $sorcerer = \App\Models\CharacterClass::factory()->create([
+        $sorcerer = CharacterClass::factory()->create([
             'name' => 'Sorcerer',
             'slug' => 'sorcerer',
             'parent_class_id' => null,
@@ -920,13 +941,13 @@ class ExtractFixturesCommandTest extends TestCase
         // Create optional features of different types
 
         // 1. Eldritch Invocation
-        $invocation = \App\Models\OptionalFeature::factory()->invocation()->create([
+        $invocation = OptionalFeature::factory()->invocation()->create([
             'name' => 'Agonizing Blast',
             'slug' => 'agonizing-blast',
             'prerequisite_text' => 'eldritch blast cantrip',
         ]);
         $invocation->classes()->attach($warlock->id);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $invocation->id,
             'source_id' => $source->id,
@@ -934,12 +955,12 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // 2. Elemental Discipline (spell-like with resource cost)
-        $discipline = \App\Models\OptionalFeature::factory()->elementalDiscipline()->create([
+        $discipline = OptionalFeature::factory()->elementalDiscipline()->create([
             'name' => 'Fangs of the Fire Snake',
             'slug' => 'fangs-of-the-fire-snake',
         ]);
         $discipline->classes()->attach($monk->id, ['subclass_name' => 'Way of the Four Elements']);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $discipline->id,
             'source_id' => $source->id,
@@ -947,12 +968,12 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // 3. Maneuver
-        $maneuver = \App\Models\OptionalFeature::factory()->maneuver()->create([
+        $maneuver = OptionalFeature::factory()->maneuver()->create([
             'name' => 'Riposte',
             'slug' => 'riposte',
         ]);
         $maneuver->classes()->attach($fighter->id, ['subclass_name' => 'Battle Master']);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $maneuver->id,
             'source_id' => $source->id,
@@ -960,12 +981,12 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // 4. Metamagic
-        $metamagic = \App\Models\OptionalFeature::factory()->metamagic()->create([
+        $metamagic = OptionalFeature::factory()->metamagic()->create([
             'name' => 'Quickened Spell',
             'slug' => 'quickened-spell',
         ]);
         $metamagic->classes()->attach($sorcerer->id);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $metamagic->id,
             'source_id' => $source->id,
@@ -973,12 +994,12 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // 5. Fighting Style (available to multiple classes)
-        $fightingStyle = \App\Models\OptionalFeature::factory()->fightingStyle()->create([
+        $fightingStyle = OptionalFeature::factory()->fightingStyle()->create([
             'name' => 'Archery',
             'slug' => 'archery',
         ]);
         $fightingStyle->classes()->attach($fighter->id);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $fightingStyle->id,
             'source_id' => $source->id,
@@ -986,18 +1007,18 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // 6. Artificer Infusion
-        $artificer = \App\Models\CharacterClass::factory()->create([
+        $artificer = CharacterClass::factory()->create([
             'name' => 'Artificer',
             'slug' => 'artificer',
             'parent_class_id' => null,
         ]);
-        $infusion = \App\Models\OptionalFeature::factory()->artificerInfusion()->create([
+        $infusion = OptionalFeature::factory()->artificerInfusion()->create([
             'name' => 'Replicate Magic Item',
             'slug' => 'replicate-magic-item',
             'level_requirement' => 2,
         ]);
         $infusion->classes()->attach($artificer->id);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $infusion->id,
             'source_id' => $source->id,
@@ -1005,13 +1026,13 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // 7. Rune
-        $rune = \App\Models\OptionalFeature::factory()->rune()->create([
+        $rune = OptionalFeature::factory()->rune()->create([
             'name' => 'Cloud Rune',
             'slug' => 'cloud-rune',
             'level_requirement' => 7,
         ]);
         $rune->classes()->attach($fighter->id, ['subclass_name' => 'Rune Knight']);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $rune->id,
             'source_id' => $source->id,
@@ -1019,12 +1040,12 @@ class ExtractFixturesCommandTest extends TestCase
         ]);
 
         // 8. Arcane Shot
-        $arcaneShot = \App\Models\OptionalFeature::factory()->arcaneShot()->create([
+        $arcaneShot = OptionalFeature::factory()->arcaneShot()->create([
             'name' => 'Bursting Arrow',
             'slug' => 'bursting-arrow',
         ]);
         $arcaneShot->classes()->attach($fighter->id, ['subclass_name' => 'Arcane Archer']);
-        \App\Models\EntitySource::create([
+        EntitySource::create([
             'reference_type' => 'App\Models\OptionalFeature',
             'reference_id' => $arcaneShot->id,
             'source_id' => $source->id,

--- a/tests/Feature/Console/ImportMonstersCommandTest.php
+++ b/tests/Feature/Console/ImportMonstersCommandTest.php
@@ -3,10 +3,13 @@
 namespace Tests\Feature\Console;
 
 use App\Models\Monster;
+use App\Models\Size;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ImportMonstersCommandTest extends TestCase
 {
     use RefreshDatabase;
@@ -16,12 +19,12 @@ class ImportMonstersCommandTest extends TestCase
         parent::setUp();
 
         // Create required lookup data
-        \App\Models\Size::firstOrCreate(['code' => 'L'], ['name' => 'Large']);
-        \App\Models\Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
-        \App\Models\Size::firstOrCreate(['code' => 'S'], ['name' => 'Small']);
+        Size::firstOrCreate(['code' => 'L'], ['name' => 'Large']);
+        Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
+        Size::firstOrCreate(['code' => 'S'], ['name' => 'Small']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_monsters_from_xml_file_via_command(): void
     {
         $xmlPath = base_path('tests/Fixtures/xml/monsters/test-monsters.xml');
@@ -33,7 +36,7 @@ class ImportMonstersCommandTest extends TestCase
         $this->assertEquals(3, Monster::count());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_displays_strategy_statistics(): void
     {
         $xmlPath = base_path('tests/Fixtures/xml/monsters/test-monsters.xml');
@@ -46,7 +49,7 @@ class ImportMonstersCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_error_for_missing_file(): void
     {
         $this->artisan('import:monsters', ['file' => 'non-existent.xml'])
@@ -54,7 +57,7 @@ class ImportMonstersCommandTest extends TestCase
             ->assertExitCode(1);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_displays_success_message_with_count(): void
     {
         $xmlPath = base_path('tests/Fixtures/xml/monsters/test-monsters.xml');
@@ -64,7 +67,7 @@ class ImportMonstersCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_displays_log_file_location(): void
     {
         $xmlPath = base_path('tests/Fixtures/xml/monsters/test-monsters.xml');

--- a/tests/Feature/Console/WarmEntitiesCacheTest.php
+++ b/tests/Feature/Console/WarmEntitiesCacheTest.php
@@ -11,9 +11,11 @@ use App\Models\Race;
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class WarmEntitiesCacheTest extends TestCase
 {
     use RefreshDatabase;
@@ -28,7 +30,7 @@ class WarmEntitiesCacheTest extends TestCase
         Cache::flush();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_warms_all_entities_by_default(): void
     {
         // Arrange: Create sample entities
@@ -54,7 +56,7 @@ class WarmEntitiesCacheTest extends TestCase
         $this->assertTrue(Cache::has("entity:feat:{$feat->id}"));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_warm_specific_entity_type(): void
     {
         // Arrange: Create sample entities
@@ -70,7 +72,7 @@ class WarmEntitiesCacheTest extends TestCase
         $this->assertFalse(Cache::has("entity:item:{$item->id}"));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_warm_multiple_specific_entity_types(): void
     {
         // Arrange: Create sample entities
@@ -88,7 +90,7 @@ class WarmEntitiesCacheTest extends TestCase
         $this->assertFalse(Cache::has("entity:monster:{$monster->id}"));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_outputs_success_messages(): void
     {
         // Arrange: Create sample entities
@@ -105,7 +107,7 @@ class WarmEntitiesCacheTest extends TestCase
             ->assertExitCode(0);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_database_gracefully(): void
     {
         // Act & Assert: Run command on empty database
@@ -117,7 +119,7 @@ class WarmEntitiesCacheTest extends TestCase
             ->assertExitCode(0);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_exception_for_invalid_entity_type(): void
     {
         // Act & Assert: Run command with invalid type

--- a/tests/Feature/Importers/BackgroundXmlReconstructionTest.php
+++ b/tests/Feature/Importers/BackgroundXmlReconstructionTest.php
@@ -2,13 +2,15 @@
 
 namespace Tests\Feature\Importers;
 
+use App\Models\Background;
 use App\Services\Importers\BackgroundImporter;
 use App\Services\Parsers\BackgroundXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class BackgroundXmlReconstructionTest extends TestCase
 {
     use RefreshDatabase;
@@ -286,7 +288,7 @@ XML;
         }
 
         // Verify polymorphic relationship
-        $this->assertEquals(\App\Models\Background::class, $background->languageChoices->first()->reference_type);
+        $this->assertEquals(Background::class, $background->languageChoices->first()->reference_type);
         $this->assertEquals($background->id, $background->languageChoices->first()->reference_id);
     }
 }

--- a/tests/Feature/Importers/ClassImporterBonusCantripTest.php
+++ b/tests/Feature/Importers/ClassImporterBonusCantripTest.php
@@ -8,6 +8,7 @@ use App\Models\EntitySpell;
 use App\Models\Spell;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -18,7 +19,7 @@ class ClassImporterBonusCantripTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     private ClassImporter $importer;
 

--- a/tests/Feature/Importers/ClassImporterBonusSpellChoiceTest.php
+++ b/tests/Feature/Importers/ClassImporterBonusSpellChoiceTest.php
@@ -7,6 +7,7 @@ use App\Models\ClassFeature;
 use App\Models\EntityChoice;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +18,7 @@ class ClassImporterBonusSpellChoiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     private ClassImporter $importer;
 

--- a/tests/Feature/Importers/ClassImporterDataTablesTest.php
+++ b/tests/Feature/Importers/ClassImporterDataTablesTest.php
@@ -8,10 +8,11 @@ use App\Models\EntityDataTable;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ClassImporterDataTablesTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/ClassImporterFeatureProficiencyTest.php
+++ b/tests/Feature/Importers/ClassImporterFeatureProficiencyTest.php
@@ -7,6 +7,7 @@ use App\Models\ClassFeature;
 use App\Models\Proficiency;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +18,7 @@ class ClassImporterFeatureProficiencyTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     private ClassImporter $importer;
 

--- a/tests/Feature/Importers/ClassImporterFeatureSkillChoiceTest.php
+++ b/tests/Feature/Importers/ClassImporterFeatureSkillChoiceTest.php
@@ -8,6 +8,7 @@ use App\Models\EntityChoice;
 use App\Models\Skill;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -18,7 +19,7 @@ class ClassImporterFeatureSkillChoiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     private ClassImporter $importer;
 

--- a/tests/Feature/Importers/ClassImporterMergeTest.php
+++ b/tests/Feature/Importers/ClassImporterMergeTest.php
@@ -6,10 +6,11 @@ use App\Models\CharacterClass;
 use App\Services\Importers\ClassImporter;
 use App\Services\Importers\MergeMode;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ClassImporterMergeTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/ClassImporterSubclassSpellsTest.php
+++ b/tests/Feature/Importers/ClassImporterSubclassSpellsTest.php
@@ -8,6 +8,7 @@ use App\Models\EntitySpell;
 use App\Models\Spell;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -18,7 +19,7 @@ class ClassImporterSubclassSpellsTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     private ClassImporter $importer;
 

--- a/tests/Feature/Importers/ClassImporterTest.php
+++ b/tests/Feature/Importers/ClassImporterTest.php
@@ -3,13 +3,15 @@
 namespace Tests\Feature\Importers;
 
 use App\Models\CharacterClass;
+use App\Models\EntityChoice;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ClassImporterTest extends TestCase
 {
     use RefreshDatabase;
@@ -277,7 +279,7 @@ class ClassImporterTest extends TestCase
         $this->assertGreaterThan(0, $proficiencies->count());
 
         // Get skill choices from EntityChoice table
-        $skillChoices = \App\Models\EntityChoice::where('reference_type', \App\Models\CharacterClass::class)
+        $skillChoices = EntityChoice::where('reference_type', CharacterClass::class)
             ->where('reference_id', $fighter->id)
             ->where('choice_type', 'proficiency')
             ->where('proficiency_type', 'skill')
@@ -334,7 +336,7 @@ class ClassImporterTest extends TestCase
         $this->assertGreaterThan(0, $barbarian->equipment()->count(), 'Barbarian should have equipment');
 
         // Assert: verify equipment choices in EntityChoice table
-        $equipmentChoices = \App\Models\EntityChoice::where('reference_type', \App\Models\CharacterClass::class)
+        $equipmentChoices = EntityChoice::where('reference_type', CharacterClass::class)
             ->where('reference_id', $barbarian->id)
             ->where('choice_type', 'equipment')
             ->get();
@@ -573,7 +575,7 @@ XML;
         $class = $this->importer->import($classData);
 
         // Get all equipment choices for this class
-        $equipmentChoices = \App\Models\EntityChoice::where('reference_type', \App\Models\CharacterClass::class)
+        $equipmentChoices = EntityChoice::where('reference_type', CharacterClass::class)
             ->where('reference_id', $class->id)
             ->where('choice_type', 'equipment')
             ->orderBy('choice_group')

--- a/tests/Feature/Importers/ClassXmlReconstructionTest.php
+++ b/tests/Feature/Importers/ClassXmlReconstructionTest.php
@@ -6,10 +6,11 @@ use App\Models\CharacterClass;
 use App\Services\Importers\ClassImporter;
 use App\Services\Parsers\ClassXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ClassXmlReconstructionTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/FeatImporterPrerequisitesTest.php
+++ b/tests/Feature/Importers/FeatImporterPrerequisitesTest.php
@@ -8,10 +8,11 @@ use App\Models\ProficiencyType;
 use App\Models\Race;
 use App\Services\Importers\FeatImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class FeatImporterPrerequisitesTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/FeatImporterTest.php
+++ b/tests/Feature/Importers/FeatImporterTest.php
@@ -2,14 +2,18 @@
 
 namespace Tests\Feature\Importers;
 
+use App\Models\AbilityScore;
+use App\Models\DamageType;
 use App\Models\Feat;
+use App\Models\Spell;
 use App\Services\Importers\FeatImporter;
 use App\Services\Parsers\FeatXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class FeatImporterTest extends TestCase
 {
     use RefreshDatabase;
@@ -170,7 +174,7 @@ class FeatImporterTest extends TestCase
         // For unrestricted proficiency choices, we need to bypass the normal flow
         // by creating the feat first, then manually calling importEntityProficiencies
 
-        $feat = \App\Models\Feat::create([
+        $feat = Feat::create([
             'name' => 'Weapon Master',
             'slug' => 'weapon-master',
             'description' => 'You have practiced extensively with weapons.',
@@ -178,7 +182,7 @@ class FeatImporterTest extends TestCase
         ]);
 
         // Call the trait method directly with properly formatted data
-        $importer = new \App\Services\Importers\FeatImporter;
+        $importer = new FeatImporter;
         $reflection = new \ReflectionClass($importer);
         $method = $reflection->getMethod('importEntityProficiencies');
         $method->setAccessible(true);
@@ -278,13 +282,13 @@ class FeatImporterTest extends TestCase
     public function it_imports_feat_with_specific_spell()
     {
         // Create test spells
-        $mistyStep = \App\Models\Spell::factory()->create([
+        $mistyStep = Spell::factory()->create([
             'name' => 'Misty Step',
             'slug' => 'misty-step',
             'level' => 2,
         ]);
 
-        $charisma = \App\Models\AbilityScore::where('code', 'CHA')->first();
+        $charisma = AbilityScore::where('code', 'CHA')->first();
 
         $featData = [
             'name' => 'Fey Touched (Charisma)',
@@ -322,8 +326,8 @@ class FeatImporterTest extends TestCase
     public function it_clears_spells_on_reimport()
     {
         // Create test spells
-        $spell1 = \App\Models\Spell::factory()->create(['name' => 'Spell One', 'slug' => 'spell-one']);
-        $spell2 = \App\Models\Spell::factory()->create(['name' => 'Spell Two', 'slug' => 'spell-two']);
+        $spell1 = Spell::factory()->create(['name' => 'Spell One', 'slug' => 'spell-one']);
+        $spell2 = Spell::factory()->create(['name' => 'Spell Two', 'slug' => 'spell-two']);
 
         $featData = [
             'name' => 'Magic Feat',
@@ -429,8 +433,8 @@ class FeatImporterTest extends TestCase
     public function it_imports_feat_with_damage_resistances()
     {
         // Get damage types that exist in the database (seeded or from import)
-        $cold = \App\Models\DamageType::whereRaw('LOWER(name) = ?', ['cold'])->first();
-        $poison = \App\Models\DamageType::whereRaw('LOWER(name) = ?', ['poison'])->first();
+        $cold = DamageType::whereRaw('LOWER(name) = ?', ['cold'])->first();
+        $poison = DamageType::whereRaw('LOWER(name) = ?', ['poison'])->first();
 
         // Skip test if damage types not available
         if (! $cold || ! $poison) {

--- a/tests/Feature/Importers/FeatXmlReconstructionTest.php
+++ b/tests/Feature/Importers/FeatXmlReconstructionTest.php
@@ -8,10 +8,11 @@ use App\Models\ProficiencyType;
 use App\Models\Race;
 use App\Services\Importers\FeatImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class FeatXmlReconstructionTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/ImporterFileNotFoundTest.php
+++ b/tests/Feature/Importers/ImporterFileNotFoundTest.php
@@ -5,10 +5,11 @@ namespace Tests\Feature\Importers;
 use App\Exceptions\Import\FileNotFoundException;
 use App\Services\Importers\SpellImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ImporterFileNotFoundTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/ItemChargesImportTest.php
+++ b/tests/Feature/Importers/ItemChargesImportTest.php
@@ -6,10 +6,11 @@ use App\Models\Item;
 use App\Services\Importers\ItemImporter;
 use App\Services\Parsers\ItemXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ItemChargesImportTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/ItemConditionalSpeedModifierTest.php
+++ b/tests/Feature/Importers/ItemConditionalSpeedModifierTest.php
@@ -6,10 +6,11 @@ use App\Models\Modifier;
 use App\Services\Importers\ItemImporter;
 use App\Services\Parsers\ItemXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ItemConditionalSpeedModifierTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/ItemPackContentsImportTest.php
+++ b/tests/Feature/Importers/ItemPackContentsImportTest.php
@@ -6,14 +6,17 @@ use App\Models\EntityItem;
 use App\Models\Item;
 use App\Models\ItemType;
 use App\Services\Importers\Concerns\ImportsPackContents;
+use Database\Seeders\ItemTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
  * Tests for the ImportsPackContents trait that links equipment packs
  * to their contained items.
  */
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ItemPackContentsImportTest extends TestCase
 {
     use RefreshDatabase;
@@ -26,13 +29,13 @@ class ItemPackContentsImportTest extends TestCase
 
         // Seed item types
         if (ItemType::count() === 0) {
-            $this->seed(\Database\Seeders\ItemTypeSeeder::class);
+            $this->seed(ItemTypeSeeder::class);
         }
 
         $this->gearType = ItemType::where('code', 'G')->first();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_links_pack_contents_to_existing_items(): void
     {
         // Create the pack with description
@@ -88,7 +91,7 @@ class ItemPackContentsImportTest extends TestCase
         $this->assertEquals(10, $torchContent->quantity);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_items_that_do_not_exist_in_database(): void
     {
         // Create the pack with description including non-existent item
@@ -120,7 +123,7 @@ class ItemPackContentsImportTest extends TestCase
         $this->assertEquals($backpack->id, $contents->first()->item_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_clears_existing_contents_before_importing(): void
     {
         // Create pack
@@ -170,7 +173,7 @@ class ItemPackContentsImportTest extends TestCase
         $this->assertEquals(1, $contents->first()->quantity);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_nothing_for_items_without_includes_section(): void
     {
         // Create a regular item (not a pack)
@@ -192,7 +195,7 @@ class ItemPackContentsImportTest extends TestCase
         $this->assertCount(0, $item->fresh()->contents);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_matches_items_case_insensitively(): void
     {
         $pack = Item::factory()->create([

--- a/tests/Feature/Importers/ItemPrerequisitesImporterTest.php
+++ b/tests/Feature/Importers/ItemPrerequisitesImporterTest.php
@@ -7,14 +7,16 @@ use App\Models\EntityPrerequisite;
 use App\Models\Item;
 use App\Services\Importers\ItemImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ItemPrerequisitesImporterTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_item_with_strength_requirement_as_prerequisite()
     {
         // Arrange: XML with strength requirement
@@ -56,7 +58,7 @@ XML;
         $this->assertEquals(1, $prerequisite->group_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_create_prerequisite_for_item_without_strength_requirement()
     {
         // Arrange: XML without strength requirement
@@ -89,7 +91,7 @@ XML;
         $this->assertEquals(0, $prerequisiteCount);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_prerequisites_on_reimport()
     {
         // Arrange: Create item with strength 13
@@ -146,7 +148,7 @@ XML;
         $this->assertEquals(15, $item->strength_requirement);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_prerequisites_when_strength_requirement_removed()
     {
         // Arrange: Create item with strength requirement

--- a/tests/Feature/Importers/ItemSpellsImportTest.php
+++ b/tests/Feature/Importers/ItemSpellsImportTest.php
@@ -3,12 +3,18 @@
 namespace Tests\Feature\Importers;
 
 use App\Models\Item;
+use App\Models\ItemType;
 use App\Models\Spell;
+use App\Models\SpellSchool;
+use Database\Seeders\ItemTypeSeeder;
+use Database\Seeders\SpellSchoolSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ItemSpellsImportTest extends TestCase
 {
     use RefreshDatabase;
@@ -19,15 +25,15 @@ class ItemSpellsImportTest extends TestCase
 
         // Seed required lookup data (only if not already seeded)
         // Sources are created via factory when needed by getSource()
-        if (\App\Models\SpellSchool::count() === 0) {
-            $this->seed(\Database\Seeders\SpellSchoolSeeder::class);
+        if (SpellSchool::count() === 0) {
+            $this->seed(SpellSchoolSeeder::class);
         }
-        if (\App\Models\ItemType::count() === 0) {
-            $this->seed(\Database\Seeders\ItemTypeSeeder::class);
+        if (ItemType::count() === 0) {
+            $this->seed(ItemTypeSeeder::class);
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_staff_of_healing_with_spell_charge_costs()
     {
         // Create the spells that the staff can cast
@@ -92,7 +98,7 @@ XML;
         fclose($xmlFile);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_items_without_spells_gracefully()
     {
         // Import Wand of Smiles (has charges but no spells)
@@ -127,7 +133,7 @@ XML;
         fclose($xmlFile);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_spells_that_dont_exist_in_database()
     {
         // Create only one of the spells
@@ -163,7 +169,7 @@ XML;
         fclose($xmlFile);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_spell_charge_costs_on_reimport()
     {
         $cureWounds = Spell::factory()->create(['name' => 'Cure Wounds', 'level' => 1]);
@@ -215,7 +221,7 @@ XML;
         fclose($xmlFile);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_case_insensitive_spell_name_matching()
     {
         // Create spell with specific casing

--- a/tests/Feature/Importers/ItemXmlReconstructionTest.php
+++ b/tests/Feature/Importers/ItemXmlReconstructionTest.php
@@ -2,14 +2,16 @@
 
 namespace Tests\Feature\Importers;
 
+use App\Models\AbilityScore;
 use App\Models\Item;
 use App\Services\Importers\ItemImporter;
 use App\Services\Parsers\ItemXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class ItemXmlReconstructionTest extends TestCase
 {
     use RefreshDatabase;
@@ -603,9 +605,9 @@ XML;
         $this->assertCount(1, $item->prerequisites);
 
         $prerequisite = $item->prerequisites->first();
-        $this->assertEquals(\App\Models\Item::class, $prerequisite->reference_type);
+        $this->assertEquals(Item::class, $prerequisite->reference_type);
         $this->assertEquals($item->id, $prerequisite->reference_id);
-        $this->assertEquals(\App\Models\AbilityScore::class, $prerequisite->prerequisite_type);
+        $this->assertEquals(AbilityScore::class, $prerequisite->prerequisite_type);
         $this->assertEquals(15, $prerequisite->minimum_value);
         $this->assertEquals(1, $prerequisite->group_id);
         $this->assertNull($prerequisite->description);

--- a/tests/Feature/Importers/OptionalFeatureXmlReconstructionTest.php
+++ b/tests/Feature/Importers/OptionalFeatureXmlReconstructionTest.php
@@ -9,10 +9,11 @@ use App\Models\OptionalFeature;
 use App\Models\SpellSchool;
 use App\Services\Importers\OptionalFeatureImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class OptionalFeatureXmlReconstructionTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/RaceXmlReconstructionTest.php
+++ b/tests/Feature/Importers/RaceXmlReconstructionTest.php
@@ -8,11 +8,15 @@ use App\Models\Race;
 use App\Models\Size;
 use App\Services\Importers\RaceImporter;
 use App\Services\Parsers\Concerns\MatchesLanguages;
+use Database\Seeders\AbilityScoreSeeder;
+use Database\Seeders\LanguageSeeder;
+use Database\Seeders\SizeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class RaceXmlReconstructionTest extends TestCase
 {
     use RefreshDatabase;
@@ -25,13 +29,13 @@ class RaceXmlReconstructionTest extends TestCase
 
         // Seed necessary lookup tables for race imports
         if (Size::count() === 0) {
-            $this->seed(\Database\Seeders\SizeSeeder::class);
+            $this->seed(SizeSeeder::class);
         }
         if (AbilityScore::count() === 0) {
-            $this->seed(\Database\Seeders\AbilityScoreSeeder::class);
+            $this->seed(AbilityScoreSeeder::class);
         }
         if (Language::count() === 0) {
-            $this->seed(\Database\Seeders\LanguageSeeder::class);
+            $this->seed(LanguageSeeder::class);
         }
 
         // Clear static cache so it uses fresh seeded data

--- a/tests/Feature/Importers/SourceImporterTest.php
+++ b/tests/Feature/Importers/SourceImporterTest.php
@@ -5,10 +5,11 @@ namespace Tests\Feature\Importers;
 use App\Models\Source;
 use App\Services\Importers\SourceImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class SourceImporterTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Importers/SpellClassMappingImporterTest.php
+++ b/tests/Feature/Importers/SpellClassMappingImporterTest.php
@@ -7,9 +7,11 @@ use App\Models\Spell;
 use App\Services\Importers\SpellClassMappingImporter;
 use App\Services\Parsers\SpellClassMappingParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class SpellClassMappingImporterTest extends TestCase
 {
     use RefreshDatabase;
@@ -25,7 +27,7 @@ class SpellClassMappingImporterTest extends TestCase
         $this->importer = new SpellClassMappingImporter(new SpellClassMappingParser);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_adds_class_associations_to_existing_spell()
     {
         // Create classes and spell
@@ -70,7 +72,7 @@ XML;
         $this->assertContains('Oathbreaker', $classNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_duplicate_existing_class_associations()
     {
         // Create classes
@@ -111,7 +113,7 @@ XML;
         $this->assertContains('Oathbreaker', $classNames);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_base_class_without_subclass()
     {
         // Create base classes
@@ -146,7 +148,7 @@ XML;
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_spells_not_found_in_database()
     {
         $xml = <<<'XML'
@@ -168,7 +170,7 @@ XML;
         $this->assertEquals(['Nonexistent Spell'], $stats['spells_not_found']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_processes_multiple_spells()
     {
         // Create classes
@@ -208,7 +210,7 @@ XML;
         $this->assertEmpty($stats['spells_not_found']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_fuzzy_matching_for_spell_names()
     {
         // Create classes
@@ -239,7 +241,7 @@ XML;
         $this->assertEquals(1, $stats['classes_added']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_subclass_aliases()
     {
         // Create classes

--- a/tests/Feature/Importers/SpellDataTableImportTest.php
+++ b/tests/Feature/Importers/SpellDataTableImportTest.php
@@ -5,12 +5,15 @@ namespace Tests\Feature\Importers;
 use App\Models\EntityDataTable;
 use App\Models\EntityDataTableEntry;
 use App\Models\Spell;
+use App\Models\SpellSchool;
 use App\Services\Importers\SpellImporter;
+use Database\Seeders\SpellSchoolSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class SpellDataTableImportTest extends TestCase
 {
     use RefreshDatabase;
@@ -20,8 +23,8 @@ class SpellDataTableImportTest extends TestCase
         parent::setUp();
 
         // Only seed if not already seeded (prevents duplicate key errors)
-        if (\App\Models\SpellSchool::count() === 0) {
-            $this->seed(\Database\Seeders\SpellSchoolSeeder::class);
+        if (SpellSchool::count() === 0) {
+            $this->seed(SpellSchoolSeeder::class);
         }
     }
 

--- a/tests/Feature/Importers/SpellXmlReconstructionTest.php
+++ b/tests/Feature/Importers/SpellXmlReconstructionTest.php
@@ -6,10 +6,11 @@ use App\Models\CharacterClass;
 use App\Models\Spell;
 use App\Services\Importers\SpellImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('importers')]
+#[Group('importers')]
 class SpellXmlReconstructionTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Models/BackgroundModelTest.php
+++ b/tests/Feature/Models/BackgroundModelTest.php
@@ -6,16 +6,18 @@ use App\Models\Background;
 use App\Models\CharacterTrait;
 use App\Models\EntitySource;
 use App\Models\Proficiency;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class BackgroundModelTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function background_has_traits_relationship()

--- a/tests/Feature/Models/CharacterClassFeatureMergingTest.php
+++ b/tests/Feature/Models/CharacterClassFeatureMergingTest.php
@@ -4,16 +4,18 @@ namespace Tests\Feature\Models;
 
 use App\Models\CharacterClass;
 use App\Models\ClassFeature;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class CharacterClassFeatureMergingTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     protected CharacterClass $baseClass;
 

--- a/tests/Feature/Models/CharacterClassSubclassLevelTest.php
+++ b/tests/Feature/Models/CharacterClassSubclassLevelTest.php
@@ -4,16 +4,18 @@ namespace Tests\Feature\Models;
 
 use App\Models\CharacterClass;
 use App\Models\ClassFeature;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class CharacterClassSubclassLevelTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function base_class_returns_subclass_level_from_subclass_features()

--- a/tests/Feature/Models/ClassFeatureParentChildTest.php
+++ b/tests/Feature/Models/ClassFeatureParentChildTest.php
@@ -4,16 +4,18 @@ namespace Tests\Feature\Models;
 
 use App\Models\CharacterClass;
 use App\Models\ClassFeature;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ClassFeatureParentChildTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     protected CharacterClass $fighter;
 

--- a/tests/Feature/Models/ConditionModelTest.php
+++ b/tests/Feature/Models/ConditionModelTest.php
@@ -6,11 +6,13 @@ use App\Models\Condition;
 use App\Models\EntityCondition;
 use App\Models\Feat;
 use App\Models\Race;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ConditionModelTest extends TestCase
 {
     use RefreshDatabase;
@@ -55,7 +57,7 @@ class ConditionModelTest extends TestCase
             'description' => 'First unique test condition.',
         ]);
 
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectException(QueryException::class);
 
         Condition::create([
             'name' => 'Unique Test (Duplicate)',

--- a/tests/Feature/Models/EntityDataTableModelTest.php
+++ b/tests/Feature/Models/EntityDataTableModelTest.php
@@ -7,10 +7,11 @@ use App\Models\EntityDataTable;
 use App\Models\EntityDataTableEntry;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class EntityDataTableModelTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Models/EntityPrerequisiteModelTest.php
+++ b/tests/Feature/Models/EntityPrerequisiteModelTest.php
@@ -9,16 +9,18 @@ use App\Models\Item;
 use App\Models\ProficiencyType;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class EntityPrerequisiteModelTest extends TestCase
 {
     use RefreshDatabase;
 
     protected $seed = true;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function feat_has_prerequisites_relationship()
     {
         $feat = Feat::factory()->create();
@@ -34,7 +36,7 @@ class EntityPrerequisiteModelTest extends TestCase
         $this->assertInstanceOf(EntityPrerequisite::class, $feat->prerequisites->first());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function item_has_prerequisites_relationship()
     {
         $item = Item::factory()->create();
@@ -47,7 +49,7 @@ class EntityPrerequisiteModelTest extends TestCase
         $this->assertCount(1, $item->prerequisites);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function prerequisite_belongs_to_reference_entity()
     {
         $feat = Feat::factory()->create();
@@ -61,7 +63,7 @@ class EntityPrerequisiteModelTest extends TestCase
         $this->assertEquals($feat->id, $prerequisite->reference->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function prerequisite_belongs_to_ability_score()
     {
         $feat = Feat::factory()->create();
@@ -76,7 +78,7 @@ class EntityPrerequisiteModelTest extends TestCase
         $this->assertEquals($str->id, $prerequisite->prerequisite->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function prerequisite_belongs_to_race()
     {
         $feat = Feat::factory()->create();
@@ -91,7 +93,7 @@ class EntityPrerequisiteModelTest extends TestCase
         $this->assertEquals('Elf', $prerequisite->prerequisite->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function prerequisite_belongs_to_proficiency_type()
     {
         $feat = Feat::factory()->create();
@@ -106,7 +108,7 @@ class EntityPrerequisiteModelTest extends TestCase
         $this->assertEquals('Medium Armor', $prerequisite->prerequisite->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function prerequisite_supports_free_form_description()
     {
         $feat = Feat::factory()->create();
@@ -120,7 +122,7 @@ class EntityPrerequisiteModelTest extends TestCase
         $this->assertEquals('The ability to cast at least one spell', $prerequisite->description);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function feat_can_have_multiple_prerequisites_with_groups()
     {
         $feat = Feat::factory()->create();

--- a/tests/Feature/Models/EntitySourceTest.php
+++ b/tests/Feature/Models/EntitySourceTest.php
@@ -6,10 +6,11 @@ use App\Models\EntitySource;
 use App\Models\Source;
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class EntitySourceTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Models/EntitySpellModelTest.php
+++ b/tests/Feature/Models/EntitySpellModelTest.php
@@ -6,11 +6,13 @@ use App\Models\AbilityScore;
 use App\Models\EntitySpell;
 use App\Models\Race;
 use App\Models\Spell;
+use Database\Seeders\AbilityScoreSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class EntitySpellModelTest extends TestCase
 {
     use RefreshDatabase;
@@ -20,7 +22,7 @@ class EntitySpellModelTest extends TestCase
         parent::setUp();
         // Only seed if ability scores don't exist
         if (AbilityScore::count() === 0) {
-            $this->seed(\Database\Seeders\AbilityScoreSeeder::class);
+            $this->seed(AbilityScoreSeeder::class);
         }
     }
 

--- a/tests/Feature/Models/FeatModelTest.php
+++ b/tests/Feature/Models/FeatModelTest.php
@@ -8,10 +8,11 @@ use App\Models\Modifier;
 use App\Models\Proficiency;
 use App\Models\Source;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class FeatModelTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Models/ModifierModelTest.php
+++ b/tests/Feature/Models/ModifierModelTest.php
@@ -3,13 +3,15 @@
 namespace Tests\Feature\Models;
 
 use App\Models\AbilityScore;
+use App\Models\EntityChoice;
 use App\Models\Modifier;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ModifierModelTest extends TestCase
 {
     use RefreshDatabase;
@@ -58,7 +60,7 @@ class ModifierModelTest extends TestCase
         $race = Race::factory()->create();
 
         // Choice modifiers are now stored in entity_choices table
-        $entityChoice = \App\Models\EntityChoice::create([
+        $entityChoice = EntityChoice::create([
             'reference_type' => Race::class,
             'reference_id' => $race->id,
             'choice_type' => 'ability_score',

--- a/tests/Feature/Models/OptionalFeatureTest.php
+++ b/tests/Feature/Models/OptionalFeatureTest.php
@@ -10,16 +10,18 @@ use App\Models\EntityDataTable;
 use App\Models\EntityPrerequisite;
 use App\Models\EntitySource;
 use App\Models\OptionalFeature;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class OptionalFeatureTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     // Basic Model Tests
 

--- a/tests/Feature/Models/ProficiencyModelTest.php
+++ b/tests/Feature/Models/ProficiencyModelTest.php
@@ -6,10 +6,11 @@ use App\Models\Proficiency;
 use App\Models\Race;
 use App\Models\Skill;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ProficiencyModelTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Models/RaceModelTest.php
+++ b/tests/Feature/Models/RaceModelTest.php
@@ -2,12 +2,18 @@
 
 namespace Tests\Feature\Models;
 
+use App\Models\Condition;
 use App\Models\EntityLanguage;
 use App\Models\EntitySense;
+use App\Models\EntitySpell;
 use App\Models\Language;
 use App\Models\Race;
 use App\Models\Sense;
+use App\Models\Spell;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -16,7 +22,7 @@ use Tests\TestCase;
  *
  * @see https://github.com/dfox288/ledger-of-heroes/issues/581
  */
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class RaceModelTest extends TestCase
 {
     use RefreshDatabase;
@@ -63,19 +69,19 @@ class RaceModelTest extends TestCase
     public function race_has_conditions_relationship(): void
     {
         $race = Race::factory()->create();
-        $condition = \App\Models\Condition::firstOrCreate(
+        $condition = Condition::firstOrCreate(
             ['slug' => 'poisoned'],
             ['name' => 'Poisoned', 'description' => 'Test condition']
         );
 
-        \Illuminate\Support\Facades\DB::table('entity_conditions')->insert([
+        DB::table('entity_conditions')->insert([
             'reference_type' => Race::class,
             'reference_id' => $race->id,
             'condition_id' => $condition->id,
             'effect_type' => 'advantage',
         ]);
 
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $race->conditions);
+        $this->assertInstanceOf(Collection::class, $race->conditions);
         $this->assertCount(1, $race->fresh()->conditions);
     }
 
@@ -83,16 +89,16 @@ class RaceModelTest extends TestCase
     public function race_has_spells_relationship(): void
     {
         $race = Race::factory()->create();
-        $spell = \App\Models\Spell::factory()->create();
+        $spell = Spell::factory()->create();
 
-        \App\Models\EntitySpell::create([
+        EntitySpell::create([
             'reference_type' => Race::class,
             'reference_id' => $race->id,
             'spell_id' => $spell->id,
             'is_cantrip' => true,
         ]);
 
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $race->spells);
+        $this->assertInstanceOf(Collection::class, $race->spells);
         $this->assertCount(1, $race->fresh()->spells);
     }
 

--- a/tests/Feature/Models/TraitModelTest.php
+++ b/tests/Feature/Models/TraitModelTest.php
@@ -5,10 +5,11 @@ namespace Tests\Feature\Models;
 use App\Models\CharacterTrait;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class TraitModelTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/OptionalFeatures/OptionalFeatureProgressionTest.php
+++ b/tests/Feature/OptionalFeatures/OptionalFeatureProgressionTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 use App\Models\Character;
 use App\Models\CharacterClass;
+use Tests\TestCase;
 use Tests\Traits\CreatesTestCharacters;
 
-uses(Tests\TestCase::class, CreatesTestCharacters::class)->group('integration');
+uses(TestCase::class, CreatesTestCharacters::class)->group('integration');
 
 /*
 |--------------------------------------------------------------------------
@@ -37,8 +38,8 @@ beforeEach(function () {
     config(['database.connections.mysql.password' => 'dnd_password']);
 
     // Purge existing connections and reconnect
-    \DB::purge('mysql');
-    \DB::reconnect('mysql');
+    DB::purge('mysql');
+    DB::reconnect('mysql');
 
     // Skip if required classes aren't imported
     $classCount = CharacterClass::count();

--- a/tests/Feature/Requests/BackgroundIndexRequestTest.php
+++ b/tests/Feature/Requests/BackgroundIndexRequestTest.php
@@ -4,16 +4,18 @@ namespace Tests\Feature\Requests;
 
 use App\Models\Background;
 use App\Models\Source;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class BackgroundIndexRequestTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_whitelists_sortable_columns()

--- a/tests/Feature/Requests/BackgroundShowRequestTest.php
+++ b/tests/Feature/Requests/BackgroundShowRequestTest.php
@@ -4,16 +4,18 @@ namespace Tests\Feature\Requests;
 
 use App\Models\Background;
 use App\Models\Source;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class BackgroundShowRequestTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_validates_includable_relationships()

--- a/tests/Feature/Requests/ClassIndexRequestTest.php
+++ b/tests/Feature/Requests/ClassIndexRequestTest.php
@@ -6,10 +6,15 @@ use App\Models\AbilityScore;
 use App\Models\CharacterClass;
 use App\Models\ProficiencyType;
 use App\Models\Skill;
+use Database\Seeders\AbilityScoreSeeder;
+use Database\Seeders\ProficiencyTypeSeeder;
+use Database\Seeders\SkillSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ClassIndexRequestTest extends TestCase
 {
     use RefreshDatabase;
@@ -20,17 +25,17 @@ class ClassIndexRequestTest extends TestCase
 
         // Only seed if database is empty
         if (AbilityScore::count() === 0) {
-            $this->seed(\Database\Seeders\AbilityScoreSeeder::class);
+            $this->seed(AbilityScoreSeeder::class);
         }
         if (ProficiencyType::count() === 0) {
-            $this->seed(\Database\Seeders\ProficiencyTypeSeeder::class);
+            $this->seed(ProficiencyTypeSeeder::class);
         }
         if (Skill::count() === 0) {
-            $this->seed(\Database\Seeders\SkillSeeder::class);
+            $this->seed(SkillSeeder::class);
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_whitelists_sortable_columns(): void
     {
         CharacterClass::factory()->create(['name' => 'Barbarian']);
@@ -48,7 +53,7 @@ class ClassIndexRequestTest extends TestCase
         $response->assertJsonValidationErrors('sort_by');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_per_page_limit(): void
     {
         CharacterClass::factory()->create(['name' => 'Paladin']);
@@ -71,7 +76,7 @@ class ClassIndexRequestTest extends TestCase
         $response->assertJsonValidationErrors('per_page');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_q_max_length(): void
     {
         CharacterClass::factory()->create(['name' => 'Druid']);

--- a/tests/Feature/Requests/ClassShowRequestTest.php
+++ b/tests/Feature/Requests/ClassShowRequestTest.php
@@ -4,9 +4,11 @@ namespace Tests\Feature\Requests;
 
 use App\Models\CharacterClass;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ClassShowRequestTest extends TestCase
 {
     use RefreshDatabase;
@@ -16,7 +18,7 @@ class ClassShowRequestTest extends TestCase
         parent::setUp();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_includable_relationships(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Wizard']);
@@ -45,7 +47,7 @@ class ClassShowRequestTest extends TestCase
         $response->assertJsonValidationErrors('include.0');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_selectable_fields(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Cleric']);
@@ -64,7 +66,7 @@ class ClassShowRequestTest extends TestCase
         $response->assertJsonValidationErrors('fields.0');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_multiple_includes(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Bard']);
@@ -76,7 +78,7 @@ class ClassShowRequestTest extends TestCase
         $response->assertStatus(200);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_multiple_fields(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Sorcerer']);

--- a/tests/Feature/Requests/ClassSpellListRequestTest.php
+++ b/tests/Feature/Requests/ClassSpellListRequestTest.php
@@ -5,10 +5,13 @@ namespace Tests\Feature\Requests;
 use App\Models\CharacterClass;
 use App\Models\Spell;
 use App\Models\SpellSchool;
+use Database\Seeders\SpellSchoolSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ClassSpellListRequestTest extends TestCase
 {
     use RefreshDatabase;
@@ -19,11 +22,11 @@ class ClassSpellListRequestTest extends TestCase
 
         // Only seed if database is empty
         if (SpellSchool::count() === 0) {
-            $this->seed(\Database\Seeders\SpellSchoolSeeder::class);
+            $this->seed(SpellSchoolSeeder::class);
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_spell_level_range(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Wizard']);
@@ -48,7 +51,7 @@ class ClassSpellListRequestTest extends TestCase
         $response->assertJsonValidationErrors('level');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_school_exists(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Sorcerer']);
@@ -67,7 +70,7 @@ class ClassSpellListRequestTest extends TestCase
         $response->assertJsonValidationErrors('school');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_boolean_filters(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Cleric']);
@@ -94,7 +97,7 @@ class ClassSpellListRequestTest extends TestCase
         $response->assertJsonValidationErrors('concentration');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_sortable_columns(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Druid']);
@@ -114,7 +117,7 @@ class ClassSpellListRequestTest extends TestCase
         $response->assertJsonValidationErrors('sort_by');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_per_page_limit(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Bard']);
@@ -139,7 +142,7 @@ class ClassSpellListRequestTest extends TestCase
         $response->assertJsonValidationErrors('per_page');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_search_max_length(): void
     {
         $class = CharacterClass::factory()->create(['name' => 'Warlock']);

--- a/tests/Feature/Requests/FeatIndexRequestTest.php
+++ b/tests/Feature/Requests/FeatIndexRequestTest.php
@@ -3,14 +3,16 @@
 namespace Tests\Feature\Requests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class FeatIndexRequestTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_whitelists_sortable_columns()
     {
         // Valid sortable columns (no timestamps - models use BaseModel with $timestamps = false)
@@ -26,7 +28,7 @@ class FeatIndexRequestTest extends TestCase
             ->assertJsonValidationErrors(['sort_by']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_base_index_parameters()
     {
         // Valid pagination

--- a/tests/Feature/Requests/FeatShowRequestTest.php
+++ b/tests/Feature/Requests/FeatShowRequestTest.php
@@ -4,14 +4,16 @@ namespace Tests\Feature\Requests;
 
 use App\Models\Feat;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class FeatShowRequestTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_includable_relationships()
     {
         $feat = Feat::factory()->create();
@@ -34,7 +36,7 @@ class FeatShowRequestTest extends TestCase
             ->assertJsonValidationErrors(['include.0']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_selectable_fields()
     {
         $feat = Feat::factory()->create();
@@ -53,7 +55,7 @@ class FeatShowRequestTest extends TestCase
             ->assertJsonValidationErrors(['fields.0']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_all_defined_includable_relationships()
     {
         $feat = Feat::factory()->create();
@@ -78,7 +80,7 @@ class FeatShowRequestTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_all_defined_selectable_fields()
     {
         $feat = Feat::factory()->create();
@@ -99,7 +101,7 @@ class FeatShowRequestTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_works_without_include_or_fields_parameters()
     {
         $feat = Feat::factory()->create();

--- a/tests/Feature/Requests/ItemIndexRequestTest.php
+++ b/tests/Feature/Requests/ItemIndexRequestTest.php
@@ -4,12 +4,14 @@ namespace Tests\Feature\Requests;
 
 use App\Http\Requests\ItemIndexRequest;
 use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ItemIndexRequestTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_per_page_limit()
     {
         $request = new ItemIndexRequest;
@@ -38,7 +40,7 @@ class ItemIndexRequestTest extends TestCase
         $this->assertArrayHasKey('per_page', $validator->errors()->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_whitelists_sortable_columns()
     {
         $request = new ItemIndexRequest;
@@ -63,7 +65,7 @@ class ItemIndexRequestTest extends TestCase
         $this->assertArrayHasKey('sort_by', $validator->errors()->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_valid_sort_direction()
     {
         $request = new ItemIndexRequest;
@@ -90,7 +92,7 @@ class ItemIndexRequestTest extends TestCase
         $this->assertArrayHasKey('sort_direction', $validator->errors()->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_valid_q_parameter()
     {
         $request = new ItemIndexRequest;
@@ -119,7 +121,7 @@ class ItemIndexRequestTest extends TestCase
         $this->assertArrayHasKey('q', $validator->errors()->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_valid_filter_parameter()
     {
         $request = new ItemIndexRequest;

--- a/tests/Feature/Requests/ItemShowRequestTest.php
+++ b/tests/Feature/Requests/ItemShowRequestTest.php
@@ -4,12 +4,14 @@ namespace Tests\Feature\Requests;
 
 use App\Http\Requests\ItemShowRequest;
 use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ItemShowRequestTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_whitelists_includable_relationships()
     {
         $request = new ItemShowRequest;
@@ -41,7 +43,7 @@ class ItemShowRequestTest extends TestCase
         $this->assertArrayHasKey('include.0', $validator->errors()->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_whitelists_selectable_fields()
     {
         $request = new ItemShowRequest;
@@ -78,7 +80,7 @@ class ItemShowRequestTest extends TestCase
         $this->assertArrayHasKey('fields.0', $validator->errors()->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_multiple_includes()
     {
         $request = new ItemShowRequest;
@@ -91,7 +93,7 @@ class ItemShowRequestTest extends TestCase
         $this->assertFalse($validator->fails());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_multiple_fields()
     {
         $request = new ItemShowRequest;
@@ -104,7 +106,7 @@ class ItemShowRequestTest extends TestCase
         $this->assertFalse($validator->fails());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_include_must_be_array()
     {
         $request = new ItemShowRequest;
@@ -118,7 +120,7 @@ class ItemShowRequestTest extends TestCase
         $this->assertArrayHasKey('include', $validator->errors()->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_fields_must_be_array()
     {
         $request = new ItemShowRequest;

--- a/tests/Feature/Requests/ProficiencyTypeIndexRequestTest.php
+++ b/tests/Feature/Requests/ProficiencyTypeIndexRequestTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Requests;
 
 use Database\Seeders\ProficiencyTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class ProficiencyTypeIndexRequestTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Requests/RaceIndexRequestTest.php
+++ b/tests/Feature/Requests/RaceIndexRequestTest.php
@@ -2,16 +2,18 @@
 
 namespace Tests\Feature\Requests;
 
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class RaceIndexRequestTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     #[Test]
     public function it_whitelists_sortable_columns()

--- a/tests/Feature/Requests/RaceShowRequestTest.php
+++ b/tests/Feature/Requests/RaceShowRequestTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Requests;
 
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class RaceShowRequestTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Requests/SourceIndexRequestTest.php
+++ b/tests/Feature/Requests/SourceIndexRequestTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Feature\Requests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SourceIndexRequestTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Requests/SpellIndexRequestTest.php
+++ b/tests/Feature/Requests/SpellIndexRequestTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Requests;
 
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SpellIndexRequestTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Requests/SpellSchoolIndexRequestTest.php
+++ b/tests/Feature/Requests/SpellSchoolIndexRequestTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Feature\Requests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SpellSchoolIndexRequestTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Requests/SpellShowRequestTest.php
+++ b/tests/Feature/Requests/SpellShowRequestTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Requests;
 
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-db')]
+#[Group('feature-db')]
 class SpellShowRequestTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Feature/Services/BackgroundSearchServiceTest.php
+++ b/tests/Feature/Services/BackgroundSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\BackgroundSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Background;
 use App\Services\BackgroundSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class BackgroundSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private BackgroundSearchService $service;
 
@@ -67,7 +71,7 @@ class BackgroundSearchServiceTest extends TestCase
     {
         $builder = $this->service->buildScoutQuery('criminal');
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -105,7 +109,7 @@ class BackgroundSearchServiceTest extends TestCase
         $builder = $this->service->buildDatabaseQuery($dto);
 
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -122,7 +126,7 @@ class BackgroundSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -143,7 +147,7 @@ class BackgroundSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($background->name, $names);
     }
@@ -162,7 +166,7 @@ class BackgroundSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         // Just verify we got valid results with the filter applied
         foreach ($result->items() as $background) {
             $this->assertInstanceOf(Background::class, $background);
@@ -219,7 +223,7 @@ class BackgroundSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 

--- a/tests/Feature/Services/ChoiceHandlers/EquipmentChoiceReplacementTest.php
+++ b/tests/Feature/Services/ChoiceHandlers/EquipmentChoiceReplacementTest.php
@@ -3,11 +3,13 @@
 namespace Tests\Feature\Services\ChoiceHandlers;
 
 use App\DTOs\PendingChoice;
+use App\Exceptions\InvalidSelectionException;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
 use App\Models\EntityChoice;
 use App\Models\Item;
+use App\Models\ProficiencyType;
 use App\Services\ChoiceHandlers\EquipmentChoiceHandler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
@@ -405,7 +407,7 @@ class EquipmentChoiceReplacementTest extends TestCase
         expect(fn () => $this->handler->resolve($character, $choice, [
             'selected' => ['b'],
             'item_selections' => ['b' => ['phb:nonexistent-item']],
-        ]))->toThrow(\App\Exceptions\InvalidSelectionException::class);
+        ]))->toThrow(InvalidSelectionException::class);
     }
 
     #[Test]
@@ -496,7 +498,7 @@ class EquipmentChoiceReplacementTest extends TestCase
         expect(fn () => $this->handler->resolve($character, $choice, [
             'selected' => ['b'],
             // No item_selections provided
-        ]))->toThrow(\App\Exceptions\InvalidSelectionException::class, 'has 3 items to choose from');
+        ]))->toThrow(InvalidSelectionException::class, 'has 3 items to choose from');
 
         // Verify no equipment was granted
         expect($character->fresh()->equipment)->toHaveCount(0);
@@ -1144,7 +1146,7 @@ class EquipmentChoiceReplacementTest extends TestCase
         ]);
 
         // Create a proficiency type for simple weapons
-        $simpleProfType = \App\Models\ProficiencyType::firstOrCreate(
+        $simpleProfType = ProficiencyType::firstOrCreate(
             ['slug' => 'core:simple-weapons'],
             ['name' => 'Simple Weapons', 'category' => 'weapon', 'subcategory' => 'simple']
         );

--- a/tests/Feature/Services/ChoiceHandlers/EquipmentModeChoiceHandlerTest.php
+++ b/tests/Feature/Services/ChoiceHandlers/EquipmentModeChoiceHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Services\ChoiceHandlers;
 
 use App\DTOs\PendingChoice;
+use App\Exceptions\InvalidSelectionException;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
@@ -728,7 +729,7 @@ class EquipmentModeChoiceHandlerTest extends TestCase
         $character = Character::factory()->create();
 
         expect(fn () => $this->handler->resolve($character, $choice, ['selected' => ['invalid']]))
-            ->toThrow(\App\Exceptions\InvalidSelectionException::class);
+            ->toThrow(InvalidSelectionException::class);
     }
 
     #[Test]
@@ -756,6 +757,6 @@ class EquipmentModeChoiceHandlerTest extends TestCase
         $character = Character::factory()->create();
 
         expect(fn () => $this->handler->resolve($character, $choice, []))
-            ->toThrow(\App\Exceptions\InvalidSelectionException::class);
+            ->toThrow(InvalidSelectionException::class);
     }
 }

--- a/tests/Feature/Services/ClassSearchServiceTest.php
+++ b/tests/Feature/Services/ClassSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\ClassSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\CharacterClass;
 use App\Services\ClassSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class ClassSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private ClassSearchService $service;
 
@@ -73,7 +77,7 @@ class ClassSearchServiceTest extends TestCase
     {
         $builder = $this->service->buildScoutQuery('wizard');
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -112,7 +116,7 @@ class ClassSearchServiceTest extends TestCase
         $builder = $this->service->buildDatabaseQuery($dto);
 
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -129,7 +133,7 @@ class ClassSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -150,7 +154,7 @@ class ClassSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($class->name, $names);
     }
@@ -169,7 +173,7 @@ class ClassSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $class) {
             $this->assertNull($class->parent_class_id, 'All classes should be base classes, not subclasses');
@@ -191,7 +195,7 @@ class ClassSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $class) {
             $this->assertGreaterThanOrEqual(8, $class->hit_die, 'All base classes should have hit die >= 8');
@@ -249,7 +253,7 @@ class ClassSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 

--- a/tests/Feature/Services/FeatSearchServiceTest.php
+++ b/tests/Feature/Services/FeatSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\FeatSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Feat;
 use App\Services\FeatSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class FeatSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private FeatSearchService $service;
 
@@ -71,7 +75,7 @@ class FeatSearchServiceTest extends TestCase
     {
         $builder = $this->service->buildScoutQuery('alert');
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -110,7 +114,7 @@ class FeatSearchServiceTest extends TestCase
         $builder = $this->service->buildDatabaseQuery($dto);
 
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -127,7 +131,7 @@ class FeatSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -148,7 +152,7 @@ class FeatSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($feat->name, $names);
     }
@@ -167,7 +171,7 @@ class FeatSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $feat) {
             $this->assertInstanceOf(Feat::class, $feat);
@@ -224,7 +228,7 @@ class FeatSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 

--- a/tests/Feature/Services/ItemSearchServiceTest.php
+++ b/tests/Feature/Services/ItemSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\ItemSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Item;
 use App\Services\ItemSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class ItemSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private ItemSearchService $service;
 
@@ -82,7 +86,7 @@ class ItemSearchServiceTest extends TestCase
 
         $builder = $this->service->buildScoutQuery($dto);
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -121,7 +125,7 @@ class ItemSearchServiceTest extends TestCase
         $builder = $this->service->buildDatabaseQuery($dto);
 
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -138,7 +142,7 @@ class ItemSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -159,7 +163,7 @@ class ItemSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($item->name, $names);
     }
@@ -184,7 +188,7 @@ class ItemSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $resultItem) {
             $this->assertEquals($item->itemType->code, $resultItem->itemType->code);
@@ -241,7 +245,7 @@ class ItemSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 
@@ -279,7 +283,7 @@ class ItemSearchServiceTest extends TestCase
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
         // Verify we get results and they preserve Meilisearch's order
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->count());
     }
 
@@ -341,6 +345,6 @@ class ItemSearchServiceTest extends TestCase
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
         // Verify the service runs without error with sort params
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
     }
 }

--- a/tests/Feature/Services/MonsterSearchServiceTest.php
+++ b/tests/Feature/Services/MonsterSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\MonsterSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Monster;
 use App\Services\MonsterSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class MonsterSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private MonsterSearchService $service;
 
@@ -80,7 +84,7 @@ class MonsterSearchServiceTest extends TestCase
 
         $builder = $this->service->buildScoutQuery($dto);
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -119,7 +123,7 @@ class MonsterSearchServiceTest extends TestCase
         $builder = $this->service->buildDatabaseQuery($dto);
 
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -136,7 +140,7 @@ class MonsterSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -157,7 +161,7 @@ class MonsterSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($monster->name, $names);
     }
@@ -176,7 +180,7 @@ class MonsterSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $monster) {
             $this->assertGreaterThanOrEqual(5, $monster->challenge_rating, 'All monsters should have CR >= 5');
@@ -233,7 +237,7 @@ class MonsterSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 
@@ -271,7 +275,7 @@ class MonsterSearchServiceTest extends TestCase
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
         // Verify we get results and they preserve Meilisearch's order
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->count());
     }
 

--- a/tests/Feature/Services/OptionalFeatureSearchServiceTest.php
+++ b/tests/Feature/Services/OptionalFeatureSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\OptionalFeatureSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\OptionalFeature;
 use App\Services\OptionalFeatureSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class OptionalFeatureSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private OptionalFeatureSearchService $service;
 
@@ -78,7 +82,7 @@ class OptionalFeatureSearchServiceTest extends TestCase
 
         $builder = $this->service->buildScoutQuery($dto);
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -117,7 +121,7 @@ class OptionalFeatureSearchServiceTest extends TestCase
         $builder = $this->service->buildDatabaseQuery($dto);
 
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -134,7 +138,7 @@ class OptionalFeatureSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -155,7 +159,7 @@ class OptionalFeatureSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($feature->name, $names);
     }
@@ -174,7 +178,7 @@ class OptionalFeatureSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $feature) {
             $this->assertInstanceOf(OptionalFeature::class, $feature);
@@ -231,7 +235,7 @@ class OptionalFeatureSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 

--- a/tests/Feature/Services/RaceSearchServiceTest.php
+++ b/tests/Feature/Services/RaceSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\RaceSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Race;
 use App\Services\RaceSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class RaceSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private RaceSearchService $service;
 
@@ -81,7 +85,7 @@ class RaceSearchServiceTest extends TestCase
 
         $builder = $this->service->buildScoutQuery($dto);
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -120,7 +124,7 @@ class RaceSearchServiceTest extends TestCase
         $builder = $this->service->buildDatabaseQuery($dto);
 
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -137,7 +141,7 @@ class RaceSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -158,7 +162,7 @@ class RaceSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($race->name, $names);
     }
@@ -177,7 +181,7 @@ class RaceSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $race) {
             $this->assertEquals('M', $race->size->code, 'All races should be Medium size');
@@ -234,7 +238,7 @@ class RaceSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 

--- a/tests/Feature/Services/ReplaceClassServiceTest.php
+++ b/tests/Feature/Services/ReplaceClassServiceTest.php
@@ -8,6 +8,7 @@ use App\Exceptions\ClassReplacementException;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
+use App\Models\CharacterEquipment;
 use App\Services\ReplaceClassService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Group;
@@ -389,14 +390,14 @@ class ReplaceClassServiceTest extends TestCase
         ]);
 
         // Add equipment from the old class
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => 'test:longsword',
             'quantity' => 1,
             'custom_description' => json_encode(['source' => 'class']),
         ]);
 
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => 'test:shield',
             'quantity' => 1,
@@ -404,7 +405,7 @@ class ReplaceClassServiceTest extends TestCase
         ]);
 
         // Add background equipment that should be preserved
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => 'test:backpack',
             'quantity' => 1,
@@ -445,7 +446,7 @@ class ReplaceClassServiceTest extends TestCase
         ]);
 
         // Add starting wealth gold from old class
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => 'phb:gold-gp',
             'quantity' => 125, // Fighter average starting wealth
@@ -453,7 +454,7 @@ class ReplaceClassServiceTest extends TestCase
         ]);
 
         // Add background gold that should be preserved
-        \App\Models\CharacterEquipment::create([
+        CharacterEquipment::create([
             'character_id' => $character->id,
             'item_slug' => 'phb:gold-gp',
             'quantity' => 15,

--- a/tests/Feature/Services/SpellSearchServiceTest.php
+++ b/tests/Feature/Services/SpellSearchServiceTest.php
@@ -6,7 +6,11 @@ use App\DTOs\SpellSearchDTO;
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use App\Models\Spell;
 use App\Services\SpellSearchService;
+use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Laravel\Scout\Builder;
 use MeiliSearch\Client;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +21,7 @@ class SpellSearchServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private SpellSearchService $service;
 
@@ -80,7 +84,7 @@ class SpellSearchServiceTest extends TestCase
 
         $builder = $this->service->buildScoutQuery($dto);
 
-        $this->assertInstanceOf(\Laravel\Scout\Builder::class, $builder);
+        $this->assertInstanceOf(Builder::class, $builder);
     }
 
     #[Test]
@@ -121,7 +125,7 @@ class SpellSearchServiceTest extends TestCase
 
         // Execute query and check it works
         $results = $builder->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
+        $this->assertInstanceOf(Collection::class, $results);
     }
 
     #[Test]
@@ -138,7 +142,7 @@ class SpellSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertGreaterThan(0, $result->total());
     }
 
@@ -159,7 +163,7 @@ class SpellSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $names = $result->pluck('name')->toArray();
         $this->assertContains($spell->name, $names);
     }
@@ -178,7 +182,7 @@ class SpellSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $spell) {
             $this->assertEquals(0, $spell->level, 'All spells should be cantrips (level 0)');
@@ -199,7 +203,7 @@ class SpellSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
 
         foreach ($result->items() as $spell) {
             $this->assertEquals('EV', $spell->spellSchool->code, 'All spells should be Evocation');
@@ -257,7 +261,7 @@ class SpellSearchServiceTest extends TestCase
 
         $result = $this->service->searchWithMeilisearch($dto, $this->client);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertEquals(0, $result->count());
     }
 

--- a/tests/Feature/Spellcasting/SpellcasterProgressionTest.php
+++ b/tests/Feature/Spellcasting/SpellcasterProgressionTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 use App\Models\Character;
 use App\Models\CharacterClass;
+use Tests\TestCase;
 use Tests\Traits\CreatesTestCharacters;
 
-uses(Tests\TestCase::class, CreatesTestCharacters::class)->group('integration');
+uses(TestCase::class, CreatesTestCharacters::class)->group('integration');
 
 /*
 |--------------------------------------------------------------------------
@@ -37,8 +38,8 @@ beforeEach(function () {
     config(['database.connections.mysql.password' => 'dnd_password']);
 
     // Purge existing connections and reconnect
-    \DB::purge('mysql');
-    \DB::reconnect('mysql');
+    DB::purge('mysql');
+    DB::reconnect('mysql');
 
     // Skip if required classes aren't imported
     $classCount = CharacterClass::count();

--- a/tests/Integration/SpellImportToApiTest.php
+++ b/tests/Integration/SpellImportToApiTest.php
@@ -2,18 +2,21 @@
 
 namespace Tests\Integration;
 
+use App\Models\Spell;
 use App\Services\Importers\SpellImporter;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('feature-search')]
-#[\PHPUnit\Framework\Attributes\Group('search-imported')]
+#[Group('feature-search')]
+#[Group('search-imported')]
 class SpellImportToApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     #[Test]
     public function spell_import_to_api_pipeline(): void
@@ -50,7 +53,7 @@ class SpellImportToApiTest extends TestCase
             ]);
 
         // Test search - use a spell we know exists from fixtures
-        $spell = \App\Models\Spell::first();
+        $spell = Spell::first();
         if ($spell) {
             $searchResponse = $this->getJson('/api/v1/spells?q='.urlencode($spell->name));
             $searchResponse->assertStatus(200);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use App\Models\Size;
 use App\Models\Skill;
 use App\Models\Source;
 use App\Models\SpellSchool;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -30,7 +31,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @var string
      */
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     /**
      * Store original error/exception handlers to restore after test.

--- a/tests/Traits/CreatesTestCharacters.php
+++ b/tests/Traits/CreatesTestCharacters.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Traits;
 
 use App\Models\Character;
+use App\Services\CharacterStatCalculator;
 use App\Services\LevelUpFlowTesting\LevelUpFlowExecutor;
 use App\Services\WizardFlowTesting\CharacterRandomizer;
 use App\Services\WizardFlowTesting\FlowExecutor;
@@ -287,7 +288,7 @@ trait CreatesTestCharacters
      */
     protected function getCharacterSpellSlots(Character $character): array
     {
-        $calculator = app(\App\Services\CharacterStatCalculator::class);
+        $calculator = app(CharacterStatCalculator::class);
         $primaryClass = $character->primary_class;
 
         if (! $primaryClass) {

--- a/tests/Unit/Concerns/ClearsCachesTest.php
+++ b/tests/Unit/Concerns/ClearsCachesTest.php
@@ -7,12 +7,14 @@ use App\Services\Importers\Concerns\ImportsSenses;
 use App\Services\Parsers\Concerns\LookupsGameEntities;
 use App\Services\Parsers\Concerns\MatchesLanguages;
 use App\Services\Parsers\Concerns\MatchesProficiencyTypes;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ClearsCachesTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function clears_caches_class_has_clear_all_method(): void
     {
         $this->assertTrue(
@@ -25,7 +27,7 @@ class ClearsCachesTest extends TestCase
         $this->assertTrue($reflection->isStatic(), 'clearAll must be static');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function concerns_have_unique_clear_cache_methods(): void
     {
         // Each trait has its own uniquely-named clearXxxCache method to avoid collisions
@@ -54,7 +56,7 @@ class ClearsCachesTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function clear_all_calls_all_cache_clear_methods(): void
     {
         // Verify clearAll doesn't throw an exception
@@ -64,7 +66,7 @@ class ClearsCachesTest extends TestCase
         $this->assertTrue(true, 'clearAll should complete without error');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_caching_concerns_returns_all_concerns(): void
     {
         $concerns = ClearsCaches::getCachingConcerns();
@@ -80,7 +82,7 @@ class ClearsCachesTest extends TestCase
         $this->assertEquals('clearLanguagesCache', $concerns[MatchesLanguages::class]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function individual_clear_cache_methods_are_callable(): void
     {
         // Verify each individual clear method can be called without error

--- a/tests/Unit/Concerns/FindsInDescriptionTest.php
+++ b/tests/Unit/Concerns/FindsInDescriptionTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Concerns;
 
 use App\Services\Parsers\Concerns\FindsInDescription;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class FindsInDescriptionTest extends TestCase
 {
     private object $subject;

--- a/tests/Unit/Concerns/ImportsClassAssociationsTest.php
+++ b/tests/Unit/Concerns/ImportsClassAssociationsTest.php
@@ -6,9 +6,11 @@ use App\Models\CharacterClass;
 use App\Models\Spell;
 use App\Services\Importers\Concerns\ImportsClassAssociations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ImportsClassAssociationsTest extends TestCase
 {
     use RefreshDatabase;
@@ -21,7 +23,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->importer = new TestImporter;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_subclass_with_exact_match(): void
     {
         $fighter = CharacterClass::factory()->create(['slug' => 'fighter', 'name' => 'Fighter']);
@@ -39,7 +41,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals($eldritchKnight->slug, $spell->classes()->first()->slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_subclass_with_fuzzy_match(): void
     {
         $warlock = CharacterClass::factory()->create(['slug' => 'warlock', 'name' => 'Warlock']);
@@ -58,7 +60,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals($archfey->slug, $spell->classes()->first()->slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_subclass_with_alias_mapping(): void
     {
         $druid = CharacterClass::factory()->create(['slug' => 'druid', 'name' => 'Druid']);
@@ -77,7 +79,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals($circleOfLand->slug, $spell->classes()->first()->slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_base_class_only(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
@@ -99,7 +101,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals($wizard->slug, $spell->classes()->first()->slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_multiple_base_classes(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
@@ -114,7 +116,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals([$sorcerer->slug, $wizard->slug], $classSlugs);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function sync_replaces_existing_associations(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
@@ -136,7 +138,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertNotContains($wizard->slug, $classSlugs);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function add_merges_with_existing_associations(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
@@ -158,7 +160,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals([$sorcerer->slug, $warlock->slug, $wizard->slug], $classSlugs);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function add_handles_duplicate_classes_correctly(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
@@ -177,7 +179,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals(2, $spell->classes()->count());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_unresolved_classes(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
@@ -192,7 +194,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals($wizard->slug, $spell->classes()->first()->slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_class_array(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);
@@ -206,7 +208,7 @@ class ImportsClassAssociationsTest extends TestCase
         $this->assertEquals(0, $spell->classes()->count());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_mixed_base_and_subclass_names(): void
     {
         $wizard = CharacterClass::factory()->create(['slug' => 'wizard', 'name' => 'Wizard']);

--- a/tests/Unit/Concerns/NormalizesSpellNamesTest.php
+++ b/tests/Unit/Concerns/NormalizesSpellNamesTest.php
@@ -5,10 +5,11 @@ namespace Tests\Unit\Concerns;
 use App\Models\Spell;
 use App\Services\Concerns\NormalizesSpellNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class NormalizesSpellNamesTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Concerns/TracksMetricsAndWarningsTest.php
+++ b/tests/Unit/Concerns/TracksMetricsAndWarningsTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Concerns;
 
 use App\Services\Concerns\TracksMetricsAndWarnings;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class TracksMetricsAndWarningsTest extends TestCase
 {
     private object $subject;

--- a/tests/Unit/DTOs/CharacterStatsDTOTest.php
+++ b/tests/Unit/DTOs/CharacterStatsDTOTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\DTOs;
 use App\DTOs\CharacterStatsDTO;
 use App\Models\Character;
 use App\Models\CharacterClass;
+use App\Models\ClassFeature;
+use App\Models\Feat;
 use App\Models\Race;
 use App\Models\Skill;
 use App\Services\CharacterStatCalculator;
@@ -319,12 +321,12 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         // Add Resilient (Wisdom) feat
-        $resilientWis = \App\Models\Feat::factory()->create([
+        $resilientWis = Feat::factory()->create([
             'name' => 'Resilient (Wisdom)',
             'slug' => 'test:resilient-wisdom',
         ]);
         $character->features()->create([
-            'feature_type' => \App\Models\Feat::class,
+            'feature_type' => Feat::class,
             'feature_id' => $resilientWis->id,
             'feature_slug' => $resilientWis->slug,
             'source' => 'asi_or_feat',
@@ -356,24 +358,24 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         // Add both Resilient (Dexterity) and Resilient (Wisdom)
-        $resilientDex = \App\Models\Feat::factory()->create([
+        $resilientDex = Feat::factory()->create([
             'name' => 'Resilient (Dexterity)',
             'slug' => 'test:resilient-dexterity',
         ]);
-        $resilientWis = \App\Models\Feat::factory()->create([
+        $resilientWis = Feat::factory()->create([
             'name' => 'Resilient (Wisdom)',
             'slug' => 'test:resilient-wisdom',
         ]);
 
         $character->features()->createMany([
             [
-                'feature_type' => \App\Models\Feat::class,
+                'feature_type' => Feat::class,
                 'feature_id' => $resilientDex->id,
                 'feature_slug' => $resilientDex->slug,
                 'source' => 'asi_or_feat',
             ],
             [
-                'feature_type' => \App\Models\Feat::class,
+                'feature_type' => Feat::class,
                 'feature_id' => $resilientWis->id,
                 'feature_slug' => $resilientWis->slug,
                 'source' => 'asi_or_feat',
@@ -397,7 +399,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         // Create fighting style feature
-        $archeryStyle = \App\Models\ClassFeature::factory()->create([
+        $archeryStyle = ClassFeature::factory()->create([
             'class_id' => $fighter->id,
             'feature_name' => 'Fighting Style: Archery',
             'level' => 1,
@@ -413,7 +415,7 @@ class CharacterStatsDTOTest extends TestCase
 
         // Assign the fighting style to the character
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $archeryStyle->id,
             'feature_slug' => 'test:fighter-fs:fighting-style-archery',
             'source' => 'class',
@@ -433,7 +435,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:fighter-archery',
         ]);
 
-        $archeryStyle = \App\Models\ClassFeature::factory()->create([
+        $archeryStyle = ClassFeature::factory()->create([
             'class_id' => $fighter->id,
             'feature_name' => 'Fighting Style: Archery',
             'level' => 1,
@@ -448,7 +450,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $archeryStyle->id,
             'feature_slug' => 'test:fighter-archery:fighting-style-archery',
             'source' => 'class',
@@ -467,7 +469,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:fighter-dueling',
         ]);
 
-        $duelingStyle = \App\Models\ClassFeature::factory()->create([
+        $duelingStyle = ClassFeature::factory()->create([
             'class_id' => $fighter->id,
             'feature_name' => 'Fighting Style: Dueling',
             'level' => 1,
@@ -482,7 +484,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $duelingStyle->id,
             'feature_slug' => 'test:fighter-dueling:fighting-style-dueling',
             'source' => 'class',
@@ -505,7 +507,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         // Create Jack of All Trades feature
-        $jackOfAllTrades = \App\Models\ClassFeature::factory()->create([
+        $jackOfAllTrades = ClassFeature::factory()->create([
             'class_id' => $bard->id,
             'feature_name' => 'Jack of All Trades',
             'level' => 2,
@@ -526,7 +528,7 @@ class CharacterStatsDTOTest extends TestCase
 
         // Assign Jack of All Trades feature
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $jackOfAllTrades->id,
             'feature_slug' => 'test:bard-jat:jack-of-all-trades',
             'source' => 'class',
@@ -550,7 +552,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:bard-jat-prof',
         ]);
 
-        $jackOfAllTrades = \App\Models\ClassFeature::factory()->create([
+        $jackOfAllTrades = ClassFeature::factory()->create([
             'class_id' => $bard->id,
             'feature_name' => 'Jack of All Trades',
             'level' => 2,
@@ -575,7 +577,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $jackOfAllTrades->id,
             'feature_slug' => 'test:bard-jat-prof:jack-of-all-trades',
             'source' => 'class',
@@ -599,7 +601,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:bard-jat-init',
         ]);
 
-        $jackOfAllTrades = \App\Models\ClassFeature::factory()->create([
+        $jackOfAllTrades = ClassFeature::factory()->create([
             'class_id' => $bard->id,
             'feature_name' => 'Jack of All Trades',
             'level' => 2,
@@ -617,7 +619,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $jackOfAllTrades->id,
             'feature_slug' => 'test:bard-jat-init:jack-of-all-trades',
             'source' => 'class',
@@ -640,7 +642,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:rogue-rt',
         ]);
 
-        $reliableTalent = \App\Models\ClassFeature::factory()->create([
+        $reliableTalent = ClassFeature::factory()->create([
             'class_id' => $rogue->id,
             'feature_name' => 'Reliable Talent',
             'level' => 11,
@@ -665,7 +667,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $reliableTalent->id,
             'feature_slug' => 'test:rogue-rt:reliable-talent',
             'source' => 'class',
@@ -687,7 +689,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:rogue-rt-np',
         ]);
 
-        $reliableTalent = \App\Models\ClassFeature::factory()->create([
+        $reliableTalent = ClassFeature::factory()->create([
             'class_id' => $rogue->id,
             'feature_name' => 'Reliable Talent',
             'level' => 11,
@@ -705,7 +707,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $reliableTalent->id,
             'feature_slug' => 'test:rogue-rt-np:reliable-talent',
             'source' => 'class',
@@ -740,7 +742,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:rogue-minroll',
         ]);
 
-        $reliableTalent = \App\Models\ClassFeature::factory()->create([
+        $reliableTalent = ClassFeature::factory()->create([
             'class_id' => $rogue->id,
             'feature_name' => 'Reliable Talent',
             'level' => 11,
@@ -765,7 +767,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $reliableTalent->id,
             'feature_slug' => 'test:rogue-minroll:reliable-talent',
             'source' => 'class',
@@ -789,7 +791,7 @@ class CharacterStatsDTOTest extends TestCase
             'slug' => 'test:rogue-minroll-neg',
         ]);
 
-        $reliableTalent = \App\Models\ClassFeature::factory()->create([
+        $reliableTalent = ClassFeature::factory()->create([
             'class_id' => $rogue->id,
             'feature_name' => 'Reliable Talent',
             'level' => 11,
@@ -814,7 +816,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $reliableTalent->id,
             'feature_slug' => 'test:rogue-minroll-neg:reliable-talent',
             'source' => 'class',
@@ -861,7 +863,7 @@ class CharacterStatsDTOTest extends TestCase
             'parent_class_id' => $bard->id,
         ]);
 
-        $silverTongue = \App\Models\ClassFeature::factory()->create([
+        $silverTongue = ClassFeature::factory()->create([
             'class_id' => $eloquenceCollege->id,
             'feature_name' => 'Silver Tongue',
             'level' => 3,
@@ -880,7 +882,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $silverTongue->id,
             'feature_slug' => 'test:bard-eloquence:silver-tongue',
             'source' => 'class',
@@ -913,7 +915,7 @@ class CharacterStatsDTOTest extends TestCase
             'parent_class_id' => $bard->id,
         ]);
 
-        $silverTongue = \App\Models\ClassFeature::factory()->create([
+        $silverTongue = ClassFeature::factory()->create([
             'class_id' => $eloquenceCollege->id,
             'feature_name' => 'Silver Tongue',
             'level' => 3,
@@ -932,7 +934,7 @@ class CharacterStatsDTOTest extends TestCase
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $silverTongue->id,
             'feature_slug' => 'test:bard-eloquence-other:silver-tongue',
             'source' => 'class',
@@ -966,13 +968,13 @@ class CharacterStatsDTOTest extends TestCase
             'parent_class_id' => $bard->id,
         ]);
 
-        $reliableTalent = \App\Models\ClassFeature::factory()->create([
+        $reliableTalent = ClassFeature::factory()->create([
             'class_id' => $rogue->id,
             'feature_name' => 'Reliable Talent',
             'level' => 11,
         ]);
 
-        $silverTongue = \App\Models\ClassFeature::factory()->create([
+        $silverTongue = ClassFeature::factory()->create([
             'class_id' => $eloquenceCollege->id,
             'feature_name' => 'Silver Tongue',
             'level' => 3,
@@ -1007,14 +1009,14 @@ class CharacterStatsDTOTest extends TestCase
 
         // Add both features
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $reliableTalent->id,
             'feature_slug' => 'test:rogue-multi:reliable-talent',
             'source' => 'class',
         ]);
 
         $character->features()->create([
-            'feature_type' => \App\Models\ClassFeature::class,
+            'feature_type' => ClassFeature::class,
             'feature_id' => $silverTongue->id,
             'feature_slug' => 'test:bard-eloquence-multi:silver-tongue',
             'source' => 'class',

--- a/tests/Unit/DTOs/CharacterStatsDTOWeaponTest.php
+++ b/tests/Unit/DTOs/CharacterStatsDTOWeaponTest.php
@@ -7,6 +7,7 @@ use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\ClassFeature;
 use App\Models\Item;
+use App\Models\ItemProperty;
 use App\Models\ItemType;
 use App\Services\CharacterStatCalculator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -742,7 +743,7 @@ class CharacterStatsDTOWeaponTest extends TestCase
     private function createMartialMeleeWeapon(string $name, bool $isMagic = false): Item
     {
         $meleeType = ItemType::where('code', 'M')->first();
-        $martialProperty = \App\Models\ItemProperty::where('code', 'M')->first();
+        $martialProperty = ItemProperty::where('code', 'M')->first();
 
         $item = Item::factory()->create([
             'name' => $name,

--- a/tests/Unit/Enums/ItemGroupTest.php
+++ b/tests/Unit/Enums/ItemGroupTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Enums;
 
 use App\Enums\ItemGroup;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ItemGroupTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Enums/RequirementLogicTest.php
+++ b/tests/Unit/Enums/RequirementLogicTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Enums;
 
 use App\Enums\RequirementLogic;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class RequirementLogicTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Enums/ToolProficiencyCategoryTest.php
+++ b/tests/Unit/Enums/ToolProficiencyCategoryTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Enums;
 
 use App\Enums\ToolProficiencyCategory;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ToolProficiencyCategoryTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Exceptions/Import/FileNotFoundExceptionTest.php
+++ b/tests/Unit/Exceptions/Import/FileNotFoundExceptionTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Exceptions\Import;
 
 use App\Exceptions\Import\FileNotFoundException;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class FileNotFoundExceptionTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Exceptions/Lookup/EntityNotFoundExceptionTest.php
+++ b/tests/Unit/Exceptions/Lookup/EntityNotFoundExceptionTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Exceptions\Lookup;
 
 use App\Exceptions\Lookup\EntityNotFoundException;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class EntityNotFoundExceptionTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Exceptions/Search/InvalidFilterSyntaxExceptionTest.php
+++ b/tests/Unit/Exceptions/Search/InvalidFilterSyntaxExceptionTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Exceptions\Search;
 
 use App\Exceptions\Search\InvalidFilterSyntaxException;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class InvalidFilterSyntaxExceptionTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Factories/EntityDataTableFactoriesTest.php
+++ b/tests/Unit/Factories/EntityDataTableFactoriesTest.php
@@ -6,10 +6,11 @@ use App\Enums\DataTableType;
 use App\Models\EntityDataTable;
 use App\Models\EntityDataTableEntry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class EntityDataTableFactoriesTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Factories/EntityPrerequisiteFactoryTest.php
+++ b/tests/Unit/Factories/EntityPrerequisiteFactoryTest.php
@@ -9,16 +9,18 @@ use App\Models\Item;
 use App\Models\ProficiencyType;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class EntityPrerequisiteFactoryTest extends TestCase
 {
     use RefreshDatabase;
 
     protected $seed = true; // Auto-seed for all tests
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_prerequisite_with_default_values()
     {
         $prerequisite = EntityPrerequisite::factory()->create();
@@ -27,7 +29,7 @@ class EntityPrerequisiteFactoryTest extends TestCase
         $this->assertEquals(1, $prerequisite->group_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_ability_score_prerequisite()
     {
         $feat = Feat::factory()->create();
@@ -45,7 +47,7 @@ class EntityPrerequisiteFactoryTest extends TestCase
         $this->assertEquals(13, $prerequisite->minimum_value);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_race_prerequisite()
     {
         $feat = Feat::factory()->create();
@@ -60,7 +62,7 @@ class EntityPrerequisiteFactoryTest extends TestCase
         $this->assertEquals($race->id, $prerequisite->prerequisite_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_proficiency_prerequisite()
     {
         $feat = Feat::factory()->create();
@@ -75,7 +77,7 @@ class EntityPrerequisiteFactoryTest extends TestCase
         $this->assertEquals($profType->id, $prerequisite->prerequisite_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_free_form_feature_prerequisite()
     {
         $feat = Feat::factory()->create();
@@ -90,7 +92,7 @@ class EntityPrerequisiteFactoryTest extends TestCase
         $this->assertEquals('Spellcasting or Pact Magic feature', $prerequisite->description);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_group_id_for_logical_grouping()
     {
         $feat = Feat::factory()->create();
@@ -113,7 +115,7 @@ class EntityPrerequisiteFactoryTest extends TestCase
         $this->assertEquals(1, $prereq2->group_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_be_used_for_items()
     {
         $item = Item::factory()->create();

--- a/tests/Unit/Factories/OptionalFeatureFactoryTest.php
+++ b/tests/Unit/Factories/OptionalFeatureFactoryTest.php
@@ -7,10 +7,11 @@ use App\Enums\ResourceType;
 use App\Models\CharacterClass;
 use App\Models\OptionalFeature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class OptionalFeatureFactoryTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Factories/PolymorphicFactoriesTest.php
+++ b/tests/Unit/Factories/PolymorphicFactoriesTest.php
@@ -7,10 +7,11 @@ use App\Models\CharacterTrait;
 use App\Models\Modifier;
 use App\Models\Proficiency;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class PolymorphicFactoriesTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Factories/SpellEffectFactoryTest.php
+++ b/tests/Unit/Factories/SpellEffectFactoryTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Factories;
 
 use App\Models\SpellEffect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SpellEffectFactoryTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Importers/Concerns/GeneratesSlugsTest.php
+++ b/tests/Unit/Importers/Concerns/GeneratesSlugsTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Importers\Concerns;
 
 use App\Services\Importers\Concerns\GeneratesSlugs;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class GeneratesSlugsTest extends TestCase
 {

--- a/tests/Unit/Importers/Concerns/ImportsDataTablesTest.php
+++ b/tests/Unit/Importers/Concerns/ImportsDataTablesTest.php
@@ -7,10 +7,11 @@ use App\Models\EntityDataTable;
 use App\Models\Race;
 use App\Services\Importers\Concerns\ImportsDataTables;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class ImportsDataTablesTest extends TestCase
 {

--- a/tests/Unit/Importers/Concerns/ImportsEntityItemsTest.php
+++ b/tests/Unit/Importers/Concerns/ImportsEntityItemsTest.php
@@ -5,9 +5,11 @@ namespace Tests\Unit\Importers\Concerns;
 use App\Models\Item;
 use App\Services\Importers\Concerns\ImportsEntityItems;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ImportsEntityItemsTest extends TestCase
 {
     use RefreshDatabase;
@@ -43,7 +45,7 @@ class ImportsEntityItemsTest extends TestCase
         Item::factory()->create(['name' => 'Arrows']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_matches_exact_item_names()
     {
         $item = $this->traitUser->match('Rapier');
@@ -52,7 +54,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Rapier', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_leading_articles()
     {
         $cases = [
@@ -68,7 +70,7 @@ class ImportsEntityItemsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_compound_items_with_and()
     {
         $item = $this->traitUser->match('a shortbow and quiver of arrows (20)');
@@ -77,7 +79,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Shortbow', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_quantity_words()
     {
         $cases = [
@@ -93,7 +95,7 @@ class ImportsEntityItemsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_plurals()
     {
         // "javelins" should match "Javelin"
@@ -103,7 +105,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Javelin', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_case_insensitivity()
     {
         $cases = [
@@ -119,7 +121,7 @@ class ImportsEntityItemsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_possessives()
     {
         $item = $this->traitUser->match("a burglar's pack");
@@ -128,7 +130,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals("Burglar's Pack", $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_unmatched_items()
     {
         $item = $this->traitUser->match('any martial weapon');
@@ -136,7 +138,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertNull($item);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_complex_real_world_cases()
     {
         $cases = [
@@ -158,7 +160,7 @@ class ImportsEntityItemsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_items_with_parenthetical_content()
     {
         $item = $this->traitUser->match('a shortbow (25 arrows)');
@@ -167,7 +169,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Shortbow', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_items_with_commas()
     {
         // Create leather armor item
@@ -179,7 +181,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Leather Armor', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_fuzzy_match_with_starts_with()
     {
         // Create longbow item
@@ -192,7 +194,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Longbow', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prefers_non_magic_items_in_fuzzy_match()
     {
         // Create both non-magic and magic versions
@@ -206,7 +208,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertFalse($item->is_magic);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_contains_fallback_when_starts_with_fails()
     {
         // Create an item where the match is in the middle
@@ -218,7 +220,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals("Alchemist's Supplies", $result->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_multiple_quantity_words()
     {
         $cases = [
@@ -235,7 +237,7 @@ class ImportsEntityItemsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_item_descriptions_with_or()
     {
         // Should extract first item before "or"
@@ -245,7 +247,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Rapier', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_whitespace_variations()
     {
         $cases = [
@@ -261,7 +263,7 @@ class ImportsEntityItemsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_category_descriptions()
     {
         $categoryDescriptions = [
@@ -277,7 +279,7 @@ class ImportsEntityItemsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_string()
     {
         // Empty string gets cleaned to empty, no match possible
@@ -291,7 +293,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertTrue($item === null || $item instanceof Item);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_single_character_descriptions()
     {
         // Single character 'a' is an article that gets removed, leaving empty string
@@ -302,7 +304,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertTrue($item === null || $item instanceof Item);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_logs_fuzzy_match_results()
     {
         // This test verifies logging behavior without asserting logs
@@ -313,7 +315,7 @@ class ImportsEntityItemsTest extends TestCase
         $this->assertEquals('Shortbow', $item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_logs_warnings_for_unmatched_items()
     {
         // This test verifies logging behavior

--- a/tests/Unit/Importers/ItemEquipmentSlotInferenceTest.php
+++ b/tests/Unit/Importers/ItemEquipmentSlotInferenceTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit\Importers;
 
 use App\Services\Importers\ItemImporter;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use ReflectionMethod;
 use Tests\TestCase;
 
@@ -14,7 +16,7 @@ use Tests\TestCase;
  *
  * @see https://github.com/dfox288/ledger-of-heroes/issues/589
  */
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ItemEquipmentSlotInferenceTest extends TestCase
 {
     private ItemImporter $importer;
@@ -41,70 +43,70 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Type-based Slot Inference Tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function light_armor_maps_to_armor_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'LA', 'Leather Armor');
         $this->assertEquals('armor', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function medium_armor_maps_to_armor_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'MA', 'Chain Shirt');
         $this->assertEquals('armor', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function heavy_armor_maps_to_armor_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'HA', 'Plate Armor');
         $this->assertEquals('armor', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function shield_maps_to_off_hand_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'S', 'Shield');
         $this->assertEquals('off_hand', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function ring_maps_to_ring_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'RG', 'Ring of Protection');
         $this->assertEquals('ring', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function melee_weapon_maps_to_hand_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'M', 'Longsword');
         $this->assertEquals('hand', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function ranged_weapon_maps_to_hand_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'R', 'Longbow');
         $this->assertEquals('hand', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function staff_maps_to_hand_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'ST', 'Staff of Fire');
         $this->assertEquals('hand', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function rod_maps_to_hand_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'RD', 'Rod of the Pact Keeper');
         $this->assertEquals('hand', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function wand_maps_to_hand_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'WD', 'Wand of Fireballs');
@@ -115,35 +117,35 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Non-equippable Type Tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function potion_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'P', 'Potion of Healing');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function scroll_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'SC', 'Spell Scroll');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function adventuring_gear_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'G', 'Torch');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function ammunition_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'A', 'Arrow');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function trade_goods_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, '$', 'Silk');
@@ -154,21 +156,21 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Item Pattern Matching Tests (feet)
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function boots_maps_to_feet_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Boots of Elvenkind');
         $this->assertEquals('feet', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function winged_boots_maps_to_feet_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Winged Boots');
         $this->assertEquals('feet', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function slippers_maps_to_feet_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Slippers of Spider Climbing');
@@ -179,28 +181,28 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Item Pattern Matching Tests (cloak)
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function cloak_maps_to_cloak_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Cloak of Protection');
         $this->assertEquals('cloak', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function cape_maps_to_cloak_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Cape of the Mountebank');
         $this->assertEquals('cloak', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function mantle_maps_to_cloak_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Mantle of Spell Resistance');
         $this->assertEquals('cloak', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function wings_of_flying_maps_to_cloak_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Wings of Flying');
@@ -211,14 +213,14 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Item Pattern Matching Tests (belt)
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function belt_maps_to_belt_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Belt of Giant Strength');
         $this->assertEquals('belt', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function girdle_maps_to_belt_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Girdle of Hill Giant Strength');
@@ -229,56 +231,56 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Item Pattern Matching Tests (head)
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function helm_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Helm of Brilliance');
         $this->assertEquals('head', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function hat_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Hat of Disguise');
         $this->assertEquals('head', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function circlet_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Circlet of Blasting');
         $this->assertEquals('head', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function crown_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', "Belashyrra's Beholder Crown");
         $this->assertEquals('head', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function headband_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Headband of Intellect');
         $this->assertEquals('head', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function cap_of_water_breathing_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Cap of Water Breathing');
         $this->assertEquals('head', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function goggles_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Goggles of Night');
         $this->assertEquals('head', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function eyes_of_charming_maps_to_head_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Eyes of Charming');
@@ -289,49 +291,49 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Item Pattern Matching Tests (neck)
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function amulet_maps_to_neck_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Amulet of Health');
         $this->assertEquals('neck', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function necklace_maps_to_neck_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Necklace of Fireballs');
         $this->assertEquals('neck', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function periapt_maps_to_neck_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Periapt of Health');
         $this->assertEquals('neck', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function medallion_maps_to_neck_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Medallion of Thoughts');
         $this->assertEquals('neck', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function brooch_maps_to_neck_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Brooch of Shielding');
         $this->assertEquals('neck', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function scarab_maps_to_neck_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Scarab of Protection');
         $this->assertEquals('neck', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function talisman_maps_to_neck_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Talisman of Pure Good');
@@ -342,21 +344,21 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Item Pattern Matching Tests (hands)
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gloves_maps_to_hands_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Gloves of Thievery');
         $this->assertEquals('hands', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gauntlets_maps_to_hands_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Gauntlets of Ogre Power');
         $this->assertEquals('hands', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function bracers_maps_to_hands_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Bracers of Defense');
@@ -367,35 +369,35 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Item Pattern Matching Tests (clothes)
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function robe_of_maps_to_clothes_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Robe of the Archmagi');
         $this->assertEquals('clothes', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function robe_of_eyes_maps_to_clothes_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Robe of Eyes');
         $this->assertEquals('clothes', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function clothes_of_mending_maps_to_clothes_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Clothes of Mending');
         $this->assertEquals('clothes', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function glamerweave_maps_to_clothes_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Glamerweave (uncommon)');
         $this->assertEquals('clothes', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function shiftweave_maps_to_clothes_slot(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Shiftweave');
@@ -406,49 +408,49 @@ class ItemEquipmentSlotInferenceTest extends TestCase
     // Wondrous Items Without Body Slot Tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function bag_of_holding_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Bag of Holding');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function ioun_stone_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Ioun Stone, Absorption');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function figurine_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Figurine of Wondrous Power, Bronze Griffon');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function tattoo_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Blood Fury Tattoo');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function deck_of_many_things_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Deck of Many Things');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function carpet_of_flying_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Carpet of Flying');
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function instrument_returns_null(): void
     {
         $result = $this->inferEquipmentSlot->invoke($this->importer, 'W', 'Instrument of the Bards, Anstruth Harp');

--- a/tests/Unit/Models/CharacterClassPivotTest.php
+++ b/tests/Unit/Models/CharacterClassPivotTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -99,7 +100,7 @@ class CharacterClassPivotTest extends TestCase
             'order' => 1,
         ]);
 
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectException(QueryException::class);
 
         CharacterClassPivot::create([
             'character_id' => $character->id,

--- a/tests/Unit/Models/CharacterClassSearchableTest.php
+++ b/tests/Unit/Models/CharacterClassSearchableTest.php
@@ -7,14 +7,16 @@ use App\Models\CharacterClass;
 use App\Models\EntitySource;
 use App\Models\Source;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class CharacterClassSearchableTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_searchable_array_with_denormalized_data(): void
     {
         $source = Source::firstOrCreate(['code' => 'PHB'], ['name' => 'Player\'s Handbook']);
@@ -42,7 +44,7 @@ class CharacterClassSearchableTest extends TestCase
         $this->assertEquals(['PHB'], $searchable['source_codes']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_defines_searchable_relationships(): void
     {
         $class = new CharacterClass;
@@ -51,7 +53,7 @@ class CharacterClassSearchableTest extends TestCase
         $this->assertContains('sources.source', $class->searchableWith());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_correct_search_index_name(): void
     {
         $class = new CharacterClass;
@@ -60,7 +62,7 @@ class CharacterClassSearchableTest extends TestCase
 
     // Computed Accessor Tests - Hit Die Inheritance
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function effective_hit_die_returns_own_hit_die_for_base_class(): void
     {
         $baseClass = CharacterClass::factory()->create([
@@ -72,7 +74,7 @@ class CharacterClassSearchableTest extends TestCase
         $this->assertEquals(10, $baseClass->effective_hit_die);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function effective_hit_die_inherits_from_parent_when_zero(): void
     {
         $baseClass = CharacterClass::factory()->create([
@@ -90,7 +92,7 @@ class CharacterClassSearchableTest extends TestCase
         $this->assertEquals(8, $subclass->effective_hit_die);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function hit_points_computed_returns_data_for_subclass_with_inherited_hit_die(): void
     {
         $baseClass = CharacterClass::factory()->create([
@@ -115,7 +117,7 @@ class CharacterClassSearchableTest extends TestCase
 
     // Computed Accessor Tests - Spellcasting Ability Inheritance
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function effective_spellcasting_ability_returns_own_ability_for_base_class(): void
     {
         $wisdom = AbilityScore::firstOrCreate(
@@ -133,7 +135,7 @@ class CharacterClassSearchableTest extends TestCase
         $this->assertEquals('WIS', $baseClass->effective_spellcasting_ability->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function effective_spellcasting_ability_inherits_from_parent_when_null(): void
     {
         $wisdom = AbilityScore::firstOrCreate(
@@ -157,7 +159,7 @@ class CharacterClassSearchableTest extends TestCase
         $this->assertEquals('WIS', $subclass->effective_spellcasting_ability->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function effective_spellcasting_ability_returns_null_for_non_caster(): void
     {
         $baseClass = CharacterClass::factory()->create([
@@ -169,7 +171,7 @@ class CharacterClassSearchableTest extends TestCase
         $this->assertNull($baseClass->effective_spellcasting_ability);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function effective_spellcasting_ability_returns_null_for_subclass_of_non_caster(): void
     {
         $baseClass = CharacterClass::factory()->create([

--- a/tests/Unit/Models/CharacterIsCompleteTest.php
+++ b/tests/Unit/Models/CharacterIsCompleteTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\Character;
 use App\Models\CharacterClass;
+use App\Models\CharacterClassPivot;
 use App\Models\Race;
 use App\Services\CharacterChoiceService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -342,7 +343,7 @@ class CharacterIsCompleteTest extends TestCase
             ->create();
 
         // Add a dangling class reference via the pivot
-        \App\Models\CharacterClassPivot::create([
+        CharacterClassPivot::create([
             'character_id' => $character->id,
             'class_slug' => 'nonexistent:class',
             'level' => 1,

--- a/tests/Unit/Models/CharacterSpellSlotTest.php
+++ b/tests/Unit/Models/CharacterSpellSlotTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Enums\SpellSlotType;
 use App\Models\Character;
 use App\Models\CharacterSpellSlot;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -115,7 +116,7 @@ class CharacterSpellSlotTest extends TestCase
             'slot_type' => SpellSlotType::STANDARD,
         ]);
 
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectException(QueryException::class);
 
         CharacterSpellSlot::factory()->create([
             'character_id' => $character->id,

--- a/tests/Unit/Models/FeatAccessorsTest.php
+++ b/tests/Unit/Models/FeatAccessorsTest.php
@@ -5,9 +5,11 @@ namespace Tests\Unit\Models;
 use App\Models\Feat;
 use App\Models\Modifier;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class FeatAccessorsTest extends TestCase
 {
     use RefreshDatabase;
@@ -16,7 +18,7 @@ class FeatAccessorsTest extends TestCase
     // is_half_feat accessor tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_true_for_feat_with_plus_one_ability_modifier(): void
     {
         $feat = Feat::factory()->create(['name' => 'Actor']);
@@ -31,7 +33,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertTrue($feat->is_half_feat);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_false_for_feat_with_plus_two_ability_modifier(): void
     {
         $feat = Feat::factory()->create(['name' => 'Test Feat']);
@@ -46,7 +48,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertFalse($feat->is_half_feat);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_false_for_feat_without_ability_modifiers(): void
     {
         $feat = Feat::factory()->create(['name' => 'Great Weapon Master']);
@@ -56,7 +58,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertFalse($feat->is_half_feat);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_false_for_feat_with_non_ability_modifiers(): void
     {
         $feat = Feat::factory()->create(['name' => 'Test Feat']);
@@ -71,7 +73,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertFalse($feat->is_half_feat);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_true_when_any_modifier_is_plus_one_ability(): void
     {
         $feat = Feat::factory()->create(['name' => 'Multi-Modifier Feat']);
@@ -99,7 +101,7 @@ class FeatAccessorsTest extends TestCase
     // parent_feat_slug accessor tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_parent_slug_for_variant_feat(): void
     {
         $feat = Feat::factory()->create([
@@ -110,7 +112,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertEquals('resilient', $feat->parent_feat_slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_parent_slug_for_elemental_adept_variant(): void
     {
         $feat = Feat::factory()->create([
@@ -121,7 +123,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertEquals('elemental-adept', $feat->parent_feat_slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_parent_slug_for_magic_initiate_variant(): void
     {
         $feat = Feat::factory()->create([
@@ -132,7 +134,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertEquals('magic-initiate', $feat->parent_feat_slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_non_variant_feat(): void
     {
         $feat = Feat::factory()->create([
@@ -143,7 +145,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertNull($feat->parent_feat_slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_feat_with_parentheses_in_middle(): void
     {
         // Edge case: feat name has parentheses but not as variant notation
@@ -155,7 +157,7 @@ class FeatAccessorsTest extends TestCase
         $this->assertNull($feat->parent_feat_slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_athlete_variants_correctly(): void
     {
         $feat = Feat::factory()->create([

--- a/tests/Unit/Models/FeatSearchableTest.php
+++ b/tests/Unit/Models/FeatSearchableTest.php
@@ -7,14 +7,16 @@ use App\Models\Feat;
 use App\Models\Modifier;
 use App\Models\Source;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class FeatSearchableTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_searchable_array_with_denormalized_data(): void
     {
         $source = Source::firstOrCreate(['code' => 'PHB'], ['name' => 'Player\'s Handbook']);
@@ -42,7 +44,7 @@ class FeatSearchableTest extends TestCase
         $this->assertEquals(['PHB'], $searchable['source_codes']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_defines_searchable_relationships(): void
     {
         $feat = new Feat;
@@ -51,14 +53,14 @@ class FeatSearchableTest extends TestCase
         $this->assertContains('sources.source', $feat->searchableWith());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_correct_search_index_name(): void
     {
         $feat = new Feat;
         $this->assertEquals('test_feats', $feat->searchableAs());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_is_half_feat_in_searchable_array(): void
     {
         $feat = Feat::factory()->create(['name' => 'Actor']);
@@ -78,7 +80,7 @@ class FeatSearchableTest extends TestCase
         $this->assertTrue($searchable['is_half_feat']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_parent_feat_slug_in_searchable_array(): void
     {
         $feat = Feat::factory()->create([
@@ -92,7 +94,7 @@ class FeatSearchableTest extends TestCase
         $this->assertEquals('resilient', $searchable['parent_feat_slug']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_new_fields_in_filterable_attributes(): void
     {
         $feat = new Feat;

--- a/tests/Unit/Models/ItemAccessorsTest.php
+++ b/tests/Unit/Models/ItemAccessorsTest.php
@@ -7,9 +7,11 @@ use App\Models\ItemProperty;
 use App\Models\ItemType;
 use App\Models\Modifier;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ItemAccessorsTest extends TestCase
 {
     use RefreshDatabase;
@@ -18,7 +20,7 @@ class ItemAccessorsTest extends TestCase
     // proficiency_category accessor tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_simple_melee_for_melee_weapon_without_martial_property(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -36,7 +38,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals('simple_melee', $item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_martial_melee_for_melee_weapon_with_martial_property(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -59,7 +61,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals('martial_melee', $item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_simple_ranged_for_ranged_weapon_without_martial_property(): void
     {
         $rangedType = ItemType::firstOrCreate(
@@ -77,7 +79,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals('simple_ranged', $item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_martial_ranged_for_ranged_weapon_with_martial_property(): void
     {
         $rangedType = ItemType::firstOrCreate(
@@ -100,7 +102,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals('martial_ranged', $item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_proficiency_category_for_non_weapons(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -116,7 +118,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertNull($item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_proficiency_category_for_armor(): void
     {
         $armorType = ItemType::firstOrCreate(
@@ -132,7 +134,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertNull($item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_musical_instrument_for_items_with_instrument_detail(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -149,7 +151,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals('musical_instrument', $item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_musical_instrument_for_items_with_instrument_detail_and_rarity(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -167,7 +169,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals('musical_instrument', $item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_artisan_tools_for_items_with_artisan_tools_detail(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -184,7 +186,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals('artisan_tools', $item->proficiency_category);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_gaming_set_for_items_with_gaming_set_detail(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -205,7 +207,7 @@ class ItemAccessorsTest extends TestCase
     // magic_bonus accessor tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_magic_bonus_from_weapon_attack_modifier(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -229,7 +231,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals(2, $item->magic_bonus);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_magic_bonus_from_ac_magic_modifier_for_armor(): void
     {
         $armorType = ItemType::firstOrCreate(
@@ -253,7 +255,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals(1, $item->magic_bonus);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_magic_bonus_from_ac_magic_modifier_for_shield(): void
     {
         $shieldType = ItemType::firstOrCreate(
@@ -277,7 +279,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertEquals(3, $item->magic_bonus);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_magic_bonus_for_non_magic_items(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -294,7 +296,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertNull($item->magic_bonus);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_magic_bonus_for_magic_items_without_bonus_modifier(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -313,7 +315,7 @@ class ItemAccessorsTest extends TestCase
         $this->assertNull($item->magic_bonus);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prefers_weapon_attack_over_ac_magic_for_magic_bonus(): void
     {
         // Edge case: if somehow both exist, weapon_attack takes precedence

--- a/tests/Unit/Models/ItemContentsTest.php
+++ b/tests/Unit/Models/ItemContentsTest.php
@@ -6,9 +6,11 @@ use App\Models\EntityItem;
 use App\Models\Item;
 use App\Models\ItemType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ItemContentsTest extends TestCase
 {
     use RefreshDatabase;
@@ -25,7 +27,7 @@ class ItemContentsTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_empty_collection_when_pack_has_no_contents(): void
     {
         $pack = Item::factory()->create([
@@ -36,7 +38,7 @@ class ItemContentsTest extends TestCase
         $this->assertCount(0, $pack->contents);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_contents_for_a_pack(): void
     {
         $pack = Item::factory()->create([
@@ -76,7 +78,7 @@ class ItemContentsTest extends TestCase
         $this->assertTrue($contents->contains('item_id', $bedroll->id));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_contents_with_quantities(): void
     {
         $pack = Item::factory()->create([
@@ -117,7 +119,7 @@ class ItemContentsTest extends TestCase
         $this->assertEquals(10, $rationsEntry->quantity);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_eager_loads_item_relationship_on_contents(): void
     {
         $pack = Item::factory()->create([
@@ -145,7 +147,7 @@ class ItemContentsTest extends TestCase
         $this->assertEquals('Backpack', $content->item->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_packs_this_item_is_contained_in_via_contained_in_relationship(): void
     {
         $explorersPack = Item::factory()->create([

--- a/tests/Unit/Models/ItemSearchableTest.php
+++ b/tests/Unit/Models/ItemSearchableTest.php
@@ -9,14 +9,16 @@ use App\Models\ItemType;
 use App\Models\Modifier;
 use App\Models\Source;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ItemSearchableTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_searchable_array_with_denormalized_data(): void
     {
         $type = ItemType::firstOrCreate(
@@ -66,7 +68,7 @@ class ItemSearchableTest extends TestCase
         $this->assertEquals(['DMG'], $searchable['source_codes']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_defines_searchable_relationships(): void
     {
         $item = new Item;
@@ -77,7 +79,7 @@ class ItemSearchableTest extends TestCase
         $this->assertContains('damageType', $item->searchableWith());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_correct_search_index_name(): void
     {
         $item = new Item;
@@ -85,7 +87,7 @@ class ItemSearchableTest extends TestCase
         $this->assertEquals('test_items', $item->searchableAs());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_proficiency_category_in_searchable_array(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -112,7 +114,7 @@ class ItemSearchableTest extends TestCase
         $this->assertEquals('martial_melee', $searchable['proficiency_category']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_magic_bonus_in_searchable_array(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -141,7 +143,7 @@ class ItemSearchableTest extends TestCase
         $this->assertEquals(2, $searchable['magic_bonus']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_new_fields_in_filterable_attributes(): void
     {
         $item = new Item;

--- a/tests/Unit/Models/MonsterTest.php
+++ b/tests/Unit/Models/MonsterTest.php
@@ -2,20 +2,24 @@
 
 namespace Tests\Unit\Models;
 
+use App\Models\CharacterTrait;
 use App\Models\Modifier;
 use App\Models\Monster;
 use App\Models\MonsterAction;
 use App\Models\MonsterLegendaryAction;
 use App\Models\Size;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class MonsterTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_size(): void
     {
         $monster = Monster::factory()->create();
@@ -23,18 +27,18 @@ class MonsterTest extends TestCase
         $this->assertInstanceOf(Size::class, $monster->size);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_polymorphic_entity_traits(): void
     {
         $monster = Monster::factory()->create();
-        \App\Models\CharacterTrait::create([
+        CharacterTrait::create([
             'reference_type' => Monster::class,
             'reference_id' => $monster->id,
             'name' => 'Magic Resistance',
             'description' => 'The monster has advantage on saving throws against spells.',
             'sort_order' => 1,
         ]);
-        \App\Models\CharacterTrait::create([
+        CharacterTrait::create([
             'reference_type' => Monster::class,
             'reference_id' => $monster->id,
             'name' => 'Amphibious',
@@ -43,12 +47,12 @@ class MonsterTest extends TestCase
         ]);
 
         $this->assertCount(2, $monster->entityTraits);
-        $this->assertInstanceOf(\App\Models\CharacterTrait::class, $monster->entityTraits->first());
+        $this->assertInstanceOf(CharacterTrait::class, $monster->entityTraits->first());
         // Verify ordering by sort_order
         $this->assertEquals('Magic Resistance', $monster->entityTraits->first()->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_actions(): void
     {
         $monster = Monster::factory()->create();
@@ -58,7 +62,7 @@ class MonsterTest extends TestCase
         $this->assertInstanceOf(MonsterAction::class, $monster->actions->first());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_legendary_actions(): void
     {
         $monster = Monster::factory()->create();
@@ -68,13 +72,13 @@ class MonsterTest extends TestCase
         $this->assertInstanceOf(MonsterLegendaryAction::class, $monster->legendaryActions->first());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_use_timestamps(): void
     {
         $this->assertFalse(Monster::make()->usesTimestamps());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_modifiers(): void
     {
         $monster = Monster::factory()->create();
@@ -89,7 +93,7 @@ class MonsterTest extends TestCase
 
     // Computed Accessor Tests
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function is_legendary_returns_true_when_has_legendary_actions(): void
     {
         $monster = Monster::factory()->create();
@@ -101,7 +105,7 @@ class MonsterTest extends TestCase
         $this->assertTrue($monster->is_legendary);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function is_legendary_returns_false_when_only_lair_actions(): void
     {
         $monster = Monster::factory()->create();
@@ -113,7 +117,7 @@ class MonsterTest extends TestCase
         $this->assertFalse($monster->is_legendary);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function is_legendary_returns_false_when_no_legendary_actions(): void
     {
         $monster = Monster::factory()->create();
@@ -121,8 +125,8 @@ class MonsterTest extends TestCase
         $this->assertFalse($monster->is_legendary);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
-    #[\PHPUnit\Framework\Attributes\DataProvider('proficiencyBonusProvider')]
+    #[Test]
+    #[DataProvider('proficiencyBonusProvider')]
     public function proficiency_bonus_is_computed_from_challenge_rating(string $cr, int $expectedBonus): void
     {
         $monster = Monster::factory()->create(['challenge_rating' => $cr]);
@@ -158,8 +162,8 @@ class MonsterTest extends TestCase
 
     // Challenge Rating Tests
 
-    #[\PHPUnit\Framework\Attributes\Test]
-    #[\PHPUnit\Framework\Attributes\DataProvider('challengeRatingProvider')]
+    #[Test]
+    #[DataProvider('challengeRatingProvider')]
     public function get_challenge_rating_numeric_converts_correctly(string $cr, float $expected): void
     {
         $monster = Monster::factory()->create(['challenge_rating' => $cr]);
@@ -184,7 +188,7 @@ class MonsterTest extends TestCase
 
     // Saving Throws Accessor Tests
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function saving_throws_returns_all_six_abilities(): void
     {
         $monster = Monster::factory()->create([
@@ -206,7 +210,7 @@ class MonsterTest extends TestCase
         $this->assertArrayHasKey('CHA', $savingThrows);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function saving_throws_calculates_from_ability_scores_when_not_proficient(): void
     {
         // Formula: floor((ability_score - 10) / 2)
@@ -229,7 +233,7 @@ class MonsterTest extends TestCase
         $this->assertSame(-2, $savingThrows['CHA']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function saving_throws_uses_stored_modifier_for_proficient_saves(): void
     {
         $monster = Monster::factory()->create([
@@ -270,7 +274,7 @@ class MonsterTest extends TestCase
         $this->assertSame(0, $savingThrows['CHA']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function saving_throws_handles_ancient_red_dragon_stats(): void
     {
         // Real stats from Ancient Red Dragon: CR 24, +7 proficiency
@@ -327,7 +331,7 @@ class MonsterTest extends TestCase
 
     // Legendary Metadata Tests
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function legendary_actions_per_round_defaults_to_null(): void
     {
         $monster = Monster::factory()->create();
@@ -335,7 +339,7 @@ class MonsterTest extends TestCase
         $this->assertNull($monster->legendary_actions_per_round);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function legendary_resistance_uses_defaults_to_null(): void
     {
         $monster = Monster::factory()->create();
@@ -343,7 +347,7 @@ class MonsterTest extends TestCase
         $this->assertNull($monster->legendary_resistance_uses);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function legendary_factory_state_sets_both_values(): void
     {
         $monster = Monster::factory()->legendary()->create();
@@ -352,7 +356,7 @@ class MonsterTest extends TestCase
         $this->assertSame(3, $monster->legendary_resistance_uses);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function legendary_factory_state_accepts_custom_values(): void
     {
         $monster = Monster::factory()->legendary(5, 2)->create();
@@ -361,7 +365,7 @@ class MonsterTest extends TestCase
         $this->assertSame(2, $monster->legendary_resistance_uses);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function can_set_legendary_actions_without_resistance(): void
     {
         $monster = Monster::factory()->withLegendaryActions(4)->create();
@@ -370,7 +374,7 @@ class MonsterTest extends TestCase
         $this->assertNull($monster->legendary_resistance_uses);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function can_set_legendary_resistance_without_actions(): void
     {
         $monster = Monster::factory()->withLegendaryResistance(5)->create();

--- a/tests/Unit/Models/MulticlassSpellSlotTest.php
+++ b/tests/Unit/Models/MulticlassSpellSlotTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Models;
 
 use App\Models\MulticlassSpellSlot;
+use Database\Seeders\MulticlassSpellSlotSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -14,7 +15,7 @@ class MulticlassSpellSlotTest extends TestCase
     #[Test]
     public function it_retrieves_spell_slots_for_caster_level(): void
     {
-        $this->seed(\Database\Seeders\MulticlassSpellSlotSeeder::class);
+        $this->seed(MulticlassSpellSlotSeeder::class);
 
         $slots = MulticlassSpellSlot::forCasterLevel(5);
 
@@ -28,7 +29,7 @@ class MulticlassSpellSlotTest extends TestCase
     #[Test]
     public function it_caps_at_level_20(): void
     {
-        $this->seed(\Database\Seeders\MulticlassSpellSlotSeeder::class);
+        $this->seed(MulticlassSpellSlotSeeder::class);
 
         $slots = MulticlassSpellSlot::forCasterLevel(25);
 
@@ -39,7 +40,7 @@ class MulticlassSpellSlotTest extends TestCase
     #[Test]
     public function it_returns_null_for_level_zero(): void
     {
-        $this->seed(\Database\Seeders\MulticlassSpellSlotSeeder::class);
+        $this->seed(MulticlassSpellSlotSeeder::class);
 
         $slots = MulticlassSpellSlot::forCasterLevel(0);
 
@@ -49,7 +50,7 @@ class MulticlassSpellSlotTest extends TestCase
     #[Test]
     public function it_returns_null_for_negative_level(): void
     {
-        $this->seed(\Database\Seeders\MulticlassSpellSlotSeeder::class);
+        $this->seed(MulticlassSpellSlotSeeder::class);
 
         $slots = MulticlassSpellSlot::forCasterLevel(-5);
 
@@ -59,7 +60,7 @@ class MulticlassSpellSlotTest extends TestCase
     #[Test]
     public function to_slots_array_returns_correct_structure(): void
     {
-        $this->seed(\Database\Seeders\MulticlassSpellSlotSeeder::class);
+        $this->seed(MulticlassSpellSlotSeeder::class);
 
         $slots = MulticlassSpellSlot::forCasterLevel(3);
         $array = $slots->toSlotsArray();
@@ -79,7 +80,7 @@ class MulticlassSpellSlotTest extends TestCase
     #[Test]
     public function to_slots_array_has_correct_values_for_level_1(): void
     {
-        $this->seed(\Database\Seeders\MulticlassSpellSlotSeeder::class);
+        $this->seed(MulticlassSpellSlotSeeder::class);
 
         $slots = MulticlassSpellSlot::forCasterLevel(1);
         $array = $slots->toSlotsArray();
@@ -93,7 +94,7 @@ class MulticlassSpellSlotTest extends TestCase
     #[Test]
     public function to_slots_array_has_correct_values_for_level_20(): void
     {
-        $this->seed(\Database\Seeders\MulticlassSpellSlotSeeder::class);
+        $this->seed(MulticlassSpellSlotSeeder::class);
 
         $slots = MulticlassSpellSlot::forCasterLevel(20);
         $array = $slots->toSlotsArray();

--- a/tests/Unit/Models/PartyTest.php
+++ b/tests/Unit/Models/PartyTest.php
@@ -5,15 +5,18 @@ namespace Tests\Unit\Models;
 use App\Models\Character;
 use App\Models\Party;
 use App\Models\User;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class PartyTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_user(): void
     {
         $user = User::factory()->create();
@@ -23,7 +26,7 @@ class PartyTest extends TestCase
         $this->assertEquals($user->id, $party->user->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_many_characters(): void
     {
         $party = Party::factory()->create();
@@ -35,7 +38,7 @@ class PartyTest extends TestCase
         $this->assertInstanceOf(Character::class, $party->characters->first());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_timestamps(): void
     {
         $party = Party::factory()->create();
@@ -44,7 +47,7 @@ class PartyTest extends TestCase
         $this->assertNotNull($party->updated_at);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_fillable_attributes(): void
     {
         $party = new Party;
@@ -54,7 +57,7 @@ class PartyTest extends TestCase
         $this->assertContains('user_id', $party->getFillable());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function characters_pivot_includes_joined_at_and_display_order(): void
     {
         $party = Party::factory()->create();
@@ -71,7 +74,7 @@ class PartyTest extends TestCase
         $this->assertEquals(1, $pivot->display_order);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function character_can_be_in_multiple_parties(): void
     {
         $character = Character::factory()->create();
@@ -86,7 +89,7 @@ class PartyTest extends TestCase
         $this->assertCount(2, $character->parties);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_get_parties_for_a_character(): void
     {
         $character = Character::factory()->create();
@@ -97,7 +100,7 @@ class PartyTest extends TestCase
         $this->assertInstanceOf(Party::class, $character->parties->first());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prevents_duplicate_character_in_same_party(): void
     {
         $party = Party::factory()->create();
@@ -105,11 +108,11 @@ class PartyTest extends TestCase
 
         $party->characters()->attach($character);
 
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectException(QueryException::class);
         $party->characters()->attach($character);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cascades_delete_on_party_deletion(): void
     {
         $party = Party::factory()->create();
@@ -124,7 +127,7 @@ class PartyTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cascades_delete_on_character_deletion(): void
     {
         $party = Party::factory()->create();
@@ -139,7 +142,7 @@ class PartyTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pivot_includes_timestamps(): void
     {
         $party = Party::factory()->create();

--- a/tests/Unit/Models/RaceSearchableTest.php
+++ b/tests/Unit/Models/RaceSearchableTest.php
@@ -2,19 +2,23 @@
 
 namespace Tests\Unit\Models;
 
+use App\Models\EntitySense;
 use App\Models\EntitySource;
 use App\Models\Race;
+use App\Models\Sense;
 use App\Models\Size;
 use App\Models\Source;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class RaceSearchableTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_searchable_array_with_denormalized_data(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -45,7 +49,7 @@ class RaceSearchableTest extends TestCase
         $this->assertEquals(['PHB'], $searchable['source_codes']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_defines_searchable_relationships(): void
     {
         $race = new Race;
@@ -56,22 +60,22 @@ class RaceSearchableTest extends TestCase
         $this->assertContains('parent', $race->searchableWith());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_correct_search_index_name(): void
     {
         $race = new Race;
         $this->assertEquals('test_races', $race->searchableAs());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_indexes_darkvision_fields_in_searchable_array(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
-        $sense = \App\Models\Sense::firstOrCreate(['slug' => 'core:darkvision'], ['name' => 'Darkvision']);
+        $sense = Sense::firstOrCreate(['slug' => 'core:darkvision'], ['name' => 'Darkvision']);
 
         $race = Race::factory()->create(['size_id' => $size->id]);
 
-        \App\Models\EntitySense::create([
+        EntitySense::create([
             'reference_type' => Race::class,
             'reference_id' => $race->id,
             'sense_id' => $sense->id,
@@ -86,7 +90,7 @@ class RaceSearchableTest extends TestCase
         $this->assertEquals(60, $searchable['darkvision_range']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_indexes_speed_fields_in_searchable_array(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -108,7 +112,7 @@ class RaceSearchableTest extends TestCase
         $this->assertTrue($searchable['has_climb_speed']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_indexes_false_for_missing_speeds(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -130,7 +134,7 @@ class RaceSearchableTest extends TestCase
         $this->assertFalse($searchable['has_climb_speed']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_speed_and_sense_fields_in_filterable_attributes(): void
     {
         $race = new Race;
@@ -148,7 +152,7 @@ class RaceSearchableTest extends TestCase
         $this->assertContains('darkvision_range', $filterable);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_climb_speed_in_sortable_attributes(): void
     {
         $race = new Race;

--- a/tests/Unit/Models/RaceTest.php
+++ b/tests/Unit/Models/RaceTest.php
@@ -5,14 +5,16 @@ namespace Tests\Unit\Models;
 use App\Models\Race;
 use App\Models\Size;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class RaceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function is_subrace_returns_true_when_has_parent_race(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -25,7 +27,7 @@ class RaceTest extends TestCase
         $this->assertTrue($subrace->is_subrace);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function is_subrace_returns_false_when_no_parent_race(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -37,7 +39,7 @@ class RaceTest extends TestCase
         $this->assertFalse($baseRace->is_subrace);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_speed_columns_fillable(): void
     {
         $race = new Race;
@@ -46,7 +48,7 @@ class RaceTest extends TestCase
         $this->assertContains('swim_speed', $race->getFillable());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_casts_speed_columns_to_integer(): void
     {
         $race = new Race;
@@ -56,7 +58,7 @@ class RaceTest extends TestCase
         $this->assertEquals('integer', $casts['swim_speed']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function factory_can_create_race_with_fly_speed(): void
     {
         $race = Race::factory()->withFlySpeed(50)->create();
@@ -64,7 +66,7 @@ class RaceTest extends TestCase
         $this->assertEquals(50, $race->fly_speed);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function factory_can_create_race_with_swim_speed(): void
     {
         $race = Race::factory()->withSwimSpeed(30)->create();
@@ -72,7 +74,7 @@ class RaceTest extends TestCase
         $this->assertEquals(30, $race->swim_speed);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function subrace_required_defaults_to_true(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -81,7 +83,7 @@ class RaceTest extends TestCase
         $this->assertTrue($race->subrace_required);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function subrace_required_can_be_set_to_false(): void
     {
         $size = Size::firstOrCreate(['code' => 'M'], ['name' => 'Medium']);
@@ -93,7 +95,7 @@ class RaceTest extends TestCase
         $this->assertFalse($race->subrace_required);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function subrace_required_is_fillable(): void
     {
         $race = new Race;
@@ -101,7 +103,7 @@ class RaceTest extends TestCase
         $this->assertContains('subrace_required', $race->getFillable());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function subrace_required_is_cast_to_boolean(): void
     {
         $race = new Race;

--- a/tests/Unit/Models/SpellAccessorsTest.php
+++ b/tests/Unit/Models/SpellAccessorsTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit\Models;
 
 use App\Models\Spell;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -16,7 +18,7 @@ use Tests\TestCase;
  * Edge cases with unusual formatting may not be parsed correctly.
  * See GitHub issues #27 and #28 for known limitations.
  */
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SpellAccessorsTest extends TestCase
 {
     use RefreshDatabase;
@@ -25,7 +27,7 @@ class SpellAccessorsTest extends TestCase
     // area_of_effect accessor tests
     // =========================================================================
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_cone_area_of_effect(): void
     {
         $spell = Spell::factory()->create([
@@ -40,7 +42,7 @@ class SpellAccessorsTest extends TestCase
         $this->assertEquals(15, $aoe['size']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_sphere_area_of_effect(): void
     {
         $spell = Spell::factory()->create([
@@ -55,7 +57,7 @@ class SpellAccessorsTest extends TestCase
         $this->assertEquals(20, $aoe['size']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_cube_area_of_effect(): void
     {
         $spell = Spell::factory()->create([
@@ -70,7 +72,7 @@ class SpellAccessorsTest extends TestCase
         $this->assertEquals(15, $aoe['size']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_line_area_of_effect(): void
     {
         $spell = Spell::factory()->create([
@@ -86,7 +88,7 @@ class SpellAccessorsTest extends TestCase
         $this->assertEquals(5, $aoe['width']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_cylinder_area_of_effect(): void
     {
         $spell = Spell::factory()->create([
@@ -102,7 +104,7 @@ class SpellAccessorsTest extends TestCase
         $this->assertEquals(40, $aoe['height']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_spells_without_area(): void
     {
         $spell = Spell::factory()->create([
@@ -113,7 +115,7 @@ class SpellAccessorsTest extends TestCase
         $this->assertNull($spell->area_of_effect);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_empty_description(): void
     {
         $spell = Spell::factory()->create([

--- a/tests/Unit/Models/SpellSearchableTest.php
+++ b/tests/Unit/Models/SpellSearchableTest.php
@@ -7,14 +7,16 @@ use App\Models\Source;
 use App\Models\Spell;
 use App\Models\SpellSchool;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SpellSearchableTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_searchable_array_with_denormalized_data(): void
     {
         $school = SpellSchool::firstOrCreate(['code' => 'EV'], ['name' => 'Evocation']);
@@ -62,7 +64,7 @@ class SpellSearchableTest extends TestCase
         $this->assertIsArray($searchable['classes']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_defines_searchable_relationships(): void
     {
         $spell = new Spell;
@@ -73,7 +75,7 @@ class SpellSearchableTest extends TestCase
         $this->assertContains('classes', $spell->searchableWith());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_correct_search_index_name(): void
     {
         $spell = new Spell;
@@ -82,7 +84,7 @@ class SpellSearchableTest extends TestCase
         $this->assertEquals('test_spells', $spell->searchableAs());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_material_cost_fields_in_searchable_array(): void
     {
         // material_cost_gp and material_consumed are now real columns,
@@ -102,7 +104,7 @@ class SpellSearchableTest extends TestCase
         $this->assertTrue($searchable['material_consumed']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_aoe_fields_in_searchable_array(): void
     {
         $spell = Spell::factory()->create([
@@ -118,7 +120,7 @@ class SpellSearchableTest extends TestCase
         $this->assertEquals(20, $searchable['aoe_size']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_new_fields_in_filterable_attributes(): void
     {
         $spell = new Spell;

--- a/tests/Unit/Models/SpellTest.php
+++ b/tests/Unit/Models/SpellTest.php
@@ -3,24 +3,28 @@
 namespace Tests\Unit\Models;
 
 use App\Models\Spell;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SpellTest extends TestCase
 {
     #[Test]
     public function spell_belongs_to_spell_school(): void
     {
         $spell = new Spell;
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\BelongsTo::class, $spell->spellSchool());
+        $this->assertInstanceOf(BelongsTo::class, $spell->spellSchool());
     }
 
     #[Test]
     public function spell_has_many_sources(): void
     {
         $spell = new Spell;
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\MorphMany::class, $spell->sources());
+        $this->assertInstanceOf(MorphMany::class, $spell->sources());
     }
 
     #[Test]
@@ -32,8 +36,8 @@ class SpellTest extends TestCase
 
     // Computed Accessor Tests
 
-    #[\PHPUnit\Framework\Attributes\Test]
-    #[\PHPUnit\Framework\Attributes\DataProvider('castingTimeTypeProvider')]
+    #[Test]
+    #[DataProvider('castingTimeTypeProvider')]
     public function casting_time_type_is_computed_from_casting_time(string $castingTime, string $expectedType): void
     {
         $spell = new Spell(['casting_time' => $castingTime]);

--- a/tests/Unit/Parsers/BackgroundXmlParserTest.php
+++ b/tests/Unit/Parsers/BackgroundXmlParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\BackgroundXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class BackgroundXmlParserTest extends TestCase
 {
     private BackgroundXmlParser $parser;

--- a/tests/Unit/Parsers/ClassXmlParserEquipmentTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserEquipmentTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ClassXmlParserEquipmentTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Parsers/ClassXmlParserMulticlassRequirementsTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserMulticlassRequirementsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -16,7 +17,7 @@ use Tests\TestCase;
  * - AND: "• Dexterity 13\n• Wisdom 13"
  * - OR: "• Strength 13, or\n• Dexterity 13"
  */
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ClassXmlParserMulticlassRequirementsTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Parsers/ClassXmlParserOptionalSlotsTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserOptionalSlotsTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ClassXmlParserOptionalSlotsTest extends TestCase
 {
     private ClassXmlParser $parser;

--- a/tests/Unit/Parsers/ClassXmlParserProficiencyChoicesTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserProficiencyChoicesTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ClassXmlParserProficiencyChoicesTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Parsers/ClassXmlParserSpellPreparationMethodTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserSpellPreparationMethodTest.php
@@ -3,12 +3,14 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ClassXmlParserSpellPreparationMethodTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_spellbook_method_from_spellcasting_feature_text(): void
     {
         // Wizard has "spellbook" in Spellcasting feature
@@ -39,7 +41,7 @@ XML;
         $this->assertEquals('spellbook', $data[0]['spell_preparation_method']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_known_method_from_spells_known_counters(): void
     {
         // Bard has "Spells Known" counters
@@ -82,7 +84,7 @@ XML;
         $this->assertEquals('known', $data[0]['spell_preparation_method']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_prepared_method_for_casters_without_spells_known(): void
     {
         // Cleric has spellcasting but no spells_known counters or spellbook
@@ -113,7 +115,7 @@ XML;
         $this->assertEquals('prepared', $data[0]['spell_preparation_method']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_non_casters(): void
     {
         // Fighter has no spellcasting ability
@@ -139,7 +141,7 @@ XML;
         $this->assertNull($data[0]['spell_preparation_method']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_spellbook_when_text_detection_fails_but_progression_matches_wizard_formula(): void
     {
         // Edge case: spellbook text check fails, but progression matches Wizard formula (6, 8, 10...)
@@ -193,7 +195,7 @@ XML;
         $this->assertEquals(14, $progression[4]['spells_known']); // Level 5: 14
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_distinguishes_known_casters_from_wizard_by_non_matching_progression(): void
     {
         // Sorcerer's spells_known don't follow Wizard formula (4, 5, 6, 7...)
@@ -247,7 +249,7 @@ XML;
         $this->assertEquals('known', $data[0]['spell_preparation_method']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_optional_spellcasters(): void
     {
         // Fighter with optional slots (Eldritch Knight) - base class is non-caster

--- a/tests/Unit/Parsers/ClassXmlParserSpellsKnownTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserSpellsKnownTest.php
@@ -3,12 +3,14 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ClassXmlParserSpellsKnownTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_spells_known_into_spell_progression(): void
     {
         // Test with NON-optional slots (e.g., Wizard)
@@ -52,7 +54,7 @@ XML;
         $this->assertEquals(4, $data[0]['spell_progression'][1]['spells_known']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_include_spells_known_in_counters(): void
     {
         $xml = <<<'XML'
@@ -84,7 +86,7 @@ XML;
         $this->assertEquals('Second Wind', $data[0]['counters'][0]['name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_merges_spells_known_from_separate_autolevel_elements(): void
     {
         // Real-world case: Bard has slots and counters in SEPARATE autolevels
@@ -134,7 +136,7 @@ XML;
         $this->assertEquals(5, $level2['spells_known'], 'Level 2 should have 5 spells known');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_spells_known_for_optional_slots(): void
     {
         // Classes with optional slots (Fighter, Rogue) should NOT have spell progression

--- a/tests/Unit/Parsers/ClassXmlParserSubclassFilteringTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserSubclassFilteringTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ClassXmlParserSubclassFilteringTest extends TestCase
 {
     private ClassXmlParser $parser;

--- a/tests/Unit/Parsers/ClassXmlParserSubclassSpellSlotsTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserSubclassSpellSlotsTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ClassXmlParserSubclassSpellSlotsTest extends TestCase
 {
     private ClassXmlParser $parser;

--- a/tests/Unit/Parsers/ClassXmlParserTest.php
+++ b/tests/Unit/Parsers/ClassXmlParserTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\ClassXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ClassXmlParserTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Parsers/Concerns/ConvertsWordNumbersTest.php
+++ b/tests/Unit/Parsers/Concerns/ConvertsWordNumbersTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\ConvertsWordNumbers;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ConvertsWordNumbersTest extends TestCase
 {
     use ConvertsWordNumbers;

--- a/tests/Unit/Parsers/Concerns/LookupsGameEntitiesTest.php
+++ b/tests/Unit/Parsers/Concerns/LookupsGameEntitiesTest.php
@@ -6,10 +6,11 @@ use App\Models\AbilityScore;
 use App\Models\Skill;
 use App\Services\Parsers\Concerns\LookupsGameEntities;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class LookupsGameEntitiesTest extends TestCase
 {
     use LookupsGameEntities, RefreshDatabase;

--- a/tests/Unit/Parsers/Concerns/MapsAbilityCodesTest.php
+++ b/tests/Unit/Parsers/Concerns/MapsAbilityCodesTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\MapsAbilityCodes;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class MapsAbilityCodesTest extends TestCase
 {
     use MapsAbilityCodes;

--- a/tests/Unit/Parsers/Concerns/MatchesProficiencyTypesTest.php
+++ b/tests/Unit/Parsers/Concerns/MatchesProficiencyTypesTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\MatchesProficiencyTypes;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class MatchesProficiencyTypesTest extends TestCase
 {
     use MatchesProficiencyTypes, RefreshDatabase;

--- a/tests/Unit/Parsers/Concerns/ParsesExpertiseTest.php
+++ b/tests/Unit/Parsers/Concerns/ParsesExpertiseTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\ParsesExpertise;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesExpertiseTest extends TestCase
 {
     use ParsesExpertise;

--- a/tests/Unit/Parsers/Concerns/ParsesFeatureChoiceProgressionsTest.php
+++ b/tests/Unit/Parsers/Concerns/ParsesFeatureChoiceProgressionsTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\ParsesFeatureChoiceProgressions;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesFeatureChoiceProgressionsTest extends TestCase
 {
     use ParsesFeatureChoiceProgressions;

--- a/tests/Unit/Parsers/Concerns/ParsesRollsTest.php
+++ b/tests/Unit/Parsers/Concerns/ParsesRollsTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\ParsesRolls;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesRollsTest extends TestCase
 {
     use ParsesRolls;

--- a/tests/Unit/Parsers/Concerns/ParsesSkillAdvantagesTest.php
+++ b/tests/Unit/Parsers/Concerns/ParsesSkillAdvantagesTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\ParsesSkillAdvantages;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesSkillAdvantagesTest extends TestCase
 {
     use ParsesSkillAdvantages;

--- a/tests/Unit/Parsers/Concerns/ParsesTraitsTest.php
+++ b/tests/Unit/Parsers/Concerns/ParsesTraitsTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Parsers\Concerns;
 
 use App\Services\Parsers\Concerns\ParsesTraits;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesTraitsTest extends TestCase
 {
     use ParsesTraits;
@@ -138,7 +139,7 @@ class ParsesTraitsTest extends TestCase
     }
 
     // Mock the parseRollElements method that will come from ParsesRolls trait
-    protected function parseRollElements(\SimpleXMLElement $element): array
+    protected function parseRollElements(SimpleXMLElement $element): array
     {
         $rolls = [];
         foreach ($element->roll as $rollElement) {

--- a/tests/Unit/Parsers/Concerns/ParsesTraitsUsageLimitsTest.php
+++ b/tests/Unit/Parsers/Concerns/ParsesTraitsUsageLimitsTest.php
@@ -6,6 +6,7 @@ use App\Enums\ResetTiming;
 use App\Services\Parsers\Concerns\ParsesRestTiming;
 use App\Services\Parsers\Concerns\ParsesTraits;
 use App\Services\Parsers\Concerns\ParsesUsageLimits;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
@@ -16,7 +17,7 @@ use Tests\TestCase;
  * These tests verify that ParsesTraits correctly extracts max_uses and resets_on
  * from trait descriptions for features like Breath Weapon, Relentless Endurance, etc.
  */
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesTraitsUsageLimitsTest extends TestCase
 {
     use ParsesRestTiming;
@@ -201,7 +202,7 @@ class ParsesTraitsUsageLimitsTest extends TestCase
     }
 
     // Mock parseRollElements for test isolation
-    protected function parseRollElements(\SimpleXMLElement $element): array
+    protected function parseRollElements(SimpleXMLElement $element): array
     {
         $rolls = [];
         foreach ($element->roll as $rollElement) {

--- a/tests/Unit/Parsers/FeatXmlParserPrerequisitesTest.php
+++ b/tests/Unit/Parsers/FeatXmlParserPrerequisitesTest.php
@@ -8,10 +8,11 @@ use App\Models\Race;
 use App\Models\Skill;
 use App\Services\Parsers\FeatXmlParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class FeatXmlParserPrerequisitesTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Parsers/FeatXmlParserTest.php
+++ b/tests/Unit/Parsers/FeatXmlParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\FeatXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class FeatXmlParserTest extends TestCase
 {
     private FeatXmlParser $parser;

--- a/tests/Unit/Parsers/ItemChargesParserTest.php
+++ b/tests/Unit/Parsers/ItemChargesParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\Concerns\ParsesCharges;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ItemChargesParserTest extends TestCase
 {
     use ParsesCharges;

--- a/tests/Unit/Parsers/ItemProficiencyParserTest.php
+++ b/tests/Unit/Parsers/ItemProficiencyParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\Concerns\ParsesItemProficiencies;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ItemProficiencyParserTest extends TestCase
 {
     private object $parser;

--- a/tests/Unit/Parsers/ItemSavingThrowsParserTest.php
+++ b/tests/Unit/Parsers/ItemSavingThrowsParserTest.php
@@ -3,14 +3,16 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\Concerns\ParsesItemSavingThrows;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ItemSavingThrowsParserTest extends TestCase
 {
     use ParsesItemSavingThrows;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_dc_10_charisma_save()
     {
         $description = 'The target must succeed on a DC 10 Charisma saving throw or be forced to smile for 1 minute.';
@@ -22,7 +24,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertTrue($result['is_initial_save']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_dc_15_dexterity_save()
     {
         $description = 'Each creature must make a DC 15 Dexterity saving throw or take 5d4 fire damage.';
@@ -33,7 +35,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('half_damage', $result['save_effect']); // "or take damage" = half on save
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_dc_15_dexterity_save_with_half_damage_explicit()
     {
         $description = 'DC 15 Dexterity saving throw, taking 5d4 fire damage on a failed save, or half as much damage on a successful one.';
@@ -44,7 +46,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('half_damage', $result['save_effect']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_dc_17_charisma_save()
     {
         $description = 'You must make a DC 17 Charisma saving throw.';
@@ -55,7 +57,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('negates', $result['save_effect']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_dc_10_constitution_save()
     {
         $description = 'A creature subjected to this poison must make a DC 10 Constitution saving throw.';
@@ -65,7 +67,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('CON', $result['ability_code']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_wisdom_saving_throw()
     {
         $description = 'The creature must make a DC 15 Wisdom saving throw or be frightened.';
@@ -75,7 +77,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('WIS', $result['ability_code']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_strength_saving_throw()
     {
         $description = 'Make a DC 12 Strength saving throw or be pushed back.';
@@ -85,7 +87,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('STR', $result['ability_code']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_intelligence_saving_throw()
     {
         $description = 'Succeed on a DC 14 Intelligence saving throw.';
@@ -95,7 +97,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('INT', $result['ability_code']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_items_without_saves()
     {
         $description = 'This wand has 3 charges and can cast spells.';
@@ -104,7 +106,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_case_insensitive_ability_names()
     {
         $description = 'DC 10 charisma SAVING THROW';
@@ -114,7 +116,7 @@ class ItemSavingThrowsParserTest extends TestCase
         $this->assertSame('CHA', $result['ability_code']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_half_damage_from_various_phrasings()
     {
         $texts = [

--- a/tests/Unit/Parsers/ItemSpellsParserTest.php
+++ b/tests/Unit/Parsers/ItemSpellsParserTest.php
@@ -3,14 +3,16 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\Concerns\ParsesItemSpells;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ItemSpellsParserTest extends TestCase
 {
     use ParsesItemSpells;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_fixed_charge_cost()
     {
         $text = 'lesser restoration (2 charges)';
@@ -21,7 +23,7 @@ class ItemSpellsParserTest extends TestCase
         $this->assertNull($result['formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_variable_charge_cost_per_spell_level()
     {
         $text = 'cure wounds (1 charge per spell level, up to 4th)';
@@ -32,7 +34,7 @@ class ItemSpellsParserTest extends TestCase
         $this->assertSame('1 per spell level', $result['formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_free_spells_with_no_charges()
     {
         $text = 'detect magic (no charges)';
@@ -43,7 +45,7 @@ class ItemSpellsParserTest extends TestCase
         $this->assertNull($result['formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_expends_syntax()
     {
         $text = 'expend 3 charges to cast fireball';
@@ -54,7 +56,7 @@ class ItemSpellsParserTest extends TestCase
         $this->assertNull($result['formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_text_without_charge_costs()
     {
         $text = 'This is just regular text without costs';
@@ -65,7 +67,7 @@ class ItemSpellsParserTest extends TestCase
         $this->assertNull($result['formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_multiple_spells_from_staff_of_healing_description()
     {
         // This matches the ACTUAL XML format with a period before "or mass cure wounds"
@@ -97,7 +99,7 @@ TEXT;
         $this->assertNull($spells[2]['charges_cost_formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_spells_from_staff_of_fire_description()
     {
         $description = <<<'TEXT'
@@ -118,7 +120,7 @@ TEXT;
         $this->assertSame(4, $spells[2]['charges_cost_min']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_empty_array_for_items_without_spells()
     {
         $description = 'This wand has 3 charges. It can force humanoids to smile.';
@@ -127,7 +129,7 @@ TEXT;
         $this->assertEmpty($spells);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_single_charge_syntax()
     {
         $text = 'detect thoughts (1 charge)';
@@ -138,7 +140,7 @@ TEXT;
         $this->assertNull($result['formula']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_at_will_usage()
     {
         $description = 'While wearing this hat, you can use an action to cast the disguise self spell from it at will.';
@@ -149,7 +151,7 @@ TEXT;
         $this->assertSame('at will', $spells[0]['usage_limit']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_at_will_with_on_yourself()
     {
         $description = 'While you wear these boots, you can use an action to cast the levitate spell on yourself at will.';
@@ -160,7 +162,7 @@ TEXT;
         $this->assertSame('at will', $spells[0]['usage_limit']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_usage_limit_when_not_specified()
     {
         // Staff of Fire has charge-based casting, not usage limits

--- a/tests/Unit/Parsers/ItemXmlParserTest.php
+++ b/tests/Unit/Parsers/ItemXmlParserTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Unit\Parsers;
 
+use App\Models\AbilityScore;
+use App\Models\ProficiencyType;
 use App\Services\Parsers\ItemXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ItemXmlParserTest extends TestCase
 {
     private ItemXmlParser $parser;
@@ -40,7 +43,7 @@ XML;
 
         // If database is seeded, should match (optional for unit tests)
         try {
-            if (\App\Models\ProficiencyType::count() > 0) {
+            if (ProficiencyType::count() > 0) {
                 $this->assertNotNull($items[0]['proficiencies'][0]['proficiency_type_id']);
             }
         } catch (\Exception $e) {
@@ -116,7 +119,7 @@ XML;
 
         // If database is seeded, should match Strength (optional for unit tests)
         try {
-            if (\App\Models\AbilityScore::count() > 0) {
+            if (AbilityScore::count() > 0) {
                 $this->assertNotNull($items[0]['modifiers'][0]['ability_score_id']);
             }
         } catch (\Exception $e) {

--- a/tests/Unit/Parsers/LuckBladeChargesTest.php
+++ b/tests/Unit/Parsers/LuckBladeChargesTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\Concerns\ParsesCharges;
 use App\Services\Parsers\Concerns\ParsesItemSpells;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class LuckBladeChargesTest extends TestCase
 {

--- a/tests/Unit/Parsers/MonsterXmlParserTest.php
+++ b/tests/Unit/Parsers/MonsterXmlParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class MonsterXmlParserTest extends TestCase
 {

--- a/tests/Unit/Parsers/PackContentsParserTest.php
+++ b/tests/Unit/Parsers/PackContentsParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\Concerns\ParsesPackContents;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class PackContentsParserTest extends TestCase
 {
     use ParsesPackContents;

--- a/tests/Unit/Parsers/ParsesMovementModifiersTest.php
+++ b/tests/Unit/Parsers/ParsesMovementModifiersTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\FeatXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -13,7 +14,7 @@ use Tests\TestCase;
  * such as climbing not costing extra movement, or standing from prone
  * costing less movement than normal.
  */
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesMovementModifiersTest extends TestCase
 {
     private FeatXmlParser $parser;

--- a/tests/Unit/Parsers/ParsesRestTimingTest.php
+++ b/tests/Unit/Parsers/ParsesRestTimingTest.php
@@ -4,10 +4,11 @@ namespace Tests\Unit\Parsers;
 
 use App\Enums\ResetTiming;
 use App\Services\Parsers\Concerns\ParsesRestTiming;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class ParsesRestTimingTest extends TestCase
 {
     use ParsesRestTiming;

--- a/tests/Unit/Parsers/ParsesScalingIncrementTest.php
+++ b/tests/Unit/Parsers/ParsesScalingIncrementTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Unit\Parsers;
 
+use App\Services\Parsers\Concerns\ParsesScalingIncrement;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
 
 // Create a test class that uses the trait
 class ParsesScalingIncrementTestClass
 {
-    use \App\Services\Parsers\Concerns\ParsesScalingIncrement;
+    use ParsesScalingIncrement;
 
     public function parse(?string $text): ?string
     {
@@ -15,7 +17,7 @@ class ParsesScalingIncrementTestClass
     }
 }
 
-class ParsesScalingIncrementTest extends \Tests\TestCase
+class ParsesScalingIncrementTest extends TestCase
 {
     private ParsesScalingIncrementTestClass $parser;
 

--- a/tests/Unit/Parsers/RaceXmlParserTest.php
+++ b/tests/Unit/Parsers/RaceXmlParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\RaceXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class RaceXmlParserTest extends TestCase
 {

--- a/tests/Unit/Parsers/SourceXmlParserTest.php
+++ b/tests/Unit/Parsers/SourceXmlParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\SourceXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class SourceXmlParserTest extends TestCase
 {

--- a/tests/Unit/Parsers/SpellClassMappingParserTest.php
+++ b/tests/Unit/Parsers/SpellClassMappingParserTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\SpellClassMappingParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class SpellClassMappingParserTest extends TestCase
 {
@@ -17,7 +19,7 @@ class SpellClassMappingParserTest extends TestCase
         $this->parser = new SpellClassMappingParser;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_spell_name_and_classes_from_xml()
     {
         $xml = <<<'XML'
@@ -41,7 +43,7 @@ XML;
         ], $result['Animate Dead']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parses_multiple_spells()
     {
         $xml = <<<'XML'
@@ -72,7 +74,7 @@ XML;
         $this->assertArrayHasKey('Confusion', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_single_class_without_subclass()
     {
         $xml = <<<'XML'
@@ -92,7 +94,7 @@ XML;
         $this->assertEquals(['Wizard'], $result['Fireball']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_spells_without_name()
     {
         $xml = <<<'XML'
@@ -116,7 +118,7 @@ XML;
         $this->assertArrayHasKey('Fireball', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_spells_without_classes()
     {
         $xml = <<<'XML'
@@ -140,7 +142,7 @@ XML;
         $this->assertArrayHasKey('Magic Missile', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_exception_for_missing_file()
     {
         $this->expectException(\Exception::class);
@@ -149,7 +151,7 @@ XML;
         $this->parser->parse('/nonexistent/file.xml');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_exception_for_invalid_xml()
     {
         $invalidXml = '<?xml version="1.0"?><broken><unclosed>';

--- a/tests/Unit/Parsers/SpellDataTableParserTest.php
+++ b/tests/Unit/Parsers/SpellDataTableParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\SpellXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class SpellDataTableParserTest extends TestCase
 {

--- a/tests/Unit/Parsers/SpellProjectileScalingParserTest.php
+++ b/tests/Unit/Parsers/SpellProjectileScalingParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\Concerns\ParsesProjectileScaling;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class SpellProjectileScalingParserTest extends TestCase
 {
     use ParsesProjectileScaling;

--- a/tests/Unit/Parsers/SpellSavingThrowsParserTest.php
+++ b/tests/Unit/Parsers/SpellSavingThrowsParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\SpellXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class SpellSavingThrowsParserTest extends TestCase
 {

--- a/tests/Unit/Parsers/SpellXmlParserTest.php
+++ b/tests/Unit/Parsers/SpellXmlParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Parsers;
 
 use App\Services\Parsers\SpellXmlParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class SpellXmlParserTest extends TestCase
 {

--- a/tests/Unit/Resources/FeatResourceTest.php
+++ b/tests/Unit/Resources/FeatResourceTest.php
@@ -6,14 +6,16 @@ use App\Http\Resources\FeatResource;
 use App\Models\Feat;
 use App\Models\Modifier;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class FeatResourceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_is_half_feat_in_response(): void
     {
         $feat = Feat::factory()->create(['name' => 'Actor']);
@@ -34,7 +36,7 @@ class FeatResourceTest extends TestCase
         $this->assertTrue($response['is_half_feat']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_parent_feat_slug_in_response(): void
     {
         $feat = Feat::factory()->create([
@@ -49,7 +51,7 @@ class FeatResourceTest extends TestCase
         $this->assertEquals('resilient', $response['parent_feat_slug']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_false_is_half_feat_for_non_half_feats(): void
     {
         $feat = Feat::factory()->create(['name' => 'Great Weapon Master']);
@@ -63,7 +65,7 @@ class FeatResourceTest extends TestCase
         $this->assertFalse($response['is_half_feat']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_parent_feat_slug_for_non_variant_feats(): void
     {
         $feat = Feat::factory()->create([

--- a/tests/Unit/Resources/ItemResourceTest.php
+++ b/tests/Unit/Resources/ItemResourceTest.php
@@ -9,14 +9,16 @@ use App\Models\ItemProperty;
 use App\Models\ItemType;
 use App\Models\Modifier;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ItemResourceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_proficiency_category_in_response(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -44,7 +46,7 @@ class ItemResourceTest extends TestCase
         $this->assertEquals('martial_melee', $response['proficiency_category']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_magic_bonus_in_response(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -74,7 +76,7 @@ class ItemResourceTest extends TestCase
         $this->assertEquals(2, $response['magic_bonus']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_proficiency_category_for_non_weapons(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -96,7 +98,7 @@ class ItemResourceTest extends TestCase
         $this->assertNull($response['proficiency_category']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_magic_bonus_for_non_magic_items(): void
     {
         $meleeType = ItemType::firstOrCreate(
@@ -119,7 +121,7 @@ class ItemResourceTest extends TestCase
         $this->assertNull($response['magic_bonus']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_contents_for_pack_items(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -174,7 +176,7 @@ class ItemResourceTest extends TestCase
         $this->assertArrayHasKey('slug', $backpackContent['item']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_empty_array_for_items_without_contents(): void
     {
         $gearType = ItemType::firstOrCreate(
@@ -196,7 +198,7 @@ class ItemResourceTest extends TestCase
         $this->assertCount(0, $response['contents']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_equipment_slot_in_response(): void
     {
         $wondrousType = ItemType::firstOrCreate(
@@ -217,7 +219,7 @@ class ItemResourceTest extends TestCase
         $this->assertEquals('cloak', $response['equipment_slot']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_equipment_slot_for_items_without_body_slot(): void
     {
         $gearType = ItemType::firstOrCreate(

--- a/tests/Unit/Resources/MediaResourceTest.php
+++ b/tests/Unit/Resources/MediaResourceTest.php
@@ -7,9 +7,11 @@ use App\Models\Character;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class MediaResourceTest extends TestCase
 {
     use RefreshDatabase;
@@ -34,7 +36,7 @@ class MediaResourceTest extends TestCase
         return $newPath;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_media_with_basic_fields(): void
     {
         $character = Character::factory()->create();
@@ -57,7 +59,7 @@ class MediaResourceTest extends TestCase
         $this->assertEquals('portrait', $array['collection']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_urls_array_with_original(): void
     {
         $character = Character::factory()->create();
@@ -74,7 +76,7 @@ class MediaResourceTest extends TestCase
         $this->assertIsString($array['urls']['original']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_null_thumb_when_conversion_does_not_exist(): void
     {
         $character = Character::factory()->create();
@@ -89,7 +91,7 @@ class MediaResourceTest extends TestCase
         $this->assertNull($array['urls']['thumb']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_null_medium_when_conversion_does_not_exist(): void
     {
         $character = Character::factory()->create();
@@ -104,7 +106,7 @@ class MediaResourceTest extends TestCase
         $this->assertNull($array['urls']['medium']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_formats_created_at_as_iso8601(): void
     {
         $character = Character::factory()->create();
@@ -120,7 +122,7 @@ class MediaResourceTest extends TestCase
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $array['created_at']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_file_metadata(): void
     {
         $character = Character::factory()->create();
@@ -138,7 +140,7 @@ class MediaResourceTest extends TestCase
         $this->assertIsInt($array['size']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_media_from_different_collections(): void
     {
         $character = Character::factory()->create();

--- a/tests/Unit/Resources/MulticlassRequirementResourceTest.php
+++ b/tests/Unit/Resources/MulticlassRequirementResourceTest.php
@@ -7,14 +7,16 @@ use App\Models\AbilityScore;
 use App\Models\CharacterClass;
 use App\Models\Proficiency;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class MulticlassRequirementResourceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_multiclass_requirement_with_ability_score(): void
     {
         $class = CharacterClass::factory()->create();
@@ -41,7 +43,7 @@ class MulticlassRequirementResourceTest extends TestCase
         $this->assertFalse($array['is_alternative']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_excludes_ability_when_relationship_not_loaded(): void
     {
         $class = CharacterClass::factory()->create();
@@ -67,7 +69,7 @@ class MulticlassRequirementResourceTest extends TestCase
         $this->assertFalse($array['is_alternative']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_marks_is_alternative_true_when_subcategory_is_or(): void
     {
         $class = CharacterClass::factory()->create();
@@ -88,7 +90,7 @@ class MulticlassRequirementResourceTest extends TestCase
         $this->assertTrue($array['is_alternative']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_none_type_for_empty_collection(): void
     {
         $requirements = collect([]);
@@ -99,7 +101,7 @@ class MulticlassRequirementResourceTest extends TestCase
         $this->assertEmpty($result['requirements']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_single_type_for_one_requirement(): void
     {
         $class = CharacterClass::factory()->create();
@@ -122,7 +124,7 @@ class MulticlassRequirementResourceTest extends TestCase
         $this->assertCount(1, $result['requirements']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_and_type_for_multiple_requirements_all_required(): void
     {
         $class = CharacterClass::factory()->create();
@@ -155,7 +157,7 @@ class MulticlassRequirementResourceTest extends TestCase
         $this->assertCount(2, $result['requirements']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_or_type_when_any_requirement_has_or_subcategory(): void
     {
         $class = CharacterClass::factory()->create();
@@ -188,7 +190,7 @@ class MulticlassRequirementResourceTest extends TestCase
         $this->assertCount(2, $result['requirements']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_requirements_in_collection(): void
     {
         $class = CharacterClass::factory()->create();

--- a/tests/Unit/Resources/ProficiencyResourceTest.php
+++ b/tests/Unit/Resources/ProficiencyResourceTest.php
@@ -10,14 +10,16 @@ use App\Models\ProficiencyType;
 use App\Models\Race;
 use App\Models\Skill;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ProficiencyResourceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_basic_proficiency_fields(): void
     {
         $race = Race::factory()->create();
@@ -41,7 +43,7 @@ class ProficiencyResourceTest extends TestCase
         $this->assertNull($array['level']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_proficiency_type_detail_when_loaded(): void
     {
         $race = Race::factory()->create();
@@ -65,7 +67,7 @@ class ProficiencyResourceTest extends TestCase
         $this->assertNotNull($array['proficiency_type_detail']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_skill_when_loaded(): void
     {
         $race = Race::factory()->create();
@@ -89,7 +91,7 @@ class ProficiencyResourceTest extends TestCase
         $this->assertNotNull($array['skill']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_item_when_present(): void
     {
         $race = Race::factory()->create();
@@ -115,7 +117,7 @@ class ProficiencyResourceTest extends TestCase
         $this->assertEquals('Longsword', $array['item']['name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_ability_score_when_loaded(): void
     {
         $race = Race::factory()->create();
@@ -142,7 +144,7 @@ class ProficiencyResourceTest extends TestCase
     // Note: Choice proficiencies are now stored in entity_choices table
     // and tested via EntityChoiceResourceTest
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_proficiency_subcategory_when_present(): void
     {
         $race = Race::factory()->create();
@@ -162,7 +164,7 @@ class ProficiencyResourceTest extends TestCase
         $this->assertEquals('artisan', $array['proficiency_subcategory']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_level_when_granted_at_specific_level(): void
     {
         $race = Race::factory()->create();

--- a/tests/Unit/Resources/RaceResourceTest.php
+++ b/tests/Unit/Resources/RaceResourceTest.php
@@ -8,14 +8,16 @@ use App\Models\Modifier;
 use App\Models\Proficiency;
 use App\Models\Race;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class RaceResourceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_basic_race_fields(): void
     {
         $race = Race::factory()->create([
@@ -45,7 +47,7 @@ class RaceResourceTest extends TestCase
         $this->assertNotNull($array['size']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_parent_race_when_is_subrace(): void
     {
         $parentRace = Race::factory()->create([
@@ -70,7 +72,7 @@ class RaceResourceTest extends TestCase
         $this->assertEquals('Elf', $array['parent_race']['name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_traits_when_loaded(): void
     {
         $race = Race::factory()->create();
@@ -92,7 +94,7 @@ class RaceResourceTest extends TestCase
         $this->assertEquals('Darkvision', $array['traits'][0]['name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_modifiers_when_loaded(): void
     {
         $race = Race::factory()->create();
@@ -114,7 +116,7 @@ class RaceResourceTest extends TestCase
         $this->assertCount(1, $array['modifiers']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_proficiencies_when_loaded(): void
     {
         $race = Race::factory()->create();
@@ -137,7 +139,7 @@ class RaceResourceTest extends TestCase
         $this->assertCount(1, $array['proficiencies']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_subraces_when_loaded(): void
     {
         $parentRace = Race::factory()->create([
@@ -166,7 +168,7 @@ class RaceResourceTest extends TestCase
         $this->assertCount(2, $array['subraces']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_inherited_data_for_subraces_with_loaded_parent(): void
     {
         $parentRace = Race::factory()->create([
@@ -212,7 +214,7 @@ class RaceResourceTest extends TestCase
         $this->assertEquals('Darkvision', $array['inherited_data']['traits'][0]['name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_null_values_for_unloaded_parent_relationships_in_inherited_data(): void
     {
         $parentRace = Race::factory()->create([
@@ -242,7 +244,7 @@ class RaceResourceTest extends TestCase
         $this->assertNull($array['inherited_data']['senses']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_all_inherited_relationship_types(): void
     {
         $parentRace = Race::factory()->create([
@@ -295,7 +297,7 @@ class RaceResourceTest extends TestCase
         $this->assertNotNull($array['inherited_data']['senses']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_includes_tags_when_loaded(): void
     {
         $race = Race::factory()->create();

--- a/tests/Unit/Resources/SpellSlotsResourceTest.php
+++ b/tests/Unit/Resources/SpellSlotsResourceTest.php
@@ -4,14 +4,16 @@ namespace Tests\Unit\Resources;
 
 use App\Http\Resources\SpellSlotsResource;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SpellSlotsResourceTest extends TestCase
 {
     use RefreshDatabase;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_old_structure_with_standard_slots(): void
     {
         $data = [
@@ -35,7 +37,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertArrayHasKey('3', $standardArray);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_old_structure_with_pact_magic(): void
     {
         $data = [
@@ -56,7 +58,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertArrayHasKey('2', $pactArray);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_old_structure_with_both_standard_and_pact_magic(): void
     {
         $data = [
@@ -78,7 +80,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertIsObject($array['pact_magic']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_transforms_new_consolidated_structure(): void
     {
         $data = [
@@ -102,7 +104,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertEquals(8, $array['preparation_limit']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_preserves_spell_level_keys_as_strings_in_json(): void
     {
         $data = [
@@ -125,7 +127,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertArrayHasKey('9', $slotsArray);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_empty_slots_array(): void
     {
         $data = [
@@ -143,7 +145,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertEquals(5, $array['preparation_limit']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_null_preparation_limit(): void
     {
         $data = [
@@ -161,7 +163,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertNull($array['preparation_limit']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_modify_structure_without_slots_key(): void
     {
         $data = [
@@ -178,7 +180,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertEquals(123, $array['another_field']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_only_converts_to_object_when_prepared_count_exists(): void
     {
         // Test that old structure with 'slots' key but no prepared_count doesn't get converted
@@ -193,7 +195,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertArrayHasKey('slots', $array);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_standard_slots_without_pact_magic(): void
     {
         $data = [
@@ -210,7 +212,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertArrayNotHasKey('pact_magic', $array);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_pact_magic_without_standard_slots(): void
     {
         $data = [
@@ -226,7 +228,7 @@ class SpellSlotsResourceTest extends TestCase
         $this->assertArrayNotHasKey('standard', $array);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_preserves_nested_slot_data_structure(): void
     {
         $data = [

--- a/tests/Unit/Resources/TagResourceTest.php
+++ b/tests/Unit/Resources/TagResourceTest.php
@@ -3,14 +3,16 @@
 namespace Tests\Unit\Resources;
 
 use App\Http\Resources\TagResource;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Tags\Tag;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class TagResourceTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_serializes_tag_with_basic_attributes()
     {
         $tag = new Tag([
@@ -30,7 +32,7 @@ class TagResourceTest extends TestCase
         $this->assertEquals('touch-spells', $array['slug']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_serializes_tag_with_type()
     {
         $tag = new Tag([
@@ -51,7 +53,7 @@ class TagResourceTest extends TestCase
         $this->assertEquals('spell_list', $array['type']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_tag_with_no_type()
     {
         $tag = new Tag([

--- a/tests/Unit/Seeders/BackgroundFixtureSeederTest.php
+++ b/tests/Unit/Seeders/BackgroundFixtureSeederTest.php
@@ -6,6 +6,7 @@ use App\Models\Background;
 use Database\Seeders\Testing\BackgroundFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class BackgroundFixtureSeederTest extends TestCase
@@ -121,7 +122,7 @@ class BackgroundFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_backgrounds_from_fixture(): void
     {
         $this->assertDatabaseMissing('backgrounds', ['slug' => 'test-acolyte']);
@@ -140,7 +141,7 @@ class BackgroundFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_skill_proficiencies(): void
     {
         $seeder = new BackgroundFixtureSeeder;
@@ -168,7 +169,7 @@ class BackgroundFixtureSeederTest extends TestCase
         $this->assertFalse($religionProf->is_choice);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_tool_proficiencies(): void
     {
         $seeder = new BackgroundFixtureSeeder;
@@ -199,7 +200,7 @@ class BackgroundFixtureSeederTest extends TestCase
         $this->assertEquals(1, $gamingSet->quantity);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_language_proficiencies(): void
     {
         $seeder = new BackgroundFixtureSeeder;
@@ -220,7 +221,7 @@ class BackgroundFixtureSeederTest extends TestCase
         $this->assertEquals(2, $langProf->quantity);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_background_features(): void
     {
         $seeder = new BackgroundFixtureSeeder;
@@ -237,7 +238,7 @@ class BackgroundFixtureSeederTest extends TestCase
         $this->assertStringContainsString('respect of those who share your faith', $trait->description);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         $seeder = new BackgroundFixtureSeeder;
@@ -252,7 +253,7 @@ class BackgroundFixtureSeederTest extends TestCase
         $this->assertEquals('127', $background->sources->first()->pages);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_backgrounds_without_tool_proficiencies(): void
     {
         $seeder = new BackgroundFixtureSeeder;
@@ -268,7 +269,7 @@ class BackgroundFixtureSeederTest extends TestCase
         $this->assertCount(0, $toolProfs);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_backgrounds_without_language_proficiencies(): void
     {
         $seeder = new BackgroundFixtureSeeder;

--- a/tests/Unit/Seeders/ClassFixtureSeederTest.php
+++ b/tests/Unit/Seeders/ClassFixtureSeederTest.php
@@ -6,6 +6,7 @@ use App\Models\CharacterClass;
 use Database\Seeders\Testing\ClassFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class ClassFixtureSeederTest extends TestCase
@@ -89,7 +90,7 @@ class ClassFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_classes_from_fixture(): void
     {
         $this->assertDatabaseMissing('classes', ['slug' => 'test-wizard']);
@@ -104,7 +105,7 @@ class ClassFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_spellcasting_ability_by_code(): void
     {
         $seeder = new ClassFixtureSeeder;
@@ -116,7 +117,7 @@ class ClassFixtureSeederTest extends TestCase
         $this->assertEquals('INT', $class->spellcastingAbility->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_parent_class_by_slug(): void
     {
         $seeder = new ClassFixtureSeeder;
@@ -130,7 +131,7 @@ class ClassFixtureSeederTest extends TestCase
         $this->assertEquals($parentClass->id, $subclass->parent_class_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_proficiencies(): void
     {
         $seeder = new ClassFixtureSeeder;
@@ -157,7 +158,7 @@ class ClassFixtureSeederTest extends TestCase
         $this->assertEquals('WIS', $wisProf->abilityScore->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         $seeder = new ClassFixtureSeeder;

--- a/tests/Unit/Seeders/FeatFixtureSeederTest.php
+++ b/tests/Unit/Seeders/FeatFixtureSeederTest.php
@@ -3,9 +3,12 @@
 namespace Tests\Unit\Seeders;
 
 use App\Models\Feat;
+use App\Models\Race;
+use App\Models\Size;
 use Database\Seeders\Testing\FeatFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class FeatFixtureSeederTest extends TestCase
@@ -118,7 +121,7 @@ class FeatFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_feats_from_fixture(): void
     {
         $this->assertDatabaseMissing('feats', ['slug' => 'test-feat-no-prerequisites']);
@@ -134,7 +137,7 @@ class FeatFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_ability_score_improvements(): void
     {
         $seeder = new FeatFixtureSeeder;
@@ -153,14 +156,14 @@ class FeatFixtureSeederTest extends TestCase
         $this->assertFalse($modifier->is_choice);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_race_prerequisites(): void
     {
         // Create the race that will be referenced as a prerequisite
-        $elf = \App\Models\Race::create([
+        $elf = Race::create([
             'name' => 'Elf',
             'slug' => 'elf',
-            'size_id' => \App\Models\Size::first()->id,
+            'size_id' => Size::first()->id,
             'speed' => 30,
         ]);
 
@@ -179,7 +182,7 @@ class FeatFixtureSeederTest extends TestCase
         $this->assertEquals('elf', $prereq->prerequisite->slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_ability_score_prerequisites(): void
     {
         $seeder = new FeatFixtureSeeder;
@@ -198,7 +201,7 @@ class FeatFixtureSeederTest extends TestCase
         $this->assertEquals(13, $prereq->minimum_value);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_ability_score_choice_modifiers(): void
     {
         $seeder = new FeatFixtureSeeder;
@@ -218,7 +221,7 @@ class FeatFixtureSeederTest extends TestCase
         $this->assertEquals(1, $modifier->choice_count);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         $seeder = new FeatFixtureSeeder;
@@ -233,7 +236,7 @@ class FeatFixtureSeederTest extends TestCase
         $this->assertEquals('165', $feat->sources->first()->pages);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_feats_without_source(): void
     {
         // Add a feat without source to fixture

--- a/tests/Unit/Seeders/ItemFixtureSeederTest.php
+++ b/tests/Unit/Seeders/ItemFixtureSeederTest.php
@@ -6,6 +6,7 @@ use App\Models\Item;
 use Database\Seeders\Testing\ItemFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class ItemFixtureSeederTest extends TestCase
@@ -88,7 +89,7 @@ class ItemFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_items_from_fixture(): void
     {
         $this->assertDatabaseMissing('items', ['slug' => 'test-longsword']);
@@ -110,7 +111,7 @@ class ItemFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_item_type_by_code(): void
     {
         $seeder = new ItemFixtureSeeder;
@@ -125,7 +126,7 @@ class ItemFixtureSeederTest extends TestCase
         $this->assertEquals('HA', $plateArmor->itemType->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_damage_type_by_code_for_weapons(): void
     {
         $seeder = new ItemFixtureSeeder;
@@ -136,7 +137,7 @@ class ItemFixtureSeederTest extends TestCase
         $this->assertEquals('S', $longsword->damageType->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_attaches_item_properties(): void
     {
         $seeder = new ItemFixtureSeeder;
@@ -150,7 +151,7 @@ class ItemFixtureSeederTest extends TestCase
         $this->assertEquals('V', $longsword->properties->first()->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         $seeder = new ItemFixtureSeeder;

--- a/tests/Unit/Seeders/MonsterFixtureSeederTest.php
+++ b/tests/Unit/Seeders/MonsterFixtureSeederTest.php
@@ -6,6 +6,7 @@ use App\Models\Monster;
 use Database\Seeders\Testing\MonsterFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class MonsterFixtureSeederTest extends TestCase
@@ -70,7 +71,7 @@ class MonsterFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_monsters_from_fixture(): void
     {
         $this->assertDatabaseMissing('monsters', ['slug' => 'test-dragon']);
@@ -88,7 +89,7 @@ class MonsterFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_size_by_code(): void
     {
         $seeder = new MonsterFixtureSeeder;
@@ -99,7 +100,7 @@ class MonsterFixtureSeederTest extends TestCase
         $this->assertEquals('L', $monster->size->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_damage_immunities(): void
     {
         $seeder = new MonsterFixtureSeeder;
@@ -116,7 +117,7 @@ class MonsterFixtureSeederTest extends TestCase
         $this->assertEquals('F', $damageImmunities->first()->damageType->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_condition_immunities(): void
     {
         $seeder = new MonsterFixtureSeeder;
@@ -133,7 +134,7 @@ class MonsterFixtureSeederTest extends TestCase
         $this->assertEquals('frightened', $conditionImmunities->first()->value);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_damage_resistances(): void
     {
         // Add a fixture with damage resistance
@@ -189,7 +190,7 @@ class MonsterFixtureSeederTest extends TestCase
         $this->assertEquals(['P', 'S'], $resistanceCodes->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_damage_vulnerabilities(): void
     {
         // Add a fixture with damage vulnerability
@@ -244,7 +245,7 @@ class MonsterFixtureSeederTest extends TestCase
         $this->assertEquals('F', $damageVulnerabilities->first()->damageType->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         $seeder = new MonsterFixtureSeeder;

--- a/tests/Unit/Seeders/OptionalFeatureFixtureSeederTest.php
+++ b/tests/Unit/Seeders/OptionalFeatureFixtureSeederTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Unit\Seeders;
 
+use App\Models\CharacterClass;
 use App\Models\OptionalFeature;
 use Database\Seeders\Testing\OptionalFeatureFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class OptionalFeatureFixtureSeederTest extends TestCase
@@ -118,7 +120,7 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_optional_features_from_fixture(): void
     {
         $this->assertDatabaseMissing('optional_features', ['slug' => 'test-invocation-no-prerequisites']);
@@ -135,11 +137,11 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_class_associations(): void
     {
         // Create classes that will be referenced
-        $warlock = \App\Models\CharacterClass::create([
+        $warlock = CharacterClass::create([
             'name' => 'Warlock',
             'slug' => 'warlock',
             'hit_die' => 8,
@@ -157,11 +159,11 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         $this->assertEquals('warlock', $feature->classes->first()->slug);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_class_associations_with_subclass_name(): void
     {
         // Create classes
-        $monk = \App\Models\CharacterClass::create([
+        $monk = CharacterClass::create([
             'name' => 'Monk',
             'slug' => 'monk',
             'hit_die' => 8,
@@ -184,25 +186,25 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         $this->assertEquals('Way of the Four Elements', $pivot->subclass_name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_multiple_class_associations(): void
     {
         // Create classes
-        $fighter = \App\Models\CharacterClass::create([
+        $fighter = CharacterClass::create([
             'name' => 'Fighter',
             'slug' => 'fighter',
             'hit_die' => 10,
             'description' => 'Test fighter class',
         ]);
 
-        $paladin = \App\Models\CharacterClass::create([
+        $paladin = CharacterClass::create([
             'name' => 'Paladin',
             'slug' => 'paladin',
             'hit_die' => 10,
             'description' => 'Test paladin class',
         ]);
 
-        $ranger = \App\Models\CharacterClass::create([
+        $ranger = CharacterClass::create([
             'name' => 'Ranger',
             'slug' => 'ranger',
             'hit_die' => 10,
@@ -221,11 +223,11 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         $this->assertEquals(['fighter', 'paladin', 'ranger'], $classSlugs->toArray());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_prerequisites(): void
     {
         // Create the class that will be referenced as a prerequisite
-        $monk = \App\Models\CharacterClass::create([
+        $monk = CharacterClass::create([
             'name' => 'Monk',
             'slug' => 'monk',
             'hit_die' => 8,
@@ -248,11 +250,11 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         $this->assertEquals(11, $prereq->minimum_value);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_spell_school_association(): void
     {
         // Create monk class
-        $monk = \App\Models\CharacterClass::create([
+        $monk = CharacterClass::create([
             'name' => 'Monk',
             'slug' => 'monk',
             'hit_die' => 8,
@@ -270,11 +272,11 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         $this->assertEquals('EV', $feature->spellSchool->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         // Create warlock class
-        $warlock = \App\Models\CharacterClass::create([
+        $warlock = CharacterClass::create([
             'name' => 'Warlock',
             'slug' => 'warlock',
             'hit_die' => 8,
@@ -293,7 +295,7 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         $this->assertEquals('110', $feature->sources->first()->pages);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_features_without_source(): void
     {
         // Add a feature without source to fixture
@@ -328,11 +330,11 @@ class OptionalFeatureFixtureSeederTest extends TestCase
         $this->assertCount(0, $feature->sources);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_features_without_spell_school(): void
     {
         // Create warlock class
-        $warlock = \App\Models\CharacterClass::create([
+        $warlock = CharacterClass::create([
             'name' => 'Warlock',
             'slug' => 'warlock',
             'hit_die' => 8,

--- a/tests/Unit/Seeders/RaceFixtureSeederTest.php
+++ b/tests/Unit/Seeders/RaceFixtureSeederTest.php
@@ -6,6 +6,7 @@ use App\Models\Race;
 use Database\Seeders\Testing\RaceFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class RaceFixtureSeederTest extends TestCase
@@ -82,7 +83,7 @@ class RaceFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_races_from_fixture(): void
     {
         $this->assertDatabaseMissing('races', ['slug' => 'test-elf']);
@@ -97,7 +98,7 @@ class RaceFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_size_by_code(): void
     {
         $seeder = new RaceFixtureSeeder;
@@ -108,7 +109,7 @@ class RaceFixtureSeederTest extends TestCase
         $this->assertEquals('M', $race->size->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_parent_race_by_slug(): void
     {
         $seeder = new RaceFixtureSeeder;
@@ -125,7 +126,7 @@ class RaceFixtureSeederTest extends TestCase
         $this->assertEquals($parentRace->id, $subrace->parent_race_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_ability_bonuses(): void
     {
         $seeder = new RaceFixtureSeeder;
@@ -145,7 +146,7 @@ class RaceFixtureSeederTest extends TestCase
         $this->assertFalse($modifier->is_choice);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_traits(): void
     {
         $seeder = new RaceFixtureSeeder;
@@ -162,7 +163,7 @@ class RaceFixtureSeederTest extends TestCase
         $this->assertStringContainsString('60 feet', $trait->description);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         $seeder = new RaceFixtureSeeder;
@@ -177,7 +178,7 @@ class RaceFixtureSeederTest extends TestCase
         $this->assertEquals('21-23', $race->sources->first()->pages);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_races_with_choice_abilities(): void
     {
         // Add a fixture with ability choice

--- a/tests/Unit/Seeders/SpellFixtureSeederTest.php
+++ b/tests/Unit/Seeders/SpellFixtureSeederTest.php
@@ -6,6 +6,7 @@ use App\Models\Spell;
 use Database\Seeders\Testing\SpellFixtureSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class SpellFixtureSeederTest extends TestCase
@@ -59,7 +60,7 @@ class SpellFixtureSeederTest extends TestCase
         parent::tearDown();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_spells_from_fixture(): void
     {
         $this->assertDatabaseMissing('spells', ['slug' => 'test-fireball']);
@@ -74,7 +75,7 @@ class SpellFixtureSeederTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resolves_school_by_code(): void
     {
         $seeder = new SpellFixtureSeeder;
@@ -85,7 +86,7 @@ class SpellFixtureSeederTest extends TestCase
         $this->assertEquals('EV', $spell->spellSchool->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_spell_effects_for_damage_types(): void
     {
         $seeder = new SpellFixtureSeeder;
@@ -99,7 +100,7 @@ class SpellFixtureSeederTest extends TestCase
         $this->assertEquals('F', $spell->effects->first()->damageType->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_entity_sources(): void
     {
         $seeder = new SpellFixtureSeeder;

--- a/tests/Unit/Seeders/TestDatabaseSeederTest.php
+++ b/tests/Unit/Seeders/TestDatabaseSeederTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Seeders;
 
 use Database\Seeders\TestDatabaseSeeder;
+use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class TestDatabaseSeederTest extends TestCase
@@ -12,15 +14,15 @@ class TestDatabaseSeederTest extends TestCase
 
     protected $seed = false; // Don't auto-seed, we're testing the seeder
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exists_and_is_runnable(): void
     {
         $seeder = new TestDatabaseSeeder;
 
-        $this->assertInstanceOf(\Illuminate\Database\Seeder::class, $seeder);
+        $this->assertInstanceOf(Seeder::class, $seeder);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_seeds_lookup_tables(): void
     {
         $this->seed(TestDatabaseSeeder::class);
@@ -31,7 +33,7 @@ class TestDatabaseSeederTest extends TestCase
         $this->assertDatabaseHas('sizes', ['name' => 'Medium']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_calls_all_fixture_seeders(): void
     {
         $this->seed(TestDatabaseSeeder::class);

--- a/tests/Unit/Services/AbilityBonusServiceTest.php
+++ b/tests/Unit/Services/AbilityBonusServiceTest.php
@@ -13,6 +13,7 @@ use App\Models\Feat;
 use App\Models\Modifier;
 use App\Models\Race;
 use App\Services\AbilityBonusService;
+use App\Services\FeatChoiceService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -410,7 +411,7 @@ class AbilityBonusServiceTest extends TestCase
         $character = Character::factory()->create(['race_slug' => $race->slug]);
 
         // Select the feat via the FeatChoiceService (simulates the real workflow)
-        $featChoiceService = app(\App\Services\FeatChoiceService::class);
+        $featChoiceService = app(FeatChoiceService::class);
         $featChoiceService->makeChoice($character, 'race', $feat->slug);
 
         // Verify the feat bonus appears

--- a/tests/Unit/Services/AddClassServiceTest.php
+++ b/tests/Unit/Services/AddClassServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\AbilityScore;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
+use App\Models\ClassFeature;
 use App\Models\Modifier;
 use App\Models\Proficiency;
 use App\Models\Race;
@@ -182,18 +183,18 @@ class AddClassServiceTest extends TestCase
         $fighter = CharacterClass::factory()->create(['name' => 'Fighter', 'parent_class_id' => null]);
 
         // Create mandatory features at level 1 for the class
-        $secondWind = \App\Models\ClassFeature::factory()
+        $secondWind = ClassFeature::factory()
             ->forClass($fighter)
             ->atLevel(1)
             ->create(['feature_name' => 'Second Wind', 'is_optional' => false]);
 
-        $fightingStyle = \App\Models\ClassFeature::factory()
+        $fightingStyle = ClassFeature::factory()
             ->forClass($fighter)
             ->atLevel(1)
             ->optional()
             ->create(['feature_name' => 'Fighting Style']);
 
-        $actionSurge = \App\Models\ClassFeature::factory()
+        $actionSurge = ClassFeature::factory()
             ->forClass($fighter)
             ->atLevel(2)
             ->create(['feature_name' => 'Action Surge', 'is_optional' => false]);

--- a/tests/Unit/Services/Cache/EntityCacheServiceTest.php
+++ b/tests/Unit/Services/Cache/EntityCacheServiceTest.php
@@ -8,9 +8,11 @@ use App\Models\Spell;
 use App\Services\Cache\EntityCacheService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class EntityCacheServiceTest extends TestCase
 {
     use RefreshDatabase;
@@ -24,7 +26,7 @@ class EntityCacheServiceTest extends TestCase
         Cache::flush();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function cache_miss_loads_spell_from_database(): void
     {
         $spell = Spell::factory()->create(['name' => 'Fireball']);
@@ -40,7 +42,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertEquals($spell->id, $result->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function cache_hit_returns_cached_spell(): void
     {
         $spell = Spell::factory()->create(['name' => 'Magic Missile']);
@@ -59,7 +61,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertTrue(Cache::has($cacheKey));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_spell_by_slug_resolves_to_id(): void
     {
         $spell = Spell::factory()->create([
@@ -75,7 +77,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertEquals('Fireball', $result->name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function cache_key_format_is_consistent(): void
     {
         $spell = Spell::factory()->create(['name' => 'Shield']);
@@ -87,7 +89,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertTrue(Cache::has($expectedKey));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function invalidate_spell_clears_cache(): void
     {
         $spell = Spell::factory()->create(['name' => 'Cure Wounds']);
@@ -105,7 +107,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertFalse(Cache::has($cacheKey));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function invalidate_all_clears_entity_type_cache(): void
     {
         $spell1 = Spell::factory()->create(['name' => 'Fireball']);
@@ -128,7 +130,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertTrue(Cache::has("entity:item:{$item->id}"));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function clear_all_clears_all_entity_caches(): void
     {
         $spell = Spell::factory()->create(['name' => 'Fireball']);
@@ -146,7 +148,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertFalse(Cache::has("entity:item:{$item->id}"));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function cache_miss_loads_item_from_database(): void
     {
         $item = Item::factory()->create(['name' => 'Longsword']);
@@ -161,7 +163,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertEquals($item->id, $result->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_monster_with_relationships_eager_loaded(): void
     {
         $monster = Monster::factory()->create(['name' => 'Dragon']);
@@ -177,7 +179,7 @@ class EntityCacheServiceTest extends TestCase
         $this->assertTrue($result->relationLoaded('sources'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function ttl_is_fifteen_minutes(): void
     {
         // This test verifies the TTL constant

--- a/tests/Unit/Services/Cache/LookupCacheServiceTest.php
+++ b/tests/Unit/Services/Cache/LookupCacheServiceTest.php
@@ -7,9 +7,11 @@ use App\Services\Cache\LookupCacheService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class LookupCacheServiceTest extends TestCase
 {
     use RefreshDatabase;
@@ -24,7 +26,7 @@ class LookupCacheServiceTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_caches_spell_schools_on_first_request(): void
     {
         Cache::flush();
@@ -36,7 +38,7 @@ class LookupCacheServiceTest extends TestCase
         $this->assertTrue(Cache::has('lookups:spell-schools:all'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_cached_spell_schools_on_subsequent_requests(): void
     {
         Cache::flush();
@@ -56,7 +58,7 @@ class LookupCacheServiceTest extends TestCase
         $this->assertEquals(0, $secondQueryCount); // No DB queries
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_caches_all_lookup_types(): void
     {
         Cache::flush();
@@ -79,7 +81,7 @@ class LookupCacheServiceTest extends TestCase
         $this->assertTrue(Cache::has('lookups:proficiency-types:all'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uses_one_hour_ttl_for_lookups(): void
     {
         // Skip if not using Redis
@@ -98,7 +100,7 @@ class LookupCacheServiceTest extends TestCase
         $this->assertLessThan(3610, $ttl);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_clears_all_lookup_caches(): void
     {
         $service = new LookupCacheService;

--- a/tests/Unit/Services/CharacterChoiceServiceTest.php
+++ b/tests/Unit/Services/CharacterChoiceServiceTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 use App\DTOs\PendingChoice;
 use App\Exceptions\ChoiceNotFoundException;
+use App\Exceptions\ChoiceNotUndoableException;
 use App\Models\Character;
 use App\Services\CharacterChoiceService;
 use App\Services\ChoiceHandlers\ChoiceTypeHandler;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 describe('CharacterChoiceService', function () {
     beforeEach(function () {
@@ -494,7 +496,7 @@ describe('CharacterChoiceService', function () {
 
     it('resolves a choice using the correct handler', function () {
         // Mock DB::transaction to simply execute the callback
-        Illuminate\Support\Facades\DB::shouldReceive('transaction')
+        DB::shouldReceive('transaction')
             ->once()
             ->andReturnUsing(fn ($callback) => $callback());
 
@@ -692,7 +694,7 @@ describe('CharacterChoiceService', function () {
         $this->service->registerHandler($handler);
 
         expect(fn () => $this->service->undoChoice($this->character, 'proficiency|class|rogue|1|skills'))
-            ->toThrow(\App\Exceptions\ChoiceNotUndoableException::class);
+            ->toThrow(ChoiceNotUndoableException::class);
     });
 
     it('parses choice ID with slug format containing colons', function () {

--- a/tests/Unit/Services/CharacterFeatureServiceTest.php
+++ b/tests/Unit/Services/CharacterFeatureServiceTest.php
@@ -6,9 +6,11 @@ use App\Models\Background;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterFeature;
+use App\Models\CharacterSpell;
 use App\Models\CharacterTrait;
 use App\Models\ClassFeature;
 use App\Models\Race;
+use App\Models\Spell;
 use App\Services\CharacterFeatureService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
@@ -469,7 +471,7 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Create the Light spell
-        $lightSpell = \App\Models\Spell::factory()->create([
+        $lightSpell = Spell::factory()->create([
             'name' => 'Light',
             'slug' => 'light',
             'level' => 0,
@@ -528,19 +530,19 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Create spells at various level requirements
-        $burningHands = \App\Models\Spell::factory()->create([
+        $burningHands = Spell::factory()->create([
             'name' => 'Burning Hands',
             'slug' => 'burning-hands',
             'level' => 1,
         ]);
 
-        $scorchingRay = \App\Models\Spell::factory()->create([
+        $scorchingRay = Spell::factory()->create([
             'name' => 'Scorching Ray',
             'slug' => 'scorching-ray',
             'level' => 2,
         ]);
 
-        $fireball = \App\Models\Spell::factory()->create([
+        $fireball = Spell::factory()->create([
             'name' => 'Fireball',
             'slug' => 'fireball',
             'level' => 3,
@@ -606,7 +608,7 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Create the Heroism spell
-        $heroism = \App\Models\Spell::factory()->create([
+        $heroism = Spell::factory()->create([
             'name' => 'Heroism',
             'slug' => 'test-heroism-'.uniqid(),
             'level' => 1,
@@ -626,7 +628,7 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Pre-existing heroism spell from another source (Divine Soul origin grants this)
-        \App\Models\CharacterSpell::create([
+        CharacterSpell::create([
             'character_id' => $character->id,
             'spell_slug' => $heroism->slug,
             'source' => 'class', // From Divine Soul Sorcerer origin
@@ -684,7 +686,7 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Create a domain spell
-        $bane = \App\Models\Spell::factory()->create([
+        $bane = Spell::factory()->create([
             'name' => 'Bane',
             'slug' => 'test-bane-'.uniqid(),
             'level' => 1,
@@ -771,8 +773,8 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Create spells for each terrain
-        $holdPerson = \App\Models\Spell::factory()->create(['name' => 'Hold Person', 'slug' => 'test-hold-person-'.uniqid()]);
-        $mirrorImage = \App\Models\Spell::factory()->create(['name' => 'Mirror Image', 'slug' => 'test-mirror-image-'.uniqid()]);
+        $holdPerson = Spell::factory()->create(['name' => 'Hold Person', 'slug' => 'test-hold-person-'.uniqid()]);
+        $mirrorImage = Spell::factory()->create(['name' => 'Mirror Image', 'slug' => 'test-mirror-image-'.uniqid()]);
 
         $arcticFeature->spells()->attach($holdPerson->id, ['level_requirement' => 3, 'is_cantrip' => false]);
         $coastFeature->spells()->attach($mirrorImage->id, ['level_requirement' => 3, 'is_cantrip' => false]);
@@ -850,10 +852,10 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Create spells for each terrain
-        $holdPerson = \App\Models\Spell::factory()->create(['name' => 'Hold Person', 'slug' => 'test-hold-person-'.uniqid(), 'level' => 2]);
-        $spikeGrowth = \App\Models\Spell::factory()->create(['name' => 'Spike Growth', 'slug' => 'test-spike-growth-'.uniqid(), 'level' => 2]);
-        $mirrorImage = \App\Models\Spell::factory()->create(['name' => 'Mirror Image', 'slug' => 'test-mirror-image-'.uniqid(), 'level' => 2]);
-        $mistyStep = \App\Models\Spell::factory()->create(['name' => 'Misty Step', 'slug' => 'test-misty-step-'.uniqid(), 'level' => 2]);
+        $holdPerson = Spell::factory()->create(['name' => 'Hold Person', 'slug' => 'test-hold-person-'.uniqid(), 'level' => 2]);
+        $spikeGrowth = Spell::factory()->create(['name' => 'Spike Growth', 'slug' => 'test-spike-growth-'.uniqid(), 'level' => 2]);
+        $mirrorImage = Spell::factory()->create(['name' => 'Mirror Image', 'slug' => 'test-mirror-image-'.uniqid(), 'level' => 2]);
+        $mistyStep = Spell::factory()->create(['name' => 'Misty Step', 'slug' => 'test-misty-step-'.uniqid(), 'level' => 2]);
 
         // Arctic gets Hold Person + Spike Growth
         $arcticFeature->spells()->attach($holdPerson->id, ['level_requirement' => 3, 'is_cantrip' => false]);
@@ -929,9 +931,9 @@ class CharacterFeatureServiceTest extends TestCase
         ]);
 
         // Create spells at various level requirements
-        $holdPerson = \App\Models\Spell::factory()->create(['name' => 'Hold Person', 'slug' => 'test-hold-person-'.uniqid(), 'level' => 2]);
-        $sleetStorm = \App\Models\Spell::factory()->create(['name' => 'Sleet Storm', 'slug' => 'test-sleet-storm-'.uniqid(), 'level' => 3]);
-        $iceStorm = \App\Models\Spell::factory()->create(['name' => 'Ice Storm', 'slug' => 'test-ice-storm-'.uniqid(), 'level' => 4]);
+        $holdPerson = Spell::factory()->create(['name' => 'Hold Person', 'slug' => 'test-hold-person-'.uniqid(), 'level' => 2]);
+        $sleetStorm = Spell::factory()->create(['name' => 'Sleet Storm', 'slug' => 'test-sleet-storm-'.uniqid(), 'level' => 3]);
+        $iceStorm = Spell::factory()->create(['name' => 'Ice Storm', 'slug' => 'test-ice-storm-'.uniqid(), 'level' => 4]);
 
         // Attach spells with different level requirements
         $arcticFeature->spells()->attach($holdPerson->id, ['level_requirement' => 3, 'is_cantrip' => false]);

--- a/tests/Unit/Services/CharacterProficiencyServiceTest.php
+++ b/tests/Unit/Services/CharacterProficiencyServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services;
 
 use App\Models\AbilityScore;
+use App\Models\Background;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterProficiency;
@@ -1179,12 +1180,12 @@ class CharacterProficiencyServiceTest extends TestCase
         ]);
 
         // Create background with gaming set choice (using 'gaming' subcategory)
-        $knightBackground = \App\Models\Background::factory()->create([
+        $knightBackground = Background::factory()->create([
             'name' => 'Knight of the Order',
             'slug' => 'test:knight-'.uniqid(),
         ]);
         EntityChoice::create([
-            'reference_type' => \App\Models\Background::class,
+            'reference_type' => Background::class,
             'reference_id' => $knightBackground->id,
             'choice_type' => 'proficiency',
             'proficiency_type' => 'tool',
@@ -1240,12 +1241,12 @@ class CharacterProficiencyServiceTest extends TestCase
         ]);
 
         // Create background with musical instrument choice (using 'musical' subcategory)
-        $entertainerBackground = \App\Models\Background::factory()->create([
+        $entertainerBackground = Background::factory()->create([
             'name' => 'Entertainer',
             'slug' => 'test:entertainer-'.uniqid(),
         ]);
         EntityChoice::create([
-            'reference_type' => \App\Models\Background::class,
+            'reference_type' => Background::class,
             'reference_id' => $entertainerBackground->id,
             'choice_type' => 'proficiency',
             'proficiency_type' => 'tool',

--- a/tests/Unit/Services/ChoiceHandlers/AbstractChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/AbstractChoiceHandlerTest.php
@@ -2,7 +2,11 @@
 
 namespace Tests\Unit\Services\ChoiceHandlers;
 
+use App\DTOs\PendingChoice;
+use App\Exceptions\InvalidChoiceException;
+use App\Models\Character;
 use App\Services\ChoiceHandlers\AbstractChoiceHandler;
+use Illuminate\Support\Collection;
 
 describe('AbstractChoiceHandler', function () {
     beforeEach(function () {
@@ -14,22 +18,22 @@ describe('AbstractChoiceHandler', function () {
                 return 'test';
             }
 
-            public function getChoices(\App\Models\Character $character): \Illuminate\Support\Collection
+            public function getChoices(Character $character): Collection
             {
                 return collect();
             }
 
-            public function resolve(\App\Models\Character $character, \App\DTOs\PendingChoice $choice, array $selection): void
+            public function resolve(Character $character, PendingChoice $choice, array $selection): void
             {
                 // No-op for testing
             }
 
-            public function canUndo(\App\Models\Character $character, \App\DTOs\PendingChoice $choice): bool
+            public function canUndo(Character $character, PendingChoice $choice): bool
             {
                 return false;
             }
 
-            public function undo(\App\Models\Character $character, \App\DTOs\PendingChoice $choice): void
+            public function undo(Character $character, PendingChoice $choice): void
             {
                 // No-op for testing
             }
@@ -138,22 +142,22 @@ describe('AbstractChoiceHandler', function () {
 
         it('throws exception for incomplete choice IDs', function () {
             expect(fn () => $this->handler->testParseChoiceId('proficiency|class'))
-                ->toThrow(\App\Exceptions\InvalidChoiceException::class);
+                ->toThrow(InvalidChoiceException::class);
         });
 
         it('throws exception for empty string', function () {
             expect(fn () => $this->handler->testParseChoiceId(''))
-                ->toThrow(\App\Exceptions\InvalidChoiceException::class);
+                ->toThrow(InvalidChoiceException::class);
         });
 
         it('throws exception for choice ID with wrong segment count', function () {
             // Too few segments
             expect(fn () => $this->handler->testParseChoiceId('a|b|c'))
-                ->toThrow(\App\Exceptions\InvalidChoiceException::class);
+                ->toThrow(InvalidChoiceException::class);
 
             // Too many segments
             expect(fn () => $this->handler->testParseChoiceId('a|b|c|d|e|f'))
-                ->toThrow(\App\Exceptions\InvalidChoiceException::class);
+                ->toThrow(InvalidChoiceException::class);
         });
     });
 

--- a/tests/Unit/Services/ChoiceHandlers/AsiChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/AsiChoiceHandlerTest.php
@@ -15,6 +15,7 @@ use App\Services\AsiChoiceService;
 use App\Services\AvailableFeatsService;
 use App\Services\ChoiceHandlers\AsiChoiceHandler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -75,7 +76,7 @@ class AsiChoiceHandlerTest extends TestCase
 
         $choices = $this->handler->getChoices($character);
 
-        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $choices);
+        $this->assertInstanceOf(Collection::class, $choices);
         $this->assertEmpty($choices);
     }
 

--- a/tests/Unit/Services/ChoiceHandlers/EquipmentChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/EquipmentChoiceHandlerTest.php
@@ -6,6 +6,7 @@ use App\Models\Character;
 use App\Services\ChoiceHandlers\EquipmentChoiceHandler;
 use App\Services\EquipmentManagerService;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 
 beforeEach(function () {
@@ -191,7 +192,7 @@ it('undoes choice by deleting CharacterEquipment records', function () {
     );
 
     // Mock equipment relationship - uses whereJsonContains for deletion
-    $equipmentQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $equipmentQuery = Mockery::mock(HasMany::class);
     $equipmentQuery->shouldReceive('whereJsonContains')
         ->with('custom_description->source', 'class')
         ->andReturnSelf();

--- a/tests/Unit/Services/ChoiceHandlers/ExpertiseChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/ExpertiseChoiceHandlerTest.php
@@ -5,6 +5,7 @@ use App\Exceptions\InvalidSelectionException;
 use App\Models\Character;
 use App\Models\CharacterProficiency;
 use App\Services\ChoiceHandlers\ExpertiseChoiceHandler;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 beforeEach(function () {
     $this->handler = new ExpertiseChoiceHandler;
@@ -57,7 +58,7 @@ it('returns expertise choices for Rogue level 1', function () {
     $proficiencies = collect([$proficiency1, $proficiency2, $proficiency3, $proficiency4]);
 
     // Mock existing expertise selections (source = class, choice_group = expertise_1)
-    $expertiseProficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $expertiseProficienciesQuery = Mockery::mock(HasMany::class);
     $expertiseProficienciesQuery->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();
@@ -68,7 +69,7 @@ it('returns expertise choices for Rogue level 1', function () {
         ->andReturn(collect()); // No selections yet
 
     // Mock proficiencies query for getting all proficiencies
-    $proficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $proficienciesQuery = Mockery::mock(HasMany::class);
     $proficienciesQuery->shouldReceive('get')
         ->andReturn($proficiencies);
 
@@ -114,7 +115,7 @@ it('returns expertise choices for Rogue level 6 (second set)', function () {
     $proficiencies = collect([$proficiency1, $proficiency2, $proficiency3, $proficiency4]);
 
     // Mock expertise_1 selections (level 1 choices)
-    $expertise1Query = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $expertise1Query = Mockery::mock(HasMany::class);
     $expertise1Query->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();
@@ -125,7 +126,7 @@ it('returns expertise choices for Rogue level 6 (second set)', function () {
         ->andReturn(collect([$proficiency1, $proficiency2])); // 2 selected at level 1
 
     // Mock expertise_6 selections (level 6 choices)
-    $expertise6Query = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $expertise6Query = Mockery::mock(HasMany::class);
     $expertise6Query->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();
@@ -136,7 +137,7 @@ it('returns expertise choices for Rogue level 6 (second set)', function () {
         ->andReturn(collect()); // No selections yet at level 6
 
     // Mock proficiencies query for getting all proficiencies
-    $proficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $proficienciesQuery = Mockery::mock(HasMany::class);
     $proficienciesQuery->shouldReceive('get')
         ->andReturn($proficiencies);
 
@@ -176,7 +177,7 @@ it('returns expertise choices for Bard level 3', function () {
     $proficiencies = collect([$proficiency1, $proficiency2, $proficiency3, $proficiency4]);
 
     // Mock existing expertise selections
-    $expertiseProficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $expertiseProficienciesQuery = Mockery::mock(HasMany::class);
     $expertiseProficienciesQuery->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();
@@ -187,7 +188,7 @@ it('returns expertise choices for Bard level 3', function () {
         ->andReturn(collect()); // No selections yet
 
     // Mock proficiencies query for getting all proficiencies
-    $proficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $proficienciesQuery = Mockery::mock(HasMany::class);
     $proficienciesQuery->shouldReceive('get')
         ->andReturn($proficiencies);
 
@@ -227,7 +228,7 @@ it('returns no choices when all expertise selections are complete', function () 
     $proficiency4 = (object) ['id' => 4, 'skill_slug' => 'core:investigation', 'proficiency_type_slug' => null, 'expertise' => true];
 
     // Mock both expertise choices complete
-    $expertise1Query = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $expertise1Query = Mockery::mock(HasMany::class);
     $expertise1Query->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();
@@ -237,7 +238,7 @@ it('returns no choices when all expertise selections are complete', function () 
     $expertise1Query->shouldReceive('get')
         ->andReturn(collect([$proficiency1, $proficiency2])); // 2 selected
 
-    $expertise6Query = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $expertise6Query = Mockery::mock(HasMany::class);
     $expertise6Query->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();
@@ -290,7 +291,7 @@ it('resolves expertise choice by updating expertise flag on proficiencies', func
         ->with(['expertise' => true, 'source' => 'class', 'choice_group' => 'expertise_1'])
         ->andReturn(true);
 
-    $proficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $proficienciesQuery = Mockery::mock(HasMany::class);
     $proficienciesQuery->shouldReceive('where')
         ->andReturnSelf();
     $proficienciesQuery->shouldReceive('get')
@@ -346,7 +347,7 @@ it('throws exception when selected proficiency does not exist', function () {
     );
 
     // Mock proficiencies query returning fewer items than selected
-    $proficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $proficienciesQuery = Mockery::mock(HasMany::class);
     $proficienciesQuery->shouldReceive('where')
         ->andReturnSelf();
     $proficienciesQuery->shouldReceive('get')
@@ -397,7 +398,7 @@ it('undoes choice by clearing expertise flag', function () {
     );
 
     // Mock proficiencies relationship
-    $proficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $proficienciesQuery = Mockery::mock(HasMany::class);
     $proficienciesQuery->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();

--- a/tests/Unit/Services/ChoiceHandlers/HitPointRollChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/HitPointRollChoiceHandlerTest.php
@@ -14,6 +14,7 @@ use App\Models\Modifier;
 use App\Models\Race;
 use App\Services\ChoiceHandlers\HitPointRollChoiceHandler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -44,7 +45,7 @@ class HitPointRollChoiceHandlerTest extends TestCase
 
         $choices = $this->handler->getChoices($character);
 
-        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $choices);
+        $this->assertInstanceOf(Collection::class, $choices);
         $this->assertEmpty($choices);
     }
 

--- a/tests/Unit/Services/ChoiceHandlers/OptionalFeatureChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/OptionalFeatureChoiceHandlerTest.php
@@ -5,6 +5,7 @@ use App\Exceptions\InvalidSelectionException;
 use App\Models\Character;
 use App\Models\FeatureSelection;
 use App\Services\ChoiceHandlers\OptionalFeatureChoiceHandler;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 beforeEach(function () {
     $this->handler = new OptionalFeatureChoiceHandler;
@@ -140,7 +141,7 @@ it('undoes choice by deleting FeatureSelection record', function () {
     );
 
     // Mock featureSelections relationship
-    $featureSelectionsQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $featureSelectionsQuery = Mockery::mock(HasMany::class);
     $featureSelectionsQuery->shouldReceive('where')
         ->with('optional_feature_slug', 'phb2014:agonizing-blast')
         ->andReturnSelf();
@@ -162,7 +163,7 @@ it('undoes choice by deleting FeatureSelection record', function () {
 
 it('returns empty collection when character has no classes', function () {
     // Mock character classes relationship
-    $characterClassesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $characterClassesQuery = Mockery::mock(HasMany::class);
     $characterClassesQuery->shouldReceive('with')
         ->with(['characterClass.counters', 'subclass.counters'])
         ->andReturnSelf();
@@ -189,7 +190,7 @@ it('skips counter when level requirement not met', function () {
     ];
 
     // Mock character classes relationship
-    $characterClassesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $characterClassesQuery = Mockery::mock(HasMany::class);
     $characterClassesQuery->shouldReceive('with')
         ->with(['characterClass.counters', 'subclass.counters'])
         ->andReturnSelf();

--- a/tests/Unit/Services/ChoiceHandlers/OptionalFeatureInlineOptionsTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/OptionalFeatureInlineOptionsTest.php
@@ -15,8 +15,9 @@ use App\Models\FeatureSelection;
 use App\Models\OptionalFeature;
 use App\Services\ChoiceHandlers\OptionalFeatureChoiceHandler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
-uses(Tests\TestCase::class, RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class);
 
 beforeEach(function () {
     $this->handler = new OptionalFeatureChoiceHandler;

--- a/tests/Unit/Services/ChoiceHandlers/ProficiencyChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/ProficiencyChoiceHandlerTest.php
@@ -5,6 +5,7 @@ use App\Exceptions\InvalidSelectionException;
 use App\Models\Character;
 use App\Services\CharacterProficiencyService;
 use App\Services\ChoiceHandlers\ProficiencyChoiceHandler;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 beforeEach(function () {
     $this->proficiencyService = Mockery::mock(CharacterProficiencyService::class);
@@ -324,7 +325,7 @@ it('undoes choice by clearing proficiencies', function () {
     );
 
     // Mock proficiencies relationship
-    $proficienciesQuery = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    $proficienciesQuery = Mockery::mock(HasMany::class);
     $proficienciesQuery->shouldReceive('where')
         ->with('source', 'class')
         ->andReturnSelf();
@@ -392,12 +393,12 @@ it('skips choices with invalid source slug', function () {
 
 it('transforms service output for subclass_feature source', function () {
     // Mock character with cleric class and nature domain subclass
-    $subclass = Mockery::mock(\stdClass::class);
+    $subclass = Mockery::mock(stdClass::class);
     $subclass->id = 15;
     $subclass->slug = 'phb:cleric-nature-domain';
     $subclass->name = 'Nature Domain';
 
-    $characterClassPivot = Mockery::mock(\stdClass::class);
+    $characterClassPivot = Mockery::mock(stdClass::class);
     $characterClassPivot->subclass = $subclass;
 
     $characterClasses = collect([$characterClassPivot]);

--- a/tests/Unit/Services/ChoiceHandlers/SpellChoiceHandlerTest.php
+++ b/tests/Unit/Services/ChoiceHandlers/SpellChoiceHandlerTest.php
@@ -8,7 +8,9 @@ use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
 use App\Models\CharacterSpell;
+use App\Models\ClassFeature;
 use App\Models\ClassLevelProgression;
+use App\Models\EntityChoice;
 use App\Models\Spell;
 use App\Services\ChoiceHandlers\SpellChoiceHandler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -562,7 +564,7 @@ class SpellChoiceHandlerTest extends TestCase
         ]);
 
         // Create a subclass feature for Nature Domain at level 1
-        $feature = \App\Models\ClassFeature::factory()->create([
+        $feature = ClassFeature::factory()->create([
             'class_id' => $natureDomain->id,
             'level' => 1,
             'feature_name' => 'Acolyte of Nature',
@@ -575,8 +577,8 @@ class SpellChoiceHandlerTest extends TestCase
         ]);
 
         // Create spell choice record for the feature (1 druid cantrip)
-        \App\Models\EntityChoice::create([
-            'reference_type' => \App\Models\ClassFeature::class,
+        EntityChoice::create([
+            'reference_type' => ClassFeature::class,
             'reference_id' => $feature->id,
             'choice_type' => 'spell',
             'choice_group' => 'acolyte_of_nature_cantrip',

--- a/tests/Unit/Services/ClassProgressionTableGeneratorTest.php
+++ b/tests/Unit/Services/ClassProgressionTableGeneratorTest.php
@@ -2,16 +2,20 @@
 
 namespace Tests\Unit\Services;
 
+use App\Enums\DataTableType;
 use App\Models\CharacterClass;
 use App\Models\ClassCounter;
 use App\Models\ClassFeature;
 use App\Models\ClassLevelProgression;
+use App\Models\EntityDataTable;
+use App\Models\EntityDataTableEntry;
 use App\Services\ClassProgressionTableGenerator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ClassProgressionTableGeneratorTest extends TestCase
 {
     use RefreshDatabase;
@@ -593,30 +597,30 @@ class ClassProgressionTableGeneratorTest extends TestCase
         ]);
 
         // Create an EntityDataTable with progression type
-        $table = \App\Models\EntityDataTable::create([
+        $table = EntityDataTable::create([
             'reference_type' => ClassFeature::class,
             'reference_id' => $feature->id,
             'table_name' => 'Extra Damage',
             'dice_type' => 'd6',
-            'table_type' => \App\Enums\DataTableType::PROGRESSION,
+            'table_type' => DataTableType::PROGRESSION,
         ]);
 
         // Create entries with level values
-        \App\Models\EntityDataTableEntry::create([
+        EntityDataTableEntry::create([
             'entity_data_table_id' => $table->id,
             'roll_min' => 1, 'roll_max' => 1,
             'result_text' => '1d6',
             'level' => 1,
             'sort_order' => 0,
         ]);
-        \App\Models\EntityDataTableEntry::create([
+        EntityDataTableEntry::create([
             'entity_data_table_id' => $table->id,
             'roll_min' => 3, 'roll_max' => 3,
             'result_text' => '2d6',
             'level' => 3,
             'sort_order' => 1,
         ]);
-        \App\Models\EntityDataTableEntry::create([
+        EntityDataTableEntry::create([
             'entity_data_table_id' => $table->id,
             'roll_min' => 5, 'roll_max' => 5,
             'result_text' => '3d6',
@@ -663,15 +667,15 @@ class ClassProgressionTableGeneratorTest extends TestCase
         ]);
 
         // Create progression table
-        $table = \App\Models\EntityDataTable::create([
+        $table = EntityDataTable::create([
             'reference_type' => ClassFeature::class,
             'reference_id' => $feature->id,
             'table_name' => 'Martial Arts',
             'dice_type' => 'd4',
-            'table_type' => \App\Enums\DataTableType::PROGRESSION,
+            'table_type' => DataTableType::PROGRESSION,
         ]);
 
-        \App\Models\EntityDataTableEntry::create([
+        EntityDataTableEntry::create([
             'entity_data_table_id' => $table->id,
             'roll_min' => 1, 'roll_max' => 1,
             'result_text' => '1d4',

--- a/tests/Unit/Services/GlobalSearchServiceTest.php
+++ b/tests/Unit/Services/GlobalSearchServiceTest.php
@@ -3,13 +3,15 @@
 namespace Tests\Unit\Services;
 
 use App\Services\Search\GlobalSearchService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class GlobalSearchServiceTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_across_multiple_models(): void
     {
         $service = new GlobalSearchService;
@@ -21,7 +23,7 @@ class GlobalSearchServiceTest extends TestCase
         $this->assertCount(2, $results);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_limits_results_per_type(): void
     {
         $service = new GlobalSearchService;
@@ -32,7 +34,7 @@ class GlobalSearchServiceTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_searches_all_types_by_default(): void
     {
         $service = new GlobalSearchService;
@@ -46,7 +48,7 @@ class GlobalSearchServiceTest extends TestCase
         $this->assertArrayHasKey('feats', $results);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_available_types(): void
     {
         $service = new GlobalSearchService;

--- a/tests/Unit/Services/Importers/Concerns/CachesLookupTablesTest.php
+++ b/tests/Unit/Services/Importers/Concerns/CachesLookupTablesTest.php
@@ -2,14 +2,17 @@
 
 namespace Tests\Unit\Services\Importers\Concerns;
 
+use App\Exceptions\Lookup\EntityNotFoundException;
 use App\Models\DamageType;
 use App\Models\ItemType;
 use App\Models\Source;
 use App\Services\Importers\Concerns\CachesLookupTables;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class CachesLookupTablesTest extends TestCase
 {
     use RefreshDatabase;
@@ -29,7 +32,7 @@ class CachesLookupTablesTest extends TestCase
         $this->importer = new TestImporterWithCache;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_caches_lookup_by_id()
     {
         $source = Source::where('code', 'PHB')->first();
@@ -44,7 +47,7 @@ class CachesLookupTablesTest extends TestCase
         $this->assertEquals($source->id, $result1->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_caches_lookup_by_code()
     {
         // First call - hits database
@@ -57,7 +60,7 @@ class CachesLookupTablesTest extends TestCase
         $this->assertEquals('PHB', $result1->code);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_id_only_when_requested()
     {
         $itemType = ItemType::where('code', 'W')->first();
@@ -68,7 +71,7 @@ class CachesLookupTablesTest extends TestCase
         $this->assertEquals($itemType->id, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_for_missing_records_when_using_first()
     {
         $result = $this->importer->testCachedFind(Source::class, 'code', 'NONEXISTENT', useFail: false);
@@ -76,26 +79,26 @@ class CachesLookupTablesTest extends TestCase
         $this->assertNull($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_exception_for_missing_records_when_using_first_or_fail()
     {
         // Now throws EntityNotFoundException instead of ModelNotFoundException
-        $this->expectException(\App\Exceptions\Lookup\EntityNotFoundException::class);
+        $this->expectException(EntityNotFoundException::class);
 
         $this->importer->testCachedFind(Source::class, 'code', 'NONEXISTENT', useFail: true);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_entity_not_found_exception_with_context()
     {
-        $this->expectException(\App\Exceptions\Lookup\EntityNotFoundException::class);
+        $this->expectException(EntityNotFoundException::class);
         $this->expectExceptionMessage('Source not found');
         $this->expectExceptionCode(404);
 
         $this->importer->testCachedFind(Source::class, 'code', 'NONEXISTENT', useFail: true);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_caches_null_results()
     {
         // First call - hits database
@@ -108,7 +111,7 @@ class CachesLookupTablesTest extends TestCase
         $this->assertNull($result2);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_multiple_model_types()
     {
         $source = $this->importer->testCachedFind(Source::class, 'code', 'PHB');
@@ -120,7 +123,7 @@ class CachesLookupTablesTest extends TestCase
         $this->assertInstanceOf(DamageType::class, $damageType);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_normalizes_cache_keys_by_uppercasing_value()
     {
         // Test with lowercase
@@ -137,7 +140,7 @@ class CachesLookupTablesTest extends TestCase
         $this->assertSame($result3, $result4);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_nullable_id_for_missing_records()
     {
         $result = $this->importer->testCachedFindId(Source::class, 'code', 'NONEXISTENT', useFail: false);

--- a/tests/Unit/Services/Importers/Concerns/ImportsConditionsTest.php
+++ b/tests/Unit/Services/Importers/Concerns/ImportsConditionsTest.php
@@ -4,13 +4,15 @@ namespace Tests\Unit\Services\Importers\Concerns;
 
 use App\Models\Condition;
 use App\Models\EntityCondition;
+use App\Models\Feat;
 use App\Models\Race;
 use App\Services\Importers\Concerns\ImportsConditions;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ImportsConditionsTest extends TestCase
 {
     use ImportsConditions;
@@ -130,7 +132,7 @@ class ImportsConditionsTest extends TestCase
     #[Test]
     public function it_works_with_feats()
     {
-        $feat = \App\Models\Feat::factory()->create();
+        $feat = Feat::factory()->create();
 
         $conditionsData = [
             [

--- a/tests/Unit/Services/Importers/Concerns/ImportsLanguagesTest.php
+++ b/tests/Unit/Services/Importers/Concerns/ImportsLanguagesTest.php
@@ -9,10 +9,11 @@ use App\Models\Language;
 use App\Models\Race;
 use App\Services\Importers\Concerns\ImportsLanguages;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ImportsLanguagesTest extends TestCase
 {
     use ImportsLanguages;

--- a/tests/Unit/Services/Importers/Concerns/ImportsModifiersTest.php
+++ b/tests/Unit/Services/Importers/Concerns/ImportsModifiersTest.php
@@ -10,10 +10,11 @@ use App\Models\Race;
 use App\Models\Skill;
 use App\Services\Importers\Concerns\ImportsModifiers;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ImportsModifiersTest extends TestCase
 {
     use ImportsModifiers;

--- a/tests/Unit/Services/Importers/Concerns/ImportsSensesTest.php
+++ b/tests/Unit/Services/Importers/Concerns/ImportsSensesTest.php
@@ -8,10 +8,11 @@ use App\Models\Race;
 use App\Models\Sense;
 use App\Services\Importers\Concerns\ImportsSenses;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class ImportsSensesTest extends TestCase
 {
     use ImportsSenses;

--- a/tests/Unit/Services/ItemTableDetectorTest.php
+++ b/tests/Unit/Services/ItemTableDetectorTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Services;
 
 use App\Services\Parsers\ItemTableDetector;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class ItemTableDetectorTest extends TestCase
 {

--- a/tests/Unit/Services/ItemTableParserTest.php
+++ b/tests/Unit/Services/ItemTableParserTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Services;
 
 use App\Services\Parsers\ItemTableParser;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class ItemTableParserTest extends TestCase
 {

--- a/tests/Unit/Services/LevelUpServiceTest.php
+++ b/tests/Unit/Services/LevelUpServiceTest.php
@@ -9,6 +9,8 @@ use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterFeature;
 use App\Models\ClassFeature;
+use App\Models\FeatureSelection;
+use App\Models\OptionalFeature;
 use App\Models\Race;
 use App\Services\LevelUpService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -219,7 +221,7 @@ class LevelUpServiceTest extends TestCase
         $race = Race::factory()->create();
 
         // Create a fighting style optional feature for the handler to check against
-        $fightingStyle = \App\Models\OptionalFeature::factory()->create([
+        $fightingStyle = OptionalFeature::factory()->create([
             'feature_type' => 'fighting_style',
             'name' => 'Defense',
         ]);
@@ -234,7 +236,7 @@ class LevelUpServiceTest extends TestCase
             ]);
 
         // Resolve the required fighting style choice
-        \App\Models\FeatureSelection::create([
+        FeatureSelection::create([
             'character_id' => $character->id,
             'class_slug' => $class->slug,
             'feature_type' => 'fighting_style',

--- a/tests/Unit/Services/Parsers/MatchesProficiencyTypesTest.php
+++ b/tests/Unit/Services/Parsers/MatchesProficiencyTypesTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Services\Parsers;
 
 use App\Services\Parsers\Concerns\MatchesProficiencyTypes;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class MatchesProficiencyTypesTest extends TestCase
 {

--- a/tests/Unit/Services/Parsers/Strategies/AbstractItemStrategyTest.php
+++ b/tests/Unit/Services/Parsers/Strategies/AbstractItemStrategyTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Services\Parsers\Strategies;
 
 use App\Services\Parsers\Strategies\AbstractItemStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class AbstractItemStrategyTest extends TestCase
 {

--- a/tests/Unit/Services/Parsers/Strategies/ChargedItemStrategyTest.php
+++ b/tests/Unit/Services/Parsers/Strategies/ChargedItemStrategyTest.php
@@ -4,11 +4,12 @@ namespace Tests\Unit\Services\Parsers\Strategies;
 
 use App\Services\Parsers\Strategies\ChargedItemStrategy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 
 class ChargedItemStrategyTest extends TestCase
 {

--- a/tests/Unit/Services/Parsers/Strategies/LegendaryStrategyTest.php
+++ b/tests/Unit/Services/Parsers/Strategies/LegendaryStrategyTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Services\Parsers\Strategies;
 
 use App\Services\Parsers\Strategies\LegendaryStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class LegendaryStrategyTest extends TestCase
 {

--- a/tests/Unit/Services/Parsers/Strategies/PotionStrategyTest.php
+++ b/tests/Unit/Services/Parsers/Strategies/PotionStrategyTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Services\Parsers\Strategies;
 
 use App\Services\Parsers\Strategies\PotionStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class PotionStrategyTest extends TestCase
 {

--- a/tests/Unit/Services/Parsers/Strategies/ScrollStrategyTest.php
+++ b/tests/Unit/Services/Parsers/Strategies/ScrollStrategyTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Services\Parsers\Strategies;
 
 use App\Services\Parsers\Strategies\ScrollStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class ScrollStrategyTest extends TestCase
 {

--- a/tests/Unit/Services/Parsers/Strategies/TattooStrategyTest.php
+++ b/tests/Unit/Services/Parsers/Strategies/TattooStrategyTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Services\Parsers\Strategies;
 
 use App\Services\Parsers\Strategies\TattooStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class TattooStrategyTest extends TestCase
 {

--- a/tests/Unit/Services/Search/MeilisearchFilterCompilerTest.php
+++ b/tests/Unit/Services/Search/MeilisearchFilterCompilerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services\Search;
 
 use App\Services\Search\MeilisearchFilterCompiler;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -18,7 +19,7 @@ use Tests\TestCase;
  * Keywords and operators (AND/OR/NOT/IN/IS/NULL/EMPTY/TO/true/false)
  * and numeric literals must pass through untouched.
  */
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class MeilisearchFilterCompilerTest extends TestCase
 {
     // ============================================================

--- a/tests/Unit/Services/SpellManagerServiceTest.php
+++ b/tests/Unit/Services/SpellManagerServiceTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services;
 
+use App\Exceptions\SpellManagementException;
+use App\Models\AbilityScore;
 use App\Models\Character;
 use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
 use App\Models\ClassFeature;
 use App\Models\Spell;
 use App\Services\SpellManagerService;
+use Database\Seeders\LookupSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
@@ -19,7 +22,7 @@ class SpellManagerServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $seeder = \Database\Seeders\LookupSeeder::class;
+    protected $seeder = LookupSeeder::class;
 
     private SpellManagerService $service;
 
@@ -538,7 +541,7 @@ class SpellManagerServiceTest extends TestCase
             'is_primary' => true,
         ]);
 
-        $this->expectException(\App\Exceptions\SpellManagementException::class);
+        $this->expectException(SpellManagementException::class);
         $this->expectExceptionMessage("not available for this character's class");
 
         $this->service->learnSpell($character, $spell);
@@ -573,7 +576,7 @@ class SpellManagerServiceTest extends TestCase
             'is_primary' => true,
         ]);
 
-        $this->expectException(\App\Exceptions\SpellManagementException::class);
+        $this->expectException(SpellManagementException::class);
         $this->expectExceptionMessage('Maximum spell level');
 
         $this->service->learnSpell($character, $spell);
@@ -615,7 +618,7 @@ class SpellManagerServiceTest extends TestCase
             'level_acquired' => 1,
         ]);
 
-        $this->expectException(\App\Exceptions\SpellManagementException::class);
+        $this->expectException(SpellManagementException::class);
         $this->expectExceptionMessage('already known');
 
         $this->service->learnSpell($character, $spell);
@@ -667,7 +670,7 @@ class SpellManagerServiceTest extends TestCase
             'level' => 3,
         ]);
 
-        $this->expectException(\App\Exceptions\SpellManagementException::class);
+        $this->expectException(SpellManagementException::class);
         $this->expectExceptionMessage('not known by this character');
 
         $this->service->forgetSpell($character, $spell);
@@ -686,7 +689,7 @@ class SpellManagerServiceTest extends TestCase
             'name' => 'Wizard',
             'slug' => 'test:wizard',
             'parent_class_id' => null,
-            'spellcasting_ability_id' => \App\Models\AbilityScore::where('code', 'INT')->first()?->id,
+            'spellcasting_ability_id' => AbilityScore::where('code', 'INT')->first()?->id,
         ]);
 
         CharacterClassPivot::factory()->create([
@@ -731,7 +734,7 @@ class SpellManagerServiceTest extends TestCase
             'level_acquired' => 1,
         ]);
 
-        $this->expectException(\App\Exceptions\SpellManagementException::class);
+        $this->expectException(SpellManagementException::class);
         $this->expectExceptionMessage('Cantrips cannot be prepared');
 
         $this->service->prepareSpell($character, $cantrip);
@@ -748,7 +751,7 @@ class SpellManagerServiceTest extends TestCase
             'level' => 3,
         ]);
 
-        $this->expectException(\App\Exceptions\SpellManagementException::class);
+        $this->expectException(SpellManagementException::class);
         $this->expectExceptionMessage('not known by this character');
 
         $this->service->prepareSpell($character, $spell);
@@ -792,7 +795,7 @@ class SpellManagerServiceTest extends TestCase
             'level' => 3,
         ]);
 
-        $this->expectException(\App\Exceptions\SpellManagementException::class);
+        $this->expectException(SpellManagementException::class);
         $this->expectExceptionMessage('not known by this character');
 
         $this->service->unprepareSpell($character, $spell);
@@ -822,7 +825,7 @@ class SpellManagerServiceTest extends TestCase
             'name' => 'Wizard',
             'slug' => 'test:wizard',
             'parent_class_id' => null,
-            'spellcasting_ability_id' => \App\Models\AbilityScore::where('code', 'INT')->first()?->id,
+            'spellcasting_ability_id' => AbilityScore::where('code', 'INT')->first()?->id,
         ]);
 
         $character = Character::factory()->create(['intelligence' => 16]);
@@ -854,7 +857,7 @@ class SpellManagerServiceTest extends TestCase
             'slug' => 'test:wizard',
             'parent_class_id' => null,
             'spell_preparation_method' => 'spellbook',
-            'spellcasting_ability_id' => \App\Models\AbilityScore::where('code', 'INT')->first()?->id,
+            'spellcasting_ability_id' => AbilityScore::where('code', 'INT')->first()?->id,
         ]);
 
         $cleric = CharacterClass::factory()->create([
@@ -862,7 +865,7 @@ class SpellManagerServiceTest extends TestCase
             'slug' => 'test:cleric',
             'parent_class_id' => null,
             'spell_preparation_method' => 'prepared',
-            'spellcasting_ability_id' => \App\Models\AbilityScore::where('code', 'WIS')->first()?->id,
+            'spellcasting_ability_id' => AbilityScore::where('code', 'WIS')->first()?->id,
         ]);
 
         // Spell that's on BOTH class lists (like Protection from Evil and Good)
@@ -935,7 +938,7 @@ class SpellManagerServiceTest extends TestCase
             'slug' => 'test:wizard',
             'parent_class_id' => null,
             'spell_preparation_method' => 'spellbook',
-            'spellcasting_ability_id' => \App\Models\AbilityScore::where('code', 'INT')->first()?->id,
+            'spellcasting_ability_id' => AbilityScore::where('code', 'INT')->first()?->id,
         ]);
 
         $cleric = CharacterClass::factory()->create([
@@ -943,7 +946,7 @@ class SpellManagerServiceTest extends TestCase
             'slug' => 'test:cleric',
             'parent_class_id' => null,
             'spell_preparation_method' => 'prepared',
-            'spellcasting_ability_id' => \App\Models\AbilityScore::where('code', 'WIS')->first()?->id,
+            'spellcasting_ability_id' => AbilityScore::where('code', 'WIS')->first()?->id,
         ]);
 
         $spell = Spell::factory()->create([

--- a/tests/Unit/Services/SpellSlotServiceTest.php
+++ b/tests/Unit/Services/SpellSlotServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\CharacterClass;
 use App\Models\CharacterClassPivot;
 use App\Models\CharacterSpellSlot;
 use App\Services\SpellSlotService;
+use Database\Seeders\TestDatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -23,7 +24,7 @@ class SpellSlotServiceTest extends TestCase
      * Use TestDatabaseSeeder to load class fixtures (Wizard, Warlock, etc.)
      * needed for multiclass and caster tests.
      */
-    protected $seeder = \Database\Seeders\TestDatabaseSeeder::class;
+    protected $seeder = TestDatabaseSeeder::class;
 
     private SpellSlotService $service;
 

--- a/tests/Unit/Strategies/CharacterClass/AbstractClassStrategyTest.php
+++ b/tests/Unit/Strategies/CharacterClass/AbstractClassStrategyTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Strategies\CharacterClass;
 
 use App\Services\Importers\Strategies\AbstractImportStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 class AbstractClassStrategyTest extends TestCase
 {
     private ConcreteTestStrategy $strategy;

--- a/tests/Unit/Strategies/CharacterClass/BaseClassStrategyTest.php
+++ b/tests/Unit/Strategies/CharacterClass/BaseClassStrategyTest.php
@@ -4,11 +4,13 @@ namespace Tests\Unit\Strategies\CharacterClass;
 
 use App\Models\AbilityScore;
 use App\Services\Importers\Strategies\CharacterClass\BaseClassStrategy;
+use Database\Seeders\AbilityScoreSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class BaseClassStrategyTest extends TestCase
 {
     use RefreshDatabase;
@@ -21,8 +23,8 @@ class BaseClassStrategyTest extends TestCase
         $this->strategy = new BaseClassStrategy;
 
         // Seed necessary lookup data only once
-        if (\App\Models\AbilityScore::count() === 0) {
-            $this->seed(\Database\Seeders\AbilityScoreSeeder::class);
+        if (AbilityScore::count() === 0) {
+            $this->seed(AbilityScoreSeeder::class);
         }
     }
 

--- a/tests/Unit/Strategies/CharacterClass/SubclassStrategyTest.php
+++ b/tests/Unit/Strategies/CharacterClass/SubclassStrategyTest.php
@@ -5,10 +5,11 @@ namespace Tests\Unit\Strategies\CharacterClass;
 use App\Models\CharacterClass;
 use App\Services\Importers\Strategies\CharacterClass\SubclassStrategy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SubclassStrategyTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Strategies/Monster/AberrationStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/AberrationStrategyTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\AberrationStrategy;
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class AberrationStrategyTest extends TestCase
 {
@@ -18,14 +20,14 @@ class AberrationStrategyTest extends TestCase
         $this->strategy = new AberrationStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_aberration_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'aberration']));
         $this->assertTrue($this->strategy->appliesTo(['type' => 'Aberration']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_apply_to_non_aberration_type(): void
     {
         $this->assertFalse($this->strategy->appliesTo(['type' => 'fiend']));
@@ -33,7 +35,7 @@ class AberrationStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'elemental']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_telepathy(): void
     {
         $monsterData = [
@@ -51,7 +53,7 @@ class AberrationStrategyTest extends TestCase
         $this->assertArrayHasKey('telepaths', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_psychic_damage_in_actions(): void
     {
         $actions = [
@@ -77,7 +79,7 @@ class AberrationStrategyTest extends TestCase
         $this->assertArrayHasKey('psychic_attackers', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_mind_control_in_traits(): void
     {
         $traits = [
@@ -98,7 +100,7 @@ class AberrationStrategyTest extends TestCase
         $this->assertArrayHasKey('mind_controllers', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_mind_control_in_actions(): void
     {
         $actions = [
@@ -124,7 +126,7 @@ class AberrationStrategyTest extends TestCase
         $this->assertArrayHasKey('mind_controllers', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_antimagic_abilities(): void
     {
         $traits = [
@@ -145,7 +147,7 @@ class AberrationStrategyTest extends TestCase
         $this->assertArrayHasKey('antimagic_users', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tracks_aberration_metrics(): void
     {
         $monsterData = ['type' => 'aberration'];
@@ -159,7 +161,7 @@ class AberrationStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['aberrations_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_integrates_with_real_xml_fixture(): void
     {
         $parser = new MonsterXmlParser;

--- a/tests/Unit/Strategies/Monster/AbstractMonsterStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/AbstractMonsterStrategyTest.php
@@ -2,15 +2,19 @@
 
 namespace Tests\Unit\Strategies\Monster;
 
+use App\Services\Importers\Strategies\Monster\AbstractMonsterStrategy;
+use App\Services\Importers\Strategies\Monster\DefaultStrategy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class AbstractMonsterStrategyTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_action_cost_from_legendary_name(): void
     {
-        $strategy = new class extends \App\Services\Importers\Strategies\Monster\AbstractMonsterStrategy
+        $strategy = new class extends AbstractMonsterStrategy
         {
             public function appliesTo(array $monsterData): bool
             {
@@ -28,10 +32,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertEquals(3, $strategy->test_extract_cost('Psychic Drain (Costs 3 Actions)'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_lair_actions_from_category(): void
     {
-        $strategy = new class extends \App\Services\Importers\Strategies\Monster\AbstractMonsterStrategy
+        $strategy = new class extends AbstractMonsterStrategy
         {
             public function appliesTo(array $monsterData): bool
             {
@@ -53,10 +57,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertTrue($enhanced[1]['is_lair_action']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_damage_immunity(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $monsterData = [
             'damage_immunities' => 'fire, cold',
         ];
@@ -66,10 +70,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertFalse($this->callProtectedMethod($strategy, 'hasDamageImmunity', [$monsterData, 'poison']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_damage_resistance(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $monsterData = [
             'damage_resistances' => 'bludgeoning, piercing',
         ];
@@ -78,10 +82,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertFalse($this->callProtectedMethod($strategy, 'hasDamageResistance', [$monsterData, 'fire']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_condition_immunity(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $monsterData = [
             'condition_immunities' => 'charmed, frightened, poisoned',
         ];
@@ -91,10 +95,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertFalse($this->callProtectedMethod($strategy, 'hasConditionImmunity', [$monsterData, 'paralyzed']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_finds_trait_containing_keyword(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $traits = [
             ['name' => 'Magic Resistance', 'description' => 'The creature has advantage on saving throws against spells'],
             ['name' => 'Pack Tactics', 'description' => 'The creature has advantage on attacks'],
@@ -105,10 +109,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertFalse($this->callProtectedMethod($strategy, 'hasTraitContaining', [$traits, 'regeneration']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_conditional_tags_with_trait_checks(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $strategy->reset();
 
         $traits = [
@@ -141,10 +145,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['beasts_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_conditional_tags_with_immunity_checks(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $strategy->reset();
 
         $monsterData = [
@@ -173,10 +177,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertNotContains('cold_immune', $tags);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_conditional_tags_with_resistance_checks(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $strategy->reset();
 
         $monsterData = [
@@ -200,10 +204,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertContains('physical_resistant', $tags);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_conditional_tags_with_condition_immunity_checks(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $strategy->reset();
 
         $monsterData = [
@@ -229,10 +233,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertNotContains('paralysis_immune', $tags);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_conditional_tags_with_custom_metric_names(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $strategy->reset();
 
         $traits = [
@@ -256,10 +260,10 @@ class AbstractMonsterStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['magic_resistant_fiends']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deduplicates_tags_when_multiple_conditions_match_same_tag(): void
     {
-        $strategy = new \App\Services\Importers\Strategies\Monster\DefaultStrategy;
+        $strategy = new DefaultStrategy;
         $strategy->reset();
 
         $traits = [

--- a/tests/Unit/Strategies/Monster/BeastStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/BeastStrategyTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\BeastStrategy;
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class BeastStrategyTest extends TestCase
 {
@@ -18,14 +20,14 @@ class BeastStrategyTest extends TestCase
         $this->strategy = new BeastStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_beast_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'beast']));
         $this->assertTrue($this->strategy->appliesTo(['type' => 'Beast']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_apply_to_non_beast_type(): void
     {
         $this->assertFalse($this->strategy->appliesTo(['type' => 'dragon']));
@@ -33,7 +35,7 @@ class BeastStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'elemental']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_keen_senses(): void
     {
         $traits = [
@@ -57,7 +59,7 @@ class BeastStrategyTest extends TestCase
         $this->assertArrayHasKey('keen_senses_count', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_pack_tactics(): void
     {
         $traits = [
@@ -81,7 +83,7 @@ class BeastStrategyTest extends TestCase
         $this->assertArrayHasKey('pack_tactics_count', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_charge_mechanics(): void
     {
         $traits = [
@@ -105,7 +107,7 @@ class BeastStrategyTest extends TestCase
         $this->assertArrayHasKey('charge_count', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_special_movement(): void
     {
         $traits = [
@@ -133,7 +135,7 @@ class BeastStrategyTest extends TestCase
         $this->assertArrayHasKey('special_movement_count', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tracks_beast_metrics(): void
     {
         $monsterData = [
@@ -149,7 +151,7 @@ class BeastStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['beasts_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_integrates_with_real_xml_fixture(): void
     {
         $parser = new MonsterXmlParser;

--- a/tests/Unit/Strategies/Monster/CelestialStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/CelestialStrategyTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\CelestialStrategy;
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class CelestialStrategyTest extends TestCase
 {
@@ -18,14 +20,14 @@ class CelestialStrategyTest extends TestCase
         $this->strategy = new CelestialStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_celestial_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'celestial']));
         $this->assertTrue($this->strategy->appliesTo(['type' => 'Celestial']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_apply_to_non_celestial_type(): void
     {
         $this->assertFalse($this->strategy->appliesTo(['type' => 'fiend']));
@@ -33,7 +35,7 @@ class CelestialStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'undead']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_radiant_damage_in_actions(): void
     {
         $actions = [
@@ -57,7 +59,7 @@ class CelestialStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['radiant_attackers']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_healing_abilities(): void
     {
         $actions = [
@@ -81,7 +83,7 @@ class CelestialStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['healers_count']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tracks_celestial_enhancement_metrics(): void
     {
         $monsterData = ['type' => 'celestial'];
@@ -94,7 +96,7 @@ class CelestialStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['celestials_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_integrates_with_real_xml_fixture(): void
     {
         $parser = new MonsterXmlParser;

--- a/tests/Unit/Strategies/Monster/ConstructStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/ConstructStrategyTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\ConstructStrategy;
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class ConstructStrategyTest extends TestCase
 {
@@ -18,14 +20,14 @@ class ConstructStrategyTest extends TestCase
         $this->strategy = new ConstructStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_construct_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'construct']));
         $this->assertTrue($this->strategy->appliesTo(['type' => 'Construct']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_apply_to_non_construct_type(): void
     {
         $this->assertFalse($this->strategy->appliesTo(['type' => 'fiend']));
@@ -33,7 +35,7 @@ class ConstructStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'celestial']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_poison_immunity(): void
     {
         $monsterData = [
@@ -50,7 +52,7 @@ class ConstructStrategyTest extends TestCase
         $this->assertContains('poison_immune', $tags);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_condition_immunities(): void
     {
         $monsterData = [
@@ -73,7 +75,7 @@ class ConstructStrategyTest extends TestCase
         )));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_constructed_nature_trait(): void
     {
         $traits = [
@@ -99,7 +101,7 @@ class ConstructStrategyTest extends TestCase
         $this->assertContains('constructed_nature', $metadata['metrics']['tags_applied']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tracks_construct_enhancement_metrics(): void
     {
         $monsterData = [
@@ -115,7 +117,7 @@ class ConstructStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['constructs_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_integrates_with_real_xml_fixture(): void
     {
         $parser = new MonsterXmlParser;

--- a/tests/Unit/Strategies/Monster/DefaultStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/DefaultStrategyTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\DefaultStrategy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class DefaultStrategyTest extends TestCase
 {
@@ -17,7 +19,7 @@ class DefaultStrategyTest extends TestCase
         $this->strategy = new DefaultStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_always_applies(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'beast']));
@@ -25,7 +27,7 @@ class DefaultStrategyTest extends TestCase
         $this->assertTrue($this->strategy->appliesTo(['type' => 'anything']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_traits_unmodified(): void
     {
         $traits = [
@@ -37,7 +39,7 @@ class DefaultStrategyTest extends TestCase
         $this->assertEquals($traits, $enhanced);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_actions_unmodified(): void
     {
         $actions = [

--- a/tests/Unit/Strategies/Monster/DragonStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/DragonStrategyTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\DragonStrategy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class DragonStrategyTest extends TestCase
 {
@@ -17,7 +19,7 @@ class DragonStrategyTest extends TestCase
         $this->strategy = new DragonStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_dragon_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'dragon']));
@@ -25,7 +27,7 @@ class DragonStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'humanoid']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_breath_weapon_recharge(): void
     {
         $actions = [
@@ -41,7 +43,7 @@ class DragonStrategyTest extends TestCase
         $this->assertEquals('5-6', $enhanced[0]['recharge']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_legendary_resistance_recharge(): void
     {
         $traits = [
@@ -57,7 +59,7 @@ class DragonStrategyTest extends TestCase
         $this->assertEquals('3/DAY', $enhanced[0]['recharge']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_metadata(): void
     {
         $monsterData = [

--- a/tests/Unit/Strategies/Monster/ElementalStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/ElementalStrategyTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\ElementalStrategy;
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class ElementalStrategyTest extends TestCase
 {
@@ -18,14 +20,14 @@ class ElementalStrategyTest extends TestCase
         $this->strategy = new ElementalStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_elemental_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'elemental']));
         $this->assertTrue($this->strategy->appliesTo(['type' => 'Elemental']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_apply_to_non_elemental_type(): void
     {
         $this->assertFalse($this->strategy->appliesTo(['type' => 'fiend']));
@@ -33,7 +35,7 @@ class ElementalStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'aberration']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_fire_elemental_subtype(): void
     {
         $monsterData = [
@@ -52,7 +54,7 @@ class ElementalStrategyTest extends TestCase
         $this->assertArrayHasKey('fire_elementals', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_water_elemental_subtype(): void
     {
         $monsterData = [
@@ -70,7 +72,7 @@ class ElementalStrategyTest extends TestCase
         $this->assertArrayHasKey('water_elementals', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_earth_elemental_subtype(): void
     {
         $monsterData = [
@@ -89,7 +91,7 @@ class ElementalStrategyTest extends TestCase
         $this->assertArrayHasKey('earth_elementals', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_air_elemental_subtype(): void
     {
         $monsterData = [
@@ -107,7 +109,7 @@ class ElementalStrategyTest extends TestCase
         $this->assertArrayHasKey('air_elementals', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_poison_immunity(): void
     {
         $monsterData = [
@@ -124,7 +126,7 @@ class ElementalStrategyTest extends TestCase
         $this->assertContains('poison_immune', $tags);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tracks_elemental_metrics(): void
     {
         $monsterData = [
@@ -141,7 +143,7 @@ class ElementalStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['elementals_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_integrates_with_real_xml_fixture(): void
     {
         $parser = new MonsterXmlParser;

--- a/tests/Unit/Strategies/Monster/FiendStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/FiendStrategyTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\FiendStrategy;
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class FiendStrategyTest extends TestCase
 {
@@ -18,7 +20,7 @@ class FiendStrategyTest extends TestCase
         $this->strategy = new FiendStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_fiend_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'fiend (demon)']));
@@ -27,7 +29,7 @@ class FiendStrategyTest extends TestCase
         $this->assertTrue($this->strategy->appliesTo(['type' => 'Fiend']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_apply_to_non_fiend_type(): void
     {
         $this->assertFalse($this->strategy->appliesTo(['type' => 'dragon']));
@@ -35,7 +37,7 @@ class FiendStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'celestial']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_fire_immunity(): void
     {
         $monsterData = [
@@ -52,7 +54,7 @@ class FiendStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['fire_immune_count']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_poison_immunity(): void
     {
         $monsterData = [
@@ -69,7 +71,7 @@ class FiendStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['poison_immune_count']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_magic_resistance_trait(): void
     {
         $traits = [
@@ -93,7 +95,7 @@ class FiendStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['magic_resistance_count']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tracks_fiend_enhancement_metrics(): void
     {
         $monsterData = [
@@ -110,7 +112,7 @@ class FiendStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['fiends_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_integrates_with_real_xml_fixture(): void
     {
         $parser = new MonsterXmlParser;

--- a/tests/Unit/Strategies/Monster/ShapechangerStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/ShapechangerStrategyTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\ShapechangerStrategy;
 use App\Services\Parsers\MonsterXmlParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class ShapechangerStrategyTest extends TestCase
 {
@@ -18,7 +20,7 @@ class ShapechangerStrategyTest extends TestCase
         $this->strategy = new ShapechangerStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_shapechanger_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'humanoid (shapechanger)']));
@@ -26,7 +28,7 @@ class ShapechangerStrategyTest extends TestCase
         $this->assertTrue($this->strategy->appliesTo(['type' => 'aberration (shapechanger)']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_does_not_apply_to_non_shapechanger_type(): void
     {
         $this->assertFalse($this->strategy->appliesTo(['type' => 'humanoid']));
@@ -34,7 +36,7 @@ class ShapechangerStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'elemental']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_lycanthrope_subtype(): void
     {
         $traits = [
@@ -58,7 +60,7 @@ class ShapechangerStrategyTest extends TestCase
         $this->assertArrayHasKey('lycanthropes', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_doppelganger_subtype(): void
     {
         $traits = [
@@ -82,7 +84,7 @@ class ShapechangerStrategyTest extends TestCase
         $this->assertArrayHasKey('doppelgangers', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detects_mimic_subtype(): void
     {
         $traits = [
@@ -110,7 +112,7 @@ class ShapechangerStrategyTest extends TestCase
         $this->assertArrayHasKey('mimics', $metadata['metrics']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tracks_shapechanger_metrics(): void
     {
         $monsterData = [
@@ -126,7 +128,7 @@ class ShapechangerStrategyTest extends TestCase
         $this->assertEquals(1, $metadata['metrics']['shapechangers_enhanced']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_integrates_with_real_xml_fixture(): void
     {
         $parser = new MonsterXmlParser;

--- a/tests/Unit/Strategies/Monster/SpellcasterStrategyEnhancementTest.php
+++ b/tests/Unit/Strategies/Monster/SpellcasterStrategyEnhancementTest.php
@@ -7,10 +7,11 @@ use App\Models\Spell;
 use App\Models\SpellSchool;
 use App\Services\Importers\Strategies\Monster\SpellcasterStrategy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SpellcasterStrategyEnhancementTest extends TestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Strategies/Monster/SwarmStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/SwarmStrategyTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\SwarmStrategy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class SwarmStrategyTest extends TestCase
 {
@@ -17,7 +19,7 @@ class SwarmStrategyTest extends TestCase
         $this->strategy = new SwarmStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_swarm_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'swarm of medium beasts']));
@@ -25,7 +27,7 @@ class SwarmStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'beast']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_individual_creature_size_from_type(): void
     {
         $monsterData = [
@@ -39,7 +41,7 @@ class SwarmStrategyTest extends TestCase
         $this->assertEquals('M', $metadata['swarm_size']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_swarm_without_size_in_type(): void
     {
         $monsterData = [

--- a/tests/Unit/Strategies/Monster/UndeadStrategyTest.php
+++ b/tests/Unit/Strategies/Monster/UndeadStrategyTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Unit\Strategies\Monster;
 
 use App\Services\Importers\Strategies\Monster\UndeadStrategy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class UndeadStrategyTest extends TestCase
 {
     protected UndeadStrategy $strategy;
@@ -16,7 +18,7 @@ class UndeadStrategyTest extends TestCase
         $this->strategy = new UndeadStrategy;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_to_undead_type(): void
     {
         $this->assertTrue($this->strategy->appliesTo(['type' => 'undead']));
@@ -24,7 +26,7 @@ class UndeadStrategyTest extends TestCase
         $this->assertFalse($this->strategy->appliesTo(['type' => 'humanoid']));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_metadata_for_turn_resistance(): void
     {
         $monsterData = [
@@ -38,7 +40,7 @@ class UndeadStrategyTest extends TestCase
         $this->assertTrue($metadata['has_turn_resistance']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_extracts_metadata_for_sunlight_sensitivity(): void
     {
         $monsterData = [

--- a/tests/Unit/Strategies/Race/AbstractRaceStrategyTest.php
+++ b/tests/Unit/Strategies/Race/AbstractRaceStrategyTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Strategies\Race;
 
 use App\Services\Importers\Strategies\AbstractImportStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class AbstractRaceStrategyTest extends TestCase
 {

--- a/tests/Unit/Strategies/Race/BaseRaceStrategyTest.php
+++ b/tests/Unit/Strategies/Race/BaseRaceStrategyTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Unit\Strategies\Race;
 
 use App\Services\Importers\Strategies\Race\BaseRaceStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-pure')]
+#[Group('unit-pure')]
 
 class BaseRaceStrategyTest extends TestCase
 {

--- a/tests/Unit/Strategies/Race/RacialVariantStrategyTest.php
+++ b/tests/Unit/Strategies/Race/RacialVariantStrategyTest.php
@@ -5,11 +5,13 @@ namespace Tests\Unit\Strategies\Race;
 use App\Models\Race;
 use App\Models\Size;
 use App\Services\Importers\Strategies\Race\RacialVariantStrategy;
+use Database\Seeders\SizeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class RacialVariantStrategyTest extends TestCase
 {
     use RefreshDatabase;
@@ -28,8 +30,8 @@ class RacialVariantStrategyTest extends TestCase
      */
     private function seedSizes(): void
     {
-        if (! \App\Models\Size::where('code', 'M')->exists()) {
-            $this->seed(\Database\Seeders\SizeSeeder::class);
+        if (! Size::where('code', 'M')->exists()) {
+            $this->seed(SizeSeeder::class);
         }
     }
 

--- a/tests/Unit/Strategies/Race/SubraceStrategyTest.php
+++ b/tests/Unit/Strategies/Race/SubraceStrategyTest.php
@@ -5,11 +5,14 @@ namespace Tests\Unit\Strategies\Race;
 use App\Models\Race;
 use App\Models\Size;
 use App\Services\Importers\Strategies\Race\SubraceStrategy;
+use Database\Seeders\SizeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('unit-db')]
+#[Group('unit-db')]
 class SubraceStrategyTest extends TestCase
 {
     use RefreshDatabase;
@@ -28,8 +31,8 @@ class SubraceStrategyTest extends TestCase
      */
     private function seedSizes(): void
     {
-        if (! \App\Models\Size::where('code', 'M')->exists()) {
-            $this->seed(\Database\Seeders\SizeSeeder::class);
+        if (! Size::where('code', 'M')->exists()) {
+            $this->seed(SizeSeeder::class);
         }
     }
 
@@ -86,7 +89,7 @@ class SubraceStrategyTest extends TestCase
 
         // Use a unique race name to avoid fixture conflicts
         $uniqueRaceName = 'TestRace'.time();
-        $uniqueRaceSlug = \Illuminate\Support\Str::slug($uniqueRaceName);
+        $uniqueRaceSlug = Str::slug($uniqueRaceName);
 
         $this->assertDatabaseMissing('races', ['slug' => "phb:{$uniqueRaceSlug}"]);
 
@@ -245,7 +248,7 @@ class SubraceStrategyTest extends TestCase
 
         // Use a unique race name to avoid fixture conflicts
         $uniqueRaceName = 'FullSlugTestRace'.time();
-        $uniqueRaceSlug = \Illuminate\Support\Str::slug($uniqueRaceName);
+        $uniqueRaceSlug = Str::slug($uniqueRaceName);
 
         $this->assertDatabaseMissing('races', ['slug' => "phb:{$uniqueRaceSlug}"]);
 
@@ -273,7 +276,7 @@ class SubraceStrategyTest extends TestCase
 
         // Use a unique race name to avoid fixture conflicts
         $uniqueRaceName = 'EmptySourceRace'.time();
-        $uniqueRaceSlug = \Illuminate\Support\Str::slug($uniqueRaceName);
+        $uniqueRaceSlug = Str::slug($uniqueRaceName);
 
         $this->assertDatabaseMissing('races', ['slug' => "phb:{$uniqueRaceSlug}"]);
 


### PR DESCRIPTION
## Summary

Mechanical Pint pass — 426 files reformatted by the `fully_qualified_strict_types` rule. **Zero application logic changes.** All 5 test suites pass with identical counts to main.

Addresses §8 of the 2026-04-18 audit remediation carry-forward.

## What Pint changed

The `fully_qualified_strict_types` fixer replaces fully-qualified class names in method signatures and PHPDoc blocks with short names + explicit `use` statements. Examples:

```diff
+use Illuminate\Database\Eloquent\Collection;

 /**
- * @return \Illuminate\Database\Eloquent\Collection<int, CharacterEquipment>
+ * @return Collection<int, CharacterEquipment>
  */
-public function equippedWeapons(): \Illuminate\Database\Eloquent\Collection
+public function equippedWeapons(): Collection
```

Net change: +2883 / −2076 lines. The +807 line delta is almost entirely the new `use` statements at the top of each file.

## Scope by directory

- `app/Services/` — 3.9%
- `app/Http/Controllers/Api/` — 2.8%
- `app/Http/Resources/` — 1.6%
- `app/Console/Commands/` — 1.1%
- `app/Http/Requests/` — ~2% combined
- `app/Models/` — 0.7%
- `database/factories/` — 8.6%
- `tests/` — majority of the rest (test files had the most FQN usage)

## Test suite state

All five suites match the **zero-fail baseline** from PR #236 exactly:

| Suite | Result |
|---|---|
| Unit-Pure | **954 pass** |
| Unit-DB | **1390 pass / 9 skip** |
| Feature-DB | **704 pass** |
| Feature-Search | **510 pass / 38 skip** |
| Importers | **351 pass / 1 incomplete** |

## Test plan

- [x] `vendor/bin/pint` — 426 files fixed
- [x] `vendor/bin/pint --test` — 0 style issues remaining
- [x] `just test-pure` — green
- [x] `just test-unit` — green
- [x] `just test-feature` — green
- [x] `just test-search` — green
- [x] `just test-importers` — green

## Why now

This PR unblocks cleaner diffs for the upcoming audit carry-forward work — specifically §5c (JsonResponse → Resource return types in ~20 controllers) and §5d (Form Request adoption in 5 actions). Those controllers are in the Pint-touched set; landing this first means the logic PRs stay focused on actual behavior changes rather than mixing style cleanup with substantive changes.