### PR TITLE
docs: ban conditional skips based on fixture content (audit §5g hygiene)

### DIFF
--- a/.claude/rules/12-factories-testing.md
+++ b/.claude/rules/12-factories-testing.md
@@ -155,3 +155,36 @@ Spell::factory()->create(['level' => 0, 'is_cantrip' => true]);
 Spell::factory()->cantrip()->create();
 Spell::factory()->cantrip()->create();
 ```
+
+### Conditional Skips Based on Fixture Content
+
+```php
+// ❌ WRONG - Skip fires when fixture data happens to lack a matching row.
+// Conflates "feature is broken" with "no data for this scenario" — both
+// paths look like success in CI, so real regressions slide through silently.
+public function feat_includes_modifiers_in_response(): void
+{
+    $feat = Feat::whereHas('modifiers')->first();
+
+    if (! $feat) {
+        $this->markTestSkipped('No feats with modifiers in imported data');
+    }
+
+    // ... assertions ...
+}
+
+// ✅ CORRECT - Factory-seed the scenario the test needs.
+// Runs deterministically on every invocation; a genuine regression
+// in the Resource's modifier serialization actually fails the test.
+public function feat_includes_modifiers_in_response(): void
+{
+    $feat = Feat::factory()->create();
+    Modifier::factory()->forEntity(Feat::class, $feat->id)->create();
+
+    // ... assertions ...
+}
+```
+
+**Rule:** Don't gate a test on `if (! $fixtureRow) { markTestSkipped(...) }`. Either factory-seed the scenario, or delete the test entirely (if a sibling test covers the same code path with guaranteed data). A test that sometimes skips and sometimes runs is worse than no test at all — it creates a false sense of coverage.
+
+Legitimate `markTestSkipped` uses are narrow: infrastructure dependencies (Redis/Meilisearch not configured, XML source files missing), feature-gated behavior (`auth:sanctum` not enabled yet), and platform-specific paths. The skip message should say *why the environment blocks the test*, never *what content the fixtures happen to contain*.


### PR DESCRIPTION
## Summary

Codifies the anti-pattern that drove the §5g cleanup. Adds one subsection to `rules/12-factories-testing.md` under **Anti-Patterns** so the pattern doesn't multiply in new tests.

## The rule

> **Don't gate a test on `if (! \$fixtureRow) { markTestSkipped(...) }`.** Either factory-seed the scenario, or delete the test entirely (if a sibling test covers the same code path with guaranteed data).

With a WRONG/CORRECT pair showing the factory-seed fix and a rationale:

> A test that sometimes skips and sometimes runs is worse than no test at all — it creates a false sense of coverage. The skip path conflates "feature is broken" with "no data for this scenario" — both paths pass CI, so real regressions slide through silently.

And a narrow definition of what `markTestSkipped` is still legitimate for:

> Infrastructure dependencies (Redis/Meilisearch not configured, XML source files missing), feature-gated behavior (`auth:sanctum` not enabled yet), and platform-specific paths. The skip message should say *why the environment blocks the test*, never *what content the fixtures happen to contain*.

## Why

The §5g cleanup (PRs #239, #241-246) took Feature-Search skips from 38 down to 11 by removing conditional-fixture-content skips across 8 files (~47 total). The pattern is tempting to add when a test fixture doesn't cleanly guarantee a scenario — especially for imports-based tests — but it silently hides regressions. Without a written rule, it will multiply back.

## ~30 remaining §5g skips

The remaining fixture-availability skips (Meilisearch filter-test files — `ItemFilterTest`, `OptionalFeatureFilterOperatorTest`, `MonsterFilterOperatorTest`, `MonsterEnhancedFilteringApiTest`, etc.) are **deliberately not touched here.** Refactoring them requires the Meilisearch factory pattern (factory + `searchable()` + index sync), which is categorically different from the DB-only factory setup used in the recent cleanup. Better to revisit those as a cohesive batch when somebody needs the coverage, rather than refactor half of them and leave flakiness.

This rule applies going forward — existing skips stay until someone touches the test for another reason.

## Test plan

No code change; no test impact.