### PR TITLE
docs: scope the whereHas ban in rules/06 (audit §5e)

### DIFF
--- a/.claude/rules/06-search-filtering.md
+++ b/.claude/rules/06-search-filtering.md
@@ -1,14 +1,28 @@
 # Search & Filtering Architecture
 
-**Use Meilisearch for ALL filtering** - no Eloquent `whereHas()` in Services.
+**Use Meilisearch for public search/filter endpoints** — no `whereHas()` in code that services those endpoints.
 
-## Correct Approach
+## Scope of the rule
+
+The ban on `whereHas()` applies specifically to the **public index / search endpoints** on large entity collections: `/spells`, `/monsters`, `/classes`, `/races`, `/items`, `/backgrounds`, `/feats`, `/optional-features`, and the global `/search`. These are unbounded over the full dataset and users drive the filter syntax — Meilisearch is mandatory because correlated subqueries degrade quickly at scale.
+
+**`whereHas()` is fine** in the following categories (and the rule should not be cited against them):
+
+1. **Model query scopes** (`app/Models/**`, `app/Models/Concerns/Has*Scopes.php`) — internal query-building helpers that may be composed into larger queries. Whether they use `whereHas` is the scope author's call.
+2. **Character-state services** (`SpellManagerService`, `AvailableFeatsService`, the `ChoiceHandlers/*`) — queries bounded by a single character's state (e.g., "which spells does this character know", "which feats can this character take given its current classes"). Result sets are tiny and per-user.
+3. **CLI / console commands** (`app/Console/Commands/**`) — not user-facing; offline execution tolerates any join cost.
+4. **Small lookup-table endpoints** — endpoints like `/lookups/skills?ability=DEX` that constrain a tiny static table (skills: 18 rows, conditions: 15 rows, ability scores: 6 rows) via a relation. A join over a handful of rows is cheaper than maintaining a Meilisearch index.
+5. **Per-character personalization endpoints** — e.g., `/characters/{id}/feature-selections/available` or similar, where the result set is bounded by a single character's attributes. These are not "search" in the public sense and shouldn't be indexed.
+
+If you're unsure which bucket a query falls into, apply this test: **can a public anonymous caller influence the query against the full dataset?** If yes → Meilisearch. If the caller is implicitly bounded to their own state (a character, a party, a user), `whereHas` is fine.
+
+## Public search endpoints — correct approach
 
 ```bash
 # CORRECT - Meilisearch filter syntax
 GET /api/v1/spells?filter=class_slugs IN [bard] AND level <= 3
 
-# WRONG - Don't add custom parameters
+# WRONG - Don't add custom query parameters that shadow the filter syntax
 GET /api/v1/spells?classes=bard
 ```
 
@@ -20,7 +34,7 @@ GET /api/v1/spells?classes=bard
 
 ## For Search/Filter Changes
 
-When adding new filterable fields:
+When adding new filterable fields to a public entity endpoint:
 
 1. Add field to model's `toSearchableArray()`
 2. Add to `searchableOptions()` → `filterableAttributes`
@@ -29,7 +43,7 @@ When adding new filterable fields:
 
 ## Service Layer Architecture
 
-Search services should extend `AbstractSearchService` for consistent behavior.
+Search services backing public entity endpoints should extend `AbstractSearchService` for consistent behavior.
 
 **Gold standard:** `SpellSearchService`
 


### PR DESCRIPTION
## Summary

Addresses audit §5e. Clarifies rules/06 to scope the `whereHas()` ban to public search/filter endpoints on large entity collections, where it was originally meant to apply. Adds explicit exemptions for the 15 legitimate uses flagged by the audit.

**No code changes** — the two borderline cases (`SkillController::index`, `FeatureSelectionController::available`) both fall cleanly into exempt categories.

## The problem

The rule as previously written:

> **Use Meilisearch for ALL filtering** - no Eloquent `whereHas()` in Services.

The "ALL" caught 15 repo-wide call sites, none of which suffer the performance pathology Meilisearch was brought in to solve (correlated subqueries against `/spells?filter=class_slugs IN [bard]` at scale). Those 15 split into:

| Category | Where | Why the rule shouldn't apply |
|---|---|---|
| Model scopes / scope traits | `Models/*`, `Models/Concerns/Has*Scopes.php` | Internal query-building helpers |
| Character-state services | `SpellManagerService`, `AvailableFeatsService`, `ChoiceHandlers/*` | Bounded by a single character's state, tiny result sets |
| CLI commands | `Console/Commands/*` | Offline, not user-facing |
| Small lookup-table endpoints | `SkillController::index` | 18-row skills table joined against 6-row ability_scores table |
| Per-character personalization | `FeatureSelectionController::available` | Result set bounded by one character's classes/subclasses/level |

## The clarification

New top-line framing: **"Use Meilisearch for public search/filter endpoints"** (specific endpoints enumerated: `/spells`, `/monsters`, `/classes`, `/races`, `/items`, `/backgrounds`, `/feats`, `/optional-features`, `/search`).

Five explicit exemption categories documented, plus a decision heuristic:

> **Can a public anonymous caller influence the query against the full dataset?** If yes → Meilisearch. If the caller is implicitly bounded to their own state (a character, a party, a user), `whereHas` is fine.

## Test plan

- [x] No code changed — suites unaffected.
- [x] Rule re-read for coherence; decision heuristic distinguishes public-dataset scans from per-entity personalization.
- [ ] Reviewers: does the exemption list match your intent? Anything I've exempted that should actually be refactored, or anything missing?

## Carry-forward

This closes §5e from the 2026-04-18 audit remediation. Remaining carry-forward:

- **§5g** — ~90 fixture-availability test skips, iterative refactor (also: user raised the question of whether some of those tests should just be *deleted* — discussion pending).
- **§5a** — auth on character/party routes, deployment blocker, standalone PR.